### PR TITLE
fix nats connect call

### DIFF
--- a/nats/bench_command.go
+++ b/nats/bench_command.go
@@ -150,7 +150,7 @@ func (c *benchCmd) bench(_ *kingpin.ParseContext) error {
 
 	if c.js {
 		// create the stream for the benchmark (and purge it)
-		nc, err := nats.Connect(config.ServerURL())
+		nc, err := nats.Connect(config.ServerURL(), natsOpts()...)
 		if err != nil {
 			log.Fatalf("nats connection failed: %s", err)
 		}


### PR DESCRIPTION
nats connect needs url,natsOpts()... in order for the connection with –tlsca and –creds to work (was mistakenly removed by some earlier commit thinking it was un-needed)