### PR TITLE
Only shorten long account names

### DIFF
--- a/nats/server_report_command.go
+++ b/nats/server_report_command.go
@@ -495,7 +495,10 @@ func (c *SrvReportCmd) renderConnections(report []connInfo) {
 		srvName := info.Info.Name
 		cluster := info.Info.Cluster
 
-		acc := info.Account[0:10] + ".." + info.Account[46:]
+		acc := info.Account
+		if len(info.Account) > 46 {
+			acc = info.Account[0:10] + ".." + info.Account[46:]
+		}
 
 		table.AddRow(info.Cid, name, srvName, cluster, info.IP, acc, info.Uptime, humanize.Comma(info.InMsgs), humanize.Comma(info.OutMsgs), humanize.IBytes(uint64(info.InBytes)), humanize.IBytes(uint64(info.OutBytes)), len(info.Subs))
 	}


### PR DESCRIPTION
We tried to show a shorter version of the account id for the
long key based ones, but didn't account for static account names
that can be shorter

Signed-off-by: R.I.Pienaar <rip@devco.net>