### PR TITLE
Report version "(devel)" as "development"

### DIFF
--- a/nats/main.go
+++ b/nats/main.go
@@ -71,7 +71,7 @@ func getVersion() string {
 	}
 
 	nfo, ok := debug.ReadBuildInfo()
-	if !ok || (nfo != nil && nfo.Main.Version == "") {
+	if !ok || (nfo != nil && (nfo.Main.Version == "" || nfo.Main.Version == "(devel)")) {
 		return version
 	}
 


### PR DESCRIPTION
"(devel)" is a default value which provides no context beyond
the prior default of "development".

When:

    go install -x -v ./nats/

Before:

    nats --version
    (devel)

    go version -m ./bin/nats | head -n3
    ./bin/nats: go1.17.3
    	path	github.com/nats-io/natscli/nats
    	mod	github.com/nats-io/natscli	(devel)

Now:

    nats --version
    development

    go version -m ./bin/nats | head -n3
    ./bin/nats: go1.17.3
    	path	github.com/nats-io/natscli/nats
    	mod	github.com/nats-io/natscli	(devel)

To get a build with a pseudo version one can build a ref in github

    go install -x -v github.com/nats-io/natscli/nats@main

    nats --version
    v0.0.28-0.20211130221026-75847abdf5a6

    go version -m ./bin/nats
    ./bin/nats: go1.17.3
    	path	github.com/nats-io/natscli/nats
    	mod	github.com/nats-io/natscli	v0.0.28-0.20211130221026-75847abdf5a6	h1:pq2FdCt0wLJ3i/phpMjbMmtItO/6uxcYlespzXb7/nM=

Unreleased Go 1.18 is expected to have better support for dealing with
adding VCS and buildinfo in binaries form local-only commits and
uncommitted changes.

* https://github.com/golang/go/issues/37475#issuecomment-933946807
* https://github.com/golang/go/issues/37475#ref-commit-fad4a16
* https://tip.golang.org/doc/go1.18#debug/buildinfo
* https://tip.golang.org/doc/go1.18#go-command

Signed-off-by: Ben Werthmann <ben@synadia.com>