### PR TITLE
Add text templating to more strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,8 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/nats-io/jsm.go v0.0.21-0.20201211094440-486574d33799
 	github.com/nats-io/nats-server/v2 v2.1.8-0.20201204171240-e1b590db604e
-	github.com/nats-io/nats.go v1.10.1-0.20201111151633-9e1f4a0d80d8
+	github.com/nats-io/nats.go v1.10.1-0.20201216235624-a3519e1e54ea
+	github.com/nats-io/nuid v1.0.1
 	github.com/tylertreat/hdrhistogram-writer v0.0.0-20180430173243-73b8d31ba571
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/nats-io/nats-server/v2 v2.1.8-0.20200601203034-f8d6dd992b71/go.mod h1
 github.com/nats-io/nats-server/v2 v2.1.8-0.20200929001935-7f44d075f7ad/go.mod h1:TkHpUIDETmTI7mrHN40D1pzxfzHZuGmtMbtb83TGVQw=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20201103213111-0965a20b516d h1:zNXqQAfBphOwTdcjnd+6wM4dmMKpW5u3a9vyBhtcEIc=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20201103213111-0965a20b516d/go.mod h1:XD0zHR/jTXdZvWaQfS5mQgsXj6x12kMjKLyAk/cOGgY=
+github.com/nats-io/nats-server/v2 v2.1.8-0.20201129161730-ebe63db3e3ed/go.mod h1:XD0zHR/jTXdZvWaQfS5mQgsXj6x12kMjKLyAk/cOGgY=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20201204171240-e1b590db604e h1:fnpbBmRJVwTKpHOK5mDVbEfTBaYTTZSbAx/HIfPhYo4=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20201204171240-e1b590db604e/go.mod h1:XD0zHR/jTXdZvWaQfS5mQgsXj6x12kMjKLyAk/cOGgY=
 github.com/nats-io/nats.go v1.10.0/go.mod h1:AjGArbfyR50+afOUotNX2Xs5SYHf+CoOa5HH1eEl2HE=
@@ -89,6 +90,8 @@ github.com/nats-io/nats.go v1.10.1-0.20201021145452-94be476ad6e0 h1:s//xxvMgNRVJ
 github.com/nats-io/nats.go v1.10.1-0.20201021145452-94be476ad6e0/go.mod h1:VU2zERjp8xmF+Lw2NH4u2t5qWZxwc7jB3+7HVMWQXPI=
 github.com/nats-io/nats.go v1.10.1-0.20201111151633-9e1f4a0d80d8 h1:OCzS7FpkXX7pyWRzIkXZVWvzGleUKbG0E0YGs1IWXMQ=
 github.com/nats-io/nats.go v1.10.1-0.20201111151633-9e1f4a0d80d8/go.mod h1:hHejHU2mytFORoW+P6jfwfMHh8Y1HLEX3o2KLIpIMYk=
+github.com/nats-io/nats.go v1.10.1-0.20201216235624-a3519e1e54ea h1:xuhp0hVHakez6GG6bbw+t/rZbha1j/ky/qwjv41Esy0=
+github.com/nats-io/nats.go v1.10.1-0.20201216235624-a3519e1e54ea/go.mod h1:Sa3kLIonafChP5IF0b55i9uvGR10I3hPETFbi4+9kOI=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.4/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=
 github.com/nats-io/nkeys v0.2.0 h1:WXKF7diOaPU9cJdLD7nuzwasQy9vT1tBqzXZZf3AMJM=

--- a/nats/consumer_command.go
+++ b/nats/consumer_command.go
@@ -677,7 +677,7 @@ func (c *consumerCmd) getNextMsgDirect(stream string, consumer string) error {
 			time.Sleep(stime)
 		}
 
-		err = msg.Ack()
+		err = msg.Respond(nil)
 		kingpin.FatalIfError(err, "could not Acknowledge message")
 		c.nc.Flush()
 		if !c.raw {
@@ -741,7 +741,7 @@ func (c *consumerCmd) subscribeConsumer(consumer *jsm.Consumer) (err error) {
 		}
 
 		if c.ack {
-			err = m.Ack()
+			err = m.Respond(nil)
 			if err != nil {
 				fmt.Printf("Acknowledging message via subject %s failed: %s\n", m.Reply, err)
 			}

--- a/nats/sub_command.go
+++ b/nats/sub_command.go
@@ -64,7 +64,7 @@ func (c *subCmd) subscribe(_ *kingpin.ParseContext) error {
 
 		if c.jsAck && info != nil {
 			defer func() {
-				err = m.Ack()
+				err = m.Respond(nil)
 				if err != nil {
 					log.Printf("Acknowledging message via subject %s failed: %s\n", m.Reply, err)
 				}


### PR DESCRIPTION
Pub and Reply can both do templates in their body
now, the same was added to header values.

Unique IDs can be generated using {{.ID}}

Signed-off-by: R.I.Pienaar <rip@devco.net>