### PR TITLE
Use "varz Uptime" in sub-command "server check server"

### DIFF
--- a/cli/server_check_command.go
+++ b/cli/server_check_command.go
@@ -462,7 +462,10 @@ func (c *SrvCheckCmd) checkVarz(check *result, vz *server.Varz) error {
 		}
 	}
 
-	up := time.Since(vz.Start)
+	up, err := parseDurationString(vz.Uptime)
+	if err != nil {
+		return fmt.Errorf("invalid uptime from server: %s", err)
+	}
 	if c.srvUptimeWarn > 0 || c.srvUptimeCrit > 0 {
 		if c.srvUptimeCrit > c.srvUptimeWarn {
 			check.critical("Up invalid thresholds")
@@ -479,7 +482,7 @@ func (c *SrvCheckCmd) checkVarz(check *result, vz *server.Varz) error {
 	}
 
 	check.pd(
-		&perfDataItem{Name: "uptime", Value: up.Round(time.Second).Seconds(), Warn: c.srvUptimeWarn.Seconds(), Crit: c.srvUptimeCrit.Seconds(), Unit: "s", Help: "NATS Server uptime in seconds"},
+		&perfDataItem{Name: "uptime", Value: up.Seconds(), Warn: c.srvUptimeWarn.Seconds(), Crit: c.srvUptimeCrit.Seconds(), Unit: "s", Help: "NATS Server uptime in seconds"},
 		&perfDataItem{Name: "cpu", Value: vz.CPU, Warn: float64(c.srvCPUWarn), Crit: float64(c.srvCPUCrit), Unit: "%", Help: "NATS Server CPU usage in percentage"},
 		&perfDataItem{Name: "mem", Value: float64(vz.Mem), Warn: float64(c.srvMemWarn), Crit: float64(c.srvMemCrit), Help: "NATS Server memory usage in bytes"},
 		&perfDataItem{Name: "connections", Value: float64(vz.Connections), Warn: float64(c.srvConnWarn), Crit: float64(c.srvConnCrit), Help: "Active connections"},


### PR DESCRIPTION
CLI sub-command "server check server" reported nonsensical "negative uptimes" in
a number of situations. Generally, this is due to calculating Uptime based
on the CLI's wall-clock and comparing with the UTC timestamp in
'varz.start'.

Previously Uptime was essentially 'time.Since(varz.start)', which
compares CLI's local wall clock with the UTC timestamp in varsz.start.
This is brittle, it requires clocks be synchronized on the CLI and on
NATS Server.

A "better" approximation of NATS Server Uptime is the duration between
'server.time' and 'varsz.start'. The time domain error is scoped to a
single machine's estimation of UTC when:

1. NATS Server most recently started
2. "this" varsz was rendered by the server in "1"

This is not robust against wall clock resets.

varz does have a 'uptime' field but it's just time.Since('Server.start')
where 'Server.start' is t.UTC(). So for simplicity, just use uptime as
reported by varz.

https://github.com/nats-io/nats-server/blob/ea48105526db36b566b3afb36ddfacccf3f97f3a/server/monitor.go#L1469

To the best of my knowledge, NATS Server does not keep a reference to
the monotonic clock since start. NATS Server's 'Server.start' is from
'time.Now().UTC()', which strips any monotonic clock reading.

https://github.com/nats-io/nats-server/blob/ea48105526db36b566b3afb36ddfacccf3f97f3a/server/server.go#L347-L356

Signed-off-by: Ben Werthmann <ben@synadia.com>