### PR TITLE
Keep environment variables when executing nats reply --command {}

### DIFF
--- a/nats/reply_command.go
+++ b/nats/reply_command.go
@@ -158,6 +158,7 @@ func (c *replyCmd) reply(_ *kingpin.ParseContext) error {
 			}
 
 			cmd := exec.Command(cmdParts[0], args...)
+			cmd.Env = os.Environ()
 			cmd.Env = append(cmd.Env, fmt.Sprintf("NATS_REQUEST_SUBJECT=%s", m.Subject))
 			cmd.Env = append(cmd.Env, fmt.Sprintf("NATS_REQUEST_BODY=%s", string(m.Data)))
 			msg.Data, err = cmd.CombinedOutput()


### PR DESCRIPTION
This keeps the environment variables from the executing shell for the command executed by `nats reply subject --comnmand {}`.