### PR TITLE
Refactor server check and add features

### DIFF
--- a/nats/server_check_command_test.go
+++ b/nats/server_check_command_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -8,6 +10,48 @@ import (
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats-server/v2/server"
 )
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func assertListIsEmpty(t *testing.T, list []string) {
+	t.Helper()
+
+	if len(list) > 0 {
+		t.Fatalf("invalid items: %v", list)
+	}
+}
+
+func assertListEquals(t *testing.T, list []string, crits ...string) {
+	t.Helper()
+
+	sort.Strings(list)
+	sort.Strings(crits)
+
+	if !cmp.Equal(list, crits) {
+		t.Fatalf("invalid items: %v", list)
+	}
+}
+
+func assertHasPDItem(t *testing.T, check *result, items ...string) {
+	t.Helper()
+
+	if len(items) == 0 {
+		t.Fatalf("no items to assert")
+	}
+
+	pd := check.PerfData.String()
+	for _, i := range items {
+		if !strings.Contains(pd, i) {
+			t.Fatalf("did not contain item: '%s': %s", i, pd)
+		}
+	}
+}
 
 func TestCheckAccountInfo(t *testing.T) {
 	setDefaults := func() (*SrvCheckCmd, *api.JetStreamAccountStats) {
@@ -41,7 +85,8 @@ func TestCheckAccountInfo(t *testing.T) {
 
 	t.Run("No info", func(t *testing.T) {
 		cmd, _ := setDefaults()
-		_, _, _, err := cmd.checkAccountInfo(nil)
+		check := &result{}
+		err := cmd.checkAccountInfo(check, nil)
 		if err == nil {
 			t.Fatalf("expected error")
 		}
@@ -51,33 +96,21 @@ func TestCheckAccountInfo(t *testing.T) {
 		cmd, info := setDefaults()
 
 		info.Limits = api.JetStreamAccountLimits{}
-		warns, crits, pd, err := cmd.checkAccountInfo(info)
-		checkErr(t, err, "unexpected error")
-		if len(crits) > 0 {
-			t.Fatalf("unexpected crits: %v", crits)
-		}
-		if len(warns) > 0 {
-			t.Fatalf("unexpected warns: %v", warns)
-		}
-		if pd != "memory=128B memory_pct=0%;75;90 storage=1024B storage_pct=0%;75;90 streams=10 streams_pct=0% consumers=100 consumers_pct=0%" {
-			t.Fatalf("unexpected pd: %s", pd)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkAccountInfo(check, info))
+		assertListIsEmpty(t, check.Criticals)
+		assertListIsEmpty(t, check.Warnings)
+		assertHasPDItem(t, check, "memory=128B memory_pct=0%;75;90 storage=1024B storage_pct=0%;75;90 streams=10 streams_pct=0% consumers=100 consumers_pct=0%")
 	})
 
 	t.Run("Limits, default thresholds", func(t *testing.T) {
 		cmd, info := setDefaults()
 
-		warns, crits, pd, err := cmd.checkAccountInfo(info)
-		checkErr(t, err, "unexpected error")
-		if len(crits) > 0 {
-			t.Fatalf("unexpected crits: %v", crits)
-		}
-		if len(warns) > 0 {
-			t.Fatalf("unexpected warns: %v", warns)
-		}
-		if pd != "memory=128B memory_pct=12%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%" {
-			t.Fatalf("unexpected pd: %s", pd)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkAccountInfo(check, info))
+		assertListIsEmpty(t, check.Criticals)
+		assertListIsEmpty(t, check.Warnings)
+		assertHasPDItem(t, check, "memory=128B memory_pct=12%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%")
 	})
 
 	t.Run("Limits, Thresholds", func(t *testing.T) {
@@ -85,17 +118,11 @@ func TestCheckAccountInfo(t *testing.T) {
 
 		t.Run("Usage exceeds max", func(t *testing.T) {
 			info.Streams = 300
-			warns, crits, pd, err := cmd.checkAccountInfo(info)
-			checkErr(t, err, "unexpected error")
-			if !cmp.Equal(crits, []string{"streams: exceed server limits"}) {
-				t.Fatalf("unexpected crits: %v", crits)
-			}
-			if len(warns) > 0 {
-				t.Fatalf("unexpected warns: %v", warns)
-			}
-			if pd != "memory=128B memory_pct=12%;75;90 storage=1024B storage_pct=5%;75;90 streams=300 streams_pct=150% consumers=100 consumers_pct=10%" {
-				t.Fatalf("unexpected pd: %s", pd)
-			}
+			check := &result{}
+			assertNoError(t, cmd.checkAccountInfo(check, info))
+			assertListEquals(t, check.Criticals, "streams: exceed server limits")
+			assertListIsEmpty(t, check.Warnings)
+			assertHasPDItem(t, check, "memory=128B memory_pct=12%;75;90 storage=1024B storage_pct=5%;75;90 streams=300 streams_pct=150% consumers=100 consumers_pct=10%")
 		})
 
 		t.Run("Invalid thresholds", func(t *testing.T) {
@@ -103,45 +130,31 @@ func TestCheckAccountInfo(t *testing.T) {
 
 			cmd.jsMemWarn = 90
 			cmd.jsMemCritical = 80
-			_, crits, _, err := cmd.checkAccountInfo(info)
-			checkErr(t, err, "unexpected error")
-			if !cmp.Equal(crits, []string{"memory: invalid thresholds"}) {
-				t.Fatalf("unexpected crits: %v", crits)
-			}
+			check := &result{}
+			assertNoError(t, cmd.checkAccountInfo(check, info))
+			assertListEquals(t, check.Criticals, "memory: invalid thresholds")
 		})
 
 		t.Run("Exceeds warning threshold", func(t *testing.T) {
 			cmd, info := setDefaults()
 
 			info.Memory = 800
-			warns, crits, pd, err := cmd.checkAccountInfo(info)
-			checkErr(t, err, "unexpected error")
-			if pd != "memory=800B memory_pct=78%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%" {
-				t.Fatalf("unexpected pd: %s", pd)
-			}
-			if len(crits) > 0 {
-				t.Fatalf("unexpected crits: %v", crits)
-			}
-			if !cmp.Equal(warns, []string{"78% memory"}) {
-				t.Fatalf("unexpected warns: %v", warns)
-			}
+			check := &result{}
+			assertNoError(t, cmd.checkAccountInfo(check, info))
+			assertHasPDItem(t, check, "memory=800B memory_pct=78%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%")
+			assertListIsEmpty(t, check.Criticals)
+			assertListEquals(t, check.Warnings, "78% memory")
 		})
 
 		t.Run("Exceeds critical threshold", func(t *testing.T) {
 			cmd, info := setDefaults()
 
 			info.Memory = 960
-			warns, crits, pd, err := cmd.checkAccountInfo(info)
-			checkErr(t, err, "unexpected error")
-			if pd != "memory=960B memory_pct=93%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%" {
-				t.Fatalf("unexpected pd: %s", pd)
-			}
-			if !cmp.Equal(crits, []string{"93% memory"}) {
-				t.Fatalf("unexpected crits: %v", crits)
-			}
-			if len(warns) > 0 {
-				t.Fatalf("unexpected warns: %v", warns)
-			}
+			check := &result{}
+			assertNoError(t, cmd.checkAccountInfo(check, info))
+			assertHasPDItem(t, check, "memory=960B memory_pct=93%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%")
+			assertListEquals(t, check.Criticals, "93% memory")
+			assertListIsEmpty(t, check.Warnings)
 		})
 	})
 }
@@ -153,35 +166,29 @@ func TestCheckMirror(t *testing.T) {
 	cmd.sourcesLagCritical = 50
 
 	t.Run("no mirror", func(t *testing.T) {
-		crits, _, err := cmd.checkMirror(info)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"not mirrored"}) {
-			t.Fatalf("expected no mirror error got %+v", crits)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkMirror(check, info))
+		assertListEquals(t, check.Criticals, "not mirrored")
+		assertListIsEmpty(t, check.Warnings)
 	})
 
 	t.Run("failed mirror", func(t *testing.T) {
 		info.Mirror = &api.StreamSourceInfo{"M", nil, 100, time.Hour, nil}
-		crits, pd, err := cmd.checkMirror(info)
+		check := &result{}
+		err := cmd.checkMirror(check, info)
 		checkErr(t, err, "unexpected error")
-		if pd != "lag=100;;50 active=3600.000000s;;1.00" {
-			t.Fatalf("invalid pd: %s", pd)
-		}
-		if !cmp.Equal(crits, []string{"100 messages behind", "last active 1h0m0s"}) {
-			t.Fatalf("unexpected crits got %+v", crits)
-		}
+		assertHasPDItem(t, check, "lag=100;;50 active=3600.0000s;;1.0000")
+		assertListEquals(t, check.Criticals, "100 messages behind", "last active 1h0m0s")
+		assertListIsEmpty(t, check.Warnings)
 	})
 
 	t.Run("ok mirror", func(t *testing.T) {
 		info.Mirror = &api.StreamSourceInfo{"M", nil, 1, 10 * time.Millisecond, nil}
-		crits, pd, err := cmd.checkMirror(info)
-		checkErr(t, err, "unexpected error")
-		if pd != "lag=1;;50 active=0.010000s;;1.00" {
-			t.Fatalf("invalid pd: %s", pd)
-		}
-		if len(crits) > 0 {
-			t.Fatalf("expected no crits got %+v", crits)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkMirror(check, info))
+		assertHasPDItem(t, check, "lag=1;;50 active=0.0100s;;1.0000")
+		assertListIsEmpty(t, check.Criticals)
+		assertListIsEmpty(t, check.Warnings)
 	})
 }
 
@@ -190,11 +197,9 @@ func TestCheckSources(t *testing.T) {
 	info := &api.StreamInfo{}
 
 	t.Run("no sources", func(t *testing.T) {
-		crits, _, err := cmd.checkSources(info)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"no sources defined"}) {
-			t.Fatalf("expected no sources error got %+v", crits)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkSources(check, info))
+		assertListEquals(t, check.Criticals, "no sources defined")
 	})
 
 	cmd.sourcesLagCritical = 10
@@ -209,14 +214,10 @@ func TestCheckSources(t *testing.T) {
 			},
 		}
 
-		crits, pd, err := cmd.checkSources(info)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"1 lagged sources"}) {
-			t.Fatalf("expected lagged error got %+v", crits)
-		}
-		if pd != "sources=1;1;10; lagged=1 inactive=0" {
-			t.Fatalf("unexpected performance data: %s", pd)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkSources(check, info))
+		assertListEquals(t, check.Criticals, "1 lagged sources")
+		assertHasPDItem(t, check, "sources=1;1;10 lagged=1 inactive=0")
 	})
 
 	t.Run("inactive source", func(t *testing.T) {
@@ -226,14 +227,10 @@ func TestCheckSources(t *testing.T) {
 			},
 		}
 
-		crits, pd, err := cmd.checkSources(info)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"1 inactive sources"}) {
-			t.Fatalf("expected inactive error got %+v", crits)
-		}
-		if pd != "sources=1;1;10; lagged=0 inactive=1" {
-			t.Fatalf("unexpected performance data: %s", pd)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkSources(check, info))
+		assertListEquals(t, check.Criticals, "1 inactive sources")
+		assertHasPDItem(t, check, "sources=1;1;10 lagged=0 inactive=1")
 	})
 
 	t.Run("not enough sources", func(t *testing.T) {
@@ -245,14 +242,10 @@ func TestCheckSources(t *testing.T) {
 
 		cmd.sourcesMinSources = 2
 
-		crits, pd, err := cmd.checkSources(info)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"1 sources of min expected 2"}) {
-			t.Fatalf("expected min error got %+v", crits)
-		}
-		if pd != "sources=1;2;10; lagged=0 inactive=0" {
-			t.Fatalf("unexpected performance data: %s", pd)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkSources(check, info))
+		assertListEquals(t, check.Criticals, "1 sources of min expected 2")
+		assertHasPDItem(t, check, "sources=1;2;10 lagged=0 inactive=0")
 	})
 
 	t.Run("too many sources", func(t *testing.T) {
@@ -266,14 +259,227 @@ func TestCheckSources(t *testing.T) {
 		cmd.sourcesMinSources = 1
 		cmd.sourcesMaxSources = 1
 
-		crits, pd, err := cmd.checkSources(info)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"2 sources of max expected 1"}) {
-			t.Fatalf("expected max error got %+v", crits)
+		check := &result{}
+		assertNoError(t, cmd.checkSources(check, info))
+		assertListEquals(t, check.Criticals, "2 sources of max expected 1")
+		assertHasPDItem(t, check, "sources=2;1;1 lagged=0 inactive=0")
+	})
+}
+
+func TestCheckVarz(t *testing.T) {
+	t.Run("nil data", func(t *testing.T) {
+		cmd := &SrvCheckCmd{srvName: "testing"}
+
+		err := cmd.checkVarz(&result{}, nil)
+		if err.Error() != "no data received" {
+			t.Fatalf("expected no data error: %s", err)
 		}
-		if pd != "sources=2;1;1; lagged=0 inactive=0" {
-			t.Fatalf("unexpected performance data: %s", pd)
+	})
+
+	t.Run("wrong server", func(t *testing.T) {
+		cmd := &SrvCheckCmd{srvName: "testing"}
+		vz := &server.Varz{Name: "other"}
+
+		err := cmd.checkVarz(&result{}, vz)
+		if err.Error() != "result from other" {
+			t.Fatalf("expected error about host: %s", err)
 		}
+	})
+
+	t.Run("jetstream", func(t *testing.T) {
+		cmd := &SrvCheckCmd{srvName: "testing"}
+		cmd.srvJSRequired = true
+		vz := &server.Varz{Name: "testing"}
+
+		check := &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "JetStream not enabled")
+		vz.JetStream.Config = &server.JetStreamConfig{}
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListIsEmpty(t, check.Criticals)
+		assertListEquals(t, check.OKs, "JetStream enabled")
+	})
+
+	t.Run("tls", func(t *testing.T) {
+		cmd := &SrvCheckCmd{srvName: "testing"}
+		cmd.srvTLSRequired = true
+		vz := &server.Varz{Name: "testing"}
+
+		check := &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "TLS not required")
+
+		vz.TLSRequired = true
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListIsEmpty(t, check.Criticals)
+		assertListEquals(t, check.OKs, "TLS required")
+	})
+
+	t.Run("authentication", func(t *testing.T) {
+		cmd := &SrvCheckCmd{srvName: "testing"}
+		cmd.srvAuthRequire = true
+		vz := &server.Varz{Name: "testing"}
+
+		check := &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "Authentication not required")
+
+		vz.AuthRequired = true
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListIsEmpty(t, check.Criticals)
+		assertListEquals(t, check.OKs, "Authentication required")
+	})
+
+	t.Run("uptime", func(t *testing.T) {
+		cmd := &SrvCheckCmd{srvName: "testing"}
+		vz := &server.Varz{Name: "testing", Start: time.Now().Add(-1 * time.Second)}
+
+		// invalid thresholds
+		check := &result{}
+		cmd.srvUptimeCrit = 20 * time.Minute
+		cmd.srvUptimeWarn = 10 * time.Minute
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "Up invalid thresholds")
+		assertListIsEmpty(t, check.OKs)
+
+		// critical uptime
+		check = &result{}
+		cmd.srvUptimeCrit = 10 * time.Minute
+		cmd.srvUptimeWarn = 20 * time.Minute
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "Up 1.00s")
+		assertListIsEmpty(t, check.OKs)
+		assertHasPDItem(t, check, "uptime=1.0000s;1200.0000;600.000")
+
+		// warning uptime
+		check = &result{}
+		vz.Start = time.Now().Add(-11 * time.Minute)
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListIsEmpty(t, check.Criticals)
+		assertListEquals(t, check.Warnings, "Up 11m0s")
+		assertListIsEmpty(t, check.OKs)
+		assertHasPDItem(t, check, "uptime=660.0000s;1200.0000;600.000")
+
+		// ok uptime
+		check = &result{}
+		vz.Start = time.Now().Add(-21 * time.Minute)
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListIsEmpty(t, check.Criticals)
+		assertListIsEmpty(t, check.Warnings)
+		assertListEquals(t, check.OKs, "Up 21m0s")
+		assertHasPDItem(t, check, "uptime=1260.0000s;1200.0000;600.0000")
+	})
+
+	t.Run("cpu", func(t *testing.T) {
+		cmd := &SrvCheckCmd{srvName: "testing"}
+		vz := &server.Varz{Name: "testing", CPU: 50}
+
+		// invalid thresholds
+		cmd.srvCPUCrit = 60
+		cmd.srvCPUWarn = 70
+		check := &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "CPU invalid thresholds")
+		assertListIsEmpty(t, check.OKs)
+
+		// critical cpu
+		cmd.srvCPUCrit = 50
+		cmd.srvCPUWarn = 30
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "CPU 50.00")
+		assertListIsEmpty(t, check.OKs)
+		assertHasPDItem(t, check, "cpu=50%;30;50")
+
+		// warning cpu
+		cmd.srvCPUCrit = 60
+		cmd.srvCPUWarn = 50
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Warnings, "CPU 50.00")
+		assertListIsEmpty(t, check.Criticals)
+		assertListIsEmpty(t, check.OKs)
+		assertHasPDItem(t, check, "cpu=50%;50;60")
+
+		// ok cpu
+		cmd.srvCPUCrit = 80
+		cmd.srvCPUWarn = 70
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.OKs, "CPU 50.00")
+		assertListIsEmpty(t, check.Criticals)
+		assertListIsEmpty(t, check.Warnings)
+		assertHasPDItem(t, check, "cpu=50%;70;80")
+	})
+
+	// memory not worth testing, its the same logic as CPU
+
+	t.Run("connections", func(t *testing.T) {
+		cmd := &SrvCheckCmd{srvName: "testing"}
+		vz := &server.Varz{Name: "testing", Connections: 1024}
+
+		// critical connections
+		cmd.srvConnCrit = 1024
+		cmd.srvConnWarn = 800
+		check := &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "Connections 1024.00")
+		assertListIsEmpty(t, check.OKs)
+		assertListIsEmpty(t, check.Warnings)
+		assertHasPDItem(t, check, "connections=1024;800;1024")
+
+		// critical connections reverse
+		cmd.srvConnCrit = 1200
+		cmd.srvConnWarn = 1300
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Criticals, "Connections 1024.00")
+		assertListIsEmpty(t, check.OKs)
+		assertListIsEmpty(t, check.Warnings)
+		assertHasPDItem(t, check, "connections=1024;1300;1200")
+
+		// warn connections
+		cmd.srvConnCrit = 2000
+		cmd.srvConnWarn = 1024
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Warnings, "Connections 1024.00")
+		assertListIsEmpty(t, check.OKs)
+		assertListIsEmpty(t, check.Criticals)
+		assertHasPDItem(t, check, "connections=1024;1024;2000")
+
+		// warn connections reverse
+		cmd.srvConnCrit = 1000
+		cmd.srvConnWarn = 1300
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.Warnings, "Connections 1024.00")
+		assertListIsEmpty(t, check.OKs)
+		assertListIsEmpty(t, check.Criticals)
+		assertHasPDItem(t, check, "connections=1024;1300;1000")
+
+		// ok connections
+		cmd.srvConnCrit = 2000
+		cmd.srvConnWarn = 1300
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListEquals(t, check.OKs, "Connections 1024.00")
+		assertListIsEmpty(t, check.Warnings)
+		assertListIsEmpty(t, check.Criticals)
+		assertHasPDItem(t, check, "connections=1024;1300;2000")
+
+		// ok connections reverse
+		cmd.srvConnCrit = 800
+		cmd.srvConnWarn = 900
+		check = &result{}
+		assertNoError(t, cmd.checkVarz(check, vz))
+		assertListIsEmpty(t, check.Warnings)
+		assertListIsEmpty(t, check.Criticals)
+		assertListEquals(t, check.OKs, "Connections 1024.00")
+		assertHasPDItem(t, check, "connections=1024;900;800")
 	})
 }
 
@@ -281,30 +487,25 @@ func TestCheckJSZ(t *testing.T) {
 	cmd := &SrvCheckCmd{}
 
 	t.Run("nil meta", func(t *testing.T) {
-		crits, _, err := cmd.checkClusterInfo(nil)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"no cluster information"}) {
-			t.Fatalf("expected api error got %+v", crits)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, nil))
+		assertListEquals(t, check.Criticals, "no cluster information")
 	})
 
 	meta := &server.ClusterInfo{}
 	t.Run("no meta leader", func(t *testing.T) {
-		crits, _, err := cmd.checkClusterInfo(meta)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"No leader"}) {
-			t.Fatalf("expected no meta leader got %+v", crits)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, meta))
+		assertListEquals(t, check.Criticals, "No leader")
+		assertListIsEmpty(t, check.OKs)
 	})
 
 	t.Run("invalid peer count", func(t *testing.T) {
 		meta = &server.ClusterInfo{Leader: "l1"}
 		cmd.raftExpect = 2
-		crits, _, err := cmd.checkClusterInfo(meta)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"1 peers of expected 2"}) {
-			t.Fatalf("expected peer error got %+v", crits)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, meta))
+		assertListEquals(t, check.Criticals, "1 peers of expected 2")
 	})
 
 	cmd.raftExpect = 3
@@ -320,14 +521,10 @@ func TestCheckJSZ(t *testing.T) {
 			},
 		}
 
-		crits, pb, err := cmd.checkClusterInfo(meta)
-		checkErr(t, err, "unexpected error")
-		if len(crits) > 0 {
-			t.Fatalf("unexpected criticals %+v", crits)
-		}
-		if pb != "peers=3;3;3  offline=0 not_current=0 inactive=0 lagged=0" {
-			t.Fatalf("unexpected performance data: %s", pb)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, meta))
+		assertListIsEmpty(t, check.Criticals)
+		assertHasPDItem(t, check, "peers=3;3;3 offline=0 not_current=0 inactive=0 lagged=0")
 	})
 
 	t.Run("not current peer", func(t *testing.T) {
@@ -339,14 +536,11 @@ func TestCheckJSZ(t *testing.T) {
 			},
 		}
 
-		crits, pb, err := cmd.checkClusterInfo(meta)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"1 not current"}) {
-			t.Fatalf("expected not current error error got %+v", crits)
-		}
-		if pb != "peers=3;3;3  offline=0 not_current=1 inactive=0 lagged=0" {
-			t.Fatalf("unexpected performance data: %s", pb)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, meta))
+		assertListEquals(t, check.Criticals, "1 not current")
+		assertListIsEmpty(t, check.OKs)
+		assertHasPDItem(t, check, "peers=3;3;3 offline=0 not_current=1 inactive=0 lagged=0")
 	})
 
 	t.Run("offline peer", func(t *testing.T) {
@@ -358,14 +552,11 @@ func TestCheckJSZ(t *testing.T) {
 			},
 		}
 
-		crits, pb, err := cmd.checkClusterInfo(meta)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"1 offline"}) {
-			t.Fatalf("expected offline error error got %+v", crits)
-		}
-		if pb != "peers=3;3;3  offline=1 not_current=0 inactive=0 lagged=0" {
-			t.Fatalf("unexpected performance data: %s", pb)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, meta))
+		assertListEquals(t, check.Criticals, "1 offline")
+		assertListIsEmpty(t, check.OKs)
+		assertHasPDItem(t, check, "peers=3;3;3 offline=1 not_current=0 inactive=0 lagged=0")
 	})
 
 	t.Run("inactive peer", func(t *testing.T) {
@@ -377,14 +568,11 @@ func TestCheckJSZ(t *testing.T) {
 			},
 		}
 
-		crits, pb, err := cmd.checkClusterInfo(meta)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"1 inactive more than 1s"}) {
-			t.Fatalf("expected inactive error error got %+v", crits)
-		}
-		if pb != "peers=3;3;3  offline=0 not_current=0 inactive=1 lagged=0" {
-			t.Fatalf("unexpected performance data: %s", pb)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, meta))
+		assertListEquals(t, check.Criticals, "1 inactive more than 1s")
+		assertListIsEmpty(t, check.OKs)
+		assertHasPDItem(t, check, "peers=3;3;3 offline=0 not_current=0 inactive=1 lagged=0")
 	})
 
 	t.Run("lagged peer", func(t *testing.T) {
@@ -396,14 +584,10 @@ func TestCheckJSZ(t *testing.T) {
 			},
 		}
 
-		crits, pb, err := cmd.checkClusterInfo(meta)
-		checkErr(t, err, "unexpected error")
-		if !cmp.Equal(crits, []string{"1 lagged more than 10 ops"}) {
-			t.Fatalf("expected lagged error error got %+v", crits)
-		}
-		if pb != "peers=3;3;3  offline=0 not_current=0 inactive=0 lagged=1" {
-			t.Fatalf("unexpected performance data: %s", pb)
-		}
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, meta))
+		assertListEquals(t, check.Criticals, "1 lagged more than 10 ops")
+		assertHasPDItem(t, check, "peers=3;3;3 offline=0 not_current=0 inactive=0 lagged=1")
 	})
 
 	t.Run("multiple errors", func(t *testing.T) {
@@ -417,20 +601,13 @@ func TestCheckJSZ(t *testing.T) {
 			},
 		}
 
-		crits, pb, err := cmd.checkClusterInfo(meta)
-		checkErr(t, err, "unexpected error")
-		expected := []string{
-			"5 peers of expected 3",
+		check := &result{}
+		assertNoError(t, cmd.checkClusterInfo(check, meta))
+		assertHasPDItem(t, check, "peers=5;3;3 offline=1 not_current=1 inactive=1 lagged=1")
+		assertListEquals(t, check.Criticals, "5 peers of expected 3",
 			"1 not current",
 			"1 inactive more than 1s",
 			"1 offline",
-			"1 lagged more than 10 ops",
-		}
-		if !cmp.Equal(crits, expected) {
-			t.Fatalf("expected errors got %+v", crits)
-		}
-		if pb != "peers=5;3;3  offline=1 not_current=1 inactive=1 lagged=1" {
-			t.Fatalf("unexpected performance data: %s", pb)
-		}
+			"1 lagged more than 10 ops")
 	})
 }


### PR DESCRIPTION
This refactors the check command around a single
data type for all results which lets us support
multiple output formats, now we have JSON and
Nagios format outputs.

This also adjusts the output to show all OK/Warn/Crit
vs previously where any critical would supress the Warn
etc

We also add a 'nats server check server' which does
a varz check for cpu, memory, connections, routes,
gateways, subscriptions, uptime and asserts auth
required, tls required and auth required.

Signed-off-by: R.I.Pienaar <rip@devco.net>