### PR TITLE
cli/stream_command.go: add trailing newline

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -1145,7 +1145,7 @@ func (c *streamCmd) editAction(_ *kingpin.ParseContext) error {
 
 	diff := cmp.Diff(sourceStream.Configuration(), cfg, sorter)
 	if diff == "" {
-		fmt.Printf("No difference in configuration")
+		fmt.Printf("No difference in configuration\n")
 		return nil
 	}
 


### PR DESCRIPTION
Add trailing newline in user output