### PR TITLE
adding --count to reply and --reply to request

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -85,6 +85,8 @@ type Options struct {
 	CfgCtx string
 	// Trace enables verbose debug logging
 	Trace bool
+	// Customer inbox Prefix
+	InboxPrefix string
 
 	// Conn sets a prepared connect to connect with
 	Conn *nats.Conn

--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -250,6 +250,7 @@ func (c *ctxCommand) showCommand(_ *kingpin.ParseContext) error {
 	c.showIfNotEmpty("    JS API Prefix: %s\n", cfg.JSAPIPrefix())
 	c.showIfNotEmpty("  JS Event Prefix: %s\n", cfg.JSEventPrefix())
 	c.showIfNotEmpty("        JS Domain: %s\n", cfg.JSDomain())
+	c.showIfNotEmpty("     Inbox Prefix: %s\n", cfg.InboxPrefix())
 	c.showIfNotEmpty("             Path: %s\n", cfg.Path())
 
 	checkConn := func() error {

--- a/cli/pub_command.go
+++ b/cli/pub_command.go
@@ -127,18 +127,18 @@ func (c *pubCmd) doReq(nc *nats.Conn, progress *uiprogress.Bar) error {
 				return err
 			}
 		} else {
-			sub, e := nc.SubscribeSync(c.replyTo)
-			if e != nil {
-				return e
+			sub, err := nc.SubscribeSync(c.replyTo)
+			if err != nil {
+				return err
 			}
-			if e := nc.PublishMsg(msg); e != nil {
-				return e
+			err = nc.PublishMsg(msg)
+			if  err != nil {
+				return err
 			}
 			m, err = sub.NextMsg(opts.Timeout)
-		}
-
-		if err != nil {
-			return err
+			if err != nil {
+				return err
+			}
 		}
 
 		if c.raw {

--- a/cli/pub_command.go
+++ b/cli/pub_command.go
@@ -88,7 +88,6 @@ nats request destination.subject "hello world" -H "Content-type:text/plain" --ra
 	req.Flag("raw", "Show just the output received").Short('r').Default("false").BoolVar(&c.raw)
 	req.Flag("header", "Adds headers to the message").Short('H').StringsVar(&c.hdrs)
 	req.Flag("count", "Publish multiple messages").Default("1").IntVar(&c.cnt)
-	req.Flag("reply", "Sets a custom reply to subject").StringVar(&c.replyTo)
 }
 
 func init() {
@@ -120,25 +119,9 @@ func (c *pubCmd) doReq(nc *nats.Conn, progress *uiprogress.Bar) error {
 			return err
 		}
 
-		var m *nats.Msg
-		if c.replyTo == "" {
-			m, err = nc.RequestMsg(msg, opts.Timeout)
-			if err != nil {
-				return err
-			}
-		} else {
-			sub, err := nc.SubscribeSync(c.replyTo)
-			if err != nil {
-				return err
-			}
-			err = nc.PublishMsg(msg)
-			if  err != nil {
-				return err
-			}
-			m, err = sub.NextMsg(opts.Timeout)
-			if err != nil {
-				return err
-			}
+		m, err := nc.RequestMsg(msg, opts.Timeout)
+		if err != nil {
+			return err
 		}
 
 		if c.raw {

--- a/cli/util.go
+++ b/cli/util.go
@@ -748,6 +748,7 @@ func loadContext() error {
 		natscontext.WithJSEventPrefix(opts.JsEventPrefix),
 		natscontext.WithJSAPIPrefix(opts.JsApiPrefix),
 		natscontext.WithJSDomain(opts.JsDomain),
+		natscontext.WithInboxPrefix(opts.InboxPrefix),
 	}
 
 	if opts.Username != "" && opts.Password == "" {

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/guptarohit/asciigraph v0.5.2
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.13.6
-	github.com/nats-io/jsm.go v0.0.27
-	github.com/nats-io/nats-server/v2 v2.6.6-0.20211122213926-f094918f35b8
+	github.com/nats-io/jsm.go v0.0.28-0.20211213114924-006ae57a98b9
+	github.com/nats-io/nats-server/v2 v2.6.7-0.20211209193502-628251d11d8a
 	github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc
 	github.com/nats-io/nuid v1.0.1
 	github.com/prometheus/client_golang v1.11.0
@@ -25,7 +25,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/tylertreat/hdrhistogram-writer v0.0.0-20210816161836-2e440612a39f
 	github.com/xlab/tablewriter v0.0.0-20160610135559-80b567a11ad5
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -198,13 +198,12 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nats-io/jsm.go v0.0.27 h1:AncMtVmFLFN4/+BkbPGJ2Y1EwpqImyVOMKFehuPDpOY=
-github.com/nats-io/jsm.go v0.0.27/go.mod h1:zuH+RjhsJ/o9Dd1ArZxcEpu48oB3pdsIVLbz3gqen/c=
+github.com/nats-io/jsm.go v0.0.28-0.20211213114924-006ae57a98b9 h1:kexYR2nvGvzL1wF5TXdbrzuEA910v2xAJOcr3TePuXI=
+github.com/nats-io/jsm.go v0.0.28-0.20211213114924-006ae57a98b9/go.mod h1:gvPCf1ErHhil0vQmnrA0eiEbocJUvXKOmbtRTfWuQk8=
 github.com/nats-io/jwt/v2 v2.2.0 h1:Yg/4WFK6vsqMudRg91eBb7Dh6XeVcDMPHycDE8CfltE=
 github.com/nats-io/jwt/v2 v2.2.0/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
-github.com/nats-io/nats-server/v2 v2.6.6-0.20211122213926-f094918f35b8 h1:UKhEhYEiZhmFabtgUyjsVEQdlfrvVrJkavxQ+++aSk4=
-github.com/nats-io/nats-server/v2 v2.6.6-0.20211122213926-f094918f35b8/go.mod h1:n8O5NeknIIQgQld7//20NnQpCe1o5xIjVFxzh7IIZ6Y=
-github.com/nats-io/nats.go v1.13.1-0.20211018182449-f2416a8b1483/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
+github.com/nats-io/nats-server/v2 v2.6.7-0.20211209193502-628251d11d8a h1:R9ygw0EHROc2O+W88P9Sc9GT8KFxr2EbWoxU7Ot4bn4=
+github.com/nats-io/nats-server/v2 v2.6.7-0.20211209193502-628251d11d8a/go.mod h1:Un2z192KV1RW8fsnOntcsK/tEI/jBq8JTvnJaycf4s4=
 github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc h1:SHr4MUUZJ/fAC0uSm2OzWOJYsHpapmR86mpw7q1qPXU=
 github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
@@ -272,9 +271,8 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211202192323-5770296d904e h1:MUP6MR3rJ7Gk9LEia0LP2ytiH6MuCfs7qYz+47jGdD8=
+golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -340,6 +338,7 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/nats/main.go
+++ b/nats/main.go
@@ -56,6 +56,7 @@ See 'nats cheat' for a quick cheatsheet of commands
 	ncli.Flag("js-api-prefix", "Subject prefix for access to JetStream API").PlaceHolder("PREFIX").StringVar(&opts.JsApiPrefix)
 	ncli.Flag("js-event-prefix", "Subject prefix for access to JetStream Advisories").PlaceHolder("PREFIX").StringVar(&opts.JsEventPrefix)
 	ncli.Flag("js-domain", "JetStream domain to access").PlaceHolder("PREFIX").PlaceHolder("DOMAIN").StringVar(&opts.JsDomain)
+	ncli.Flag("inbox-prefix", "Custom inbox prefix to use for inboxes").PlaceHolder("PREFIX").StringVar(&opts.InboxPrefix)
 	ncli.Flag("domain", "JetStream domain to access").PlaceHolder("PREFIX").PlaceHolder("DOMAIN").Hidden().StringVar(&opts.JsDomain)
 	ncli.Flag("context", "Configuration context").Envar("NATS_CONTEXT").StringVar(&opts.CfgCtx)
 	ncli.Flag("trace", "Trace API interactions").BoolVar(&opts.Trace)


### PR DESCRIPTION
--count limits the number of messages to reply to before exiting
--reply allows to specify the reply subject

fixes #314

requesting with a different subject (instead of a plain inbox) is a pattern nats allows for. 
Which is why natscli should support it natively, just to make demos easier.
When I experimented with this, the go api, always overwrote the reply subject with an inbox.
Which is why code to avoid the request was added too.

Signed-off-by: Matthias Hanel <mh@synadia.com>