### PR TITLE
Calculate "Uptime" monotonically in sub-command "server list"

### DIFF
--- a/cli/server_list_command.go
+++ b/cli/server_list_command.go
@@ -197,7 +197,7 @@ func (c *SrvLsCmd) list(_ *kingpin.ParseContext) error {
 			humanize.IBytes(uint64(ssm.Stats.Mem)),
 			fmt.Sprintf("%.1f", ssm.Stats.CPU),
 			ssm.Stats.SlowConsumers,
-			humanizeTime(ssm.Stats.Start),
+			humanizeDuration(ssm.Server.Time.Sub(ssm.Stats.Start)),
 			ssm.rtt.Round(time.Millisecond))
 	}
 

--- a/cli/util.go
+++ b/cli/util.go
@@ -546,10 +546,6 @@ func humanizeDuration(d time.Duration) string {
 	return fmt.Sprintf("%.2fs", d.Seconds())
 }
 
-func humanizeTime(t time.Time) string {
-	return humanizeDuration(time.Since(t))
-}
-
 const (
 	hdrLine   = "NATS/1.0\r\n"
 	crlf      = "\r\n"


### PR DESCRIPTION
CLI sub-command "server list" reported nonsensical "negative uptimes" in
a number of situations. Generally, this is due to calculating Uptime based
on the CLI's wall-clock and comparing with the UTC timestamp in
'statsz.start'.

Previously Uptime was essentially 'time.Since(statsz.start)', which
compares CLI's local wall clock with the UTC timestamp in statsz.start.
This is brittle, it requires clocks be synchronized on the CLI and on
NATS Server.

A "better" approximation of NATS Server Uptime is the duration between
'server.time' and 'statsz.start'. The time domain error is scoped to a
single machine's estimation of UTC when:

1. NATS Server most recently started
2. "this" statsz was rendered by the server in "1"

This is not robust against wall clock resets.

To the best of my knowledge, NATS Server does not keep a reference to
the monotonic clock since start. NATS Server's 'Server.start' is from
'time.Now().UTC()', which strips any monotonic clock reading.

https://github.com/nats-io/nats-server/blob/ea48105526db36b566b3afb36ddfacccf3f97f3a/server/server.go#L347-L356

varz does have a 'uptime' field but it's just time.Since('Server.start')
where 'Server.start' is t.UTC()

https://github.com/nats-io/nats-server/blob/ea48105526db36b566b3afb36ddfacccf3f97f3a/server/monitor.go#L1469

Signed-off-by: Ben Werthmann <ben@synadia.com>