### PR TITLE
Add replicas handling in Stream editing

### DIFF
--- a/nats/stream_command.go
+++ b/nats/stream_command.go
@@ -669,6 +669,10 @@ func (c *streamCmd) copyAndEditStream(cfg api.StreamConfig) (api.StreamConfig, e
 		cfg.Duplicates = dw
 	}
 
+	if c.replicas != 0 {
+		cfg.Replicas = int(c.replicas)
+	}
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
It seems `nats str edit` with new replica count was not handled. It may be better to add some validation, but kept it simple for now, as I assume the server will validate the input.