### PR TITLE
Rename commands for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ Matched Schemas:
 
 The schemas can be limited using a regular expression, try `nats schema ls request` to see all API requests.
 
-Schemas can be viewed in their raw JSON or YAML formats using `nats schema show io.nats.jetstream.advisory.v1.consumer_action`,
+Schemas can be viewed in their raw JSON or YAML formats using `nats schema info io.nats.jetstream.advisory.v1.consumer_action`,
 these schemas include descriptions about each field and more.
 
 Finally, if you are interacting with the API using JSON request messages constructed using languages that is not supported

--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -60,10 +60,10 @@ func configureCtxCommand(app commandHost) {
 	pick := context.Command("select", "Select the default context").Alias("switch").Alias("set").Action(c.selectCommand)
 	pick.Arg("name", "The context name to select").StringVar(&c.name)
 
-	show := context.Command("show", "Show the current or named context").Action(c.showCommand)
-	show.Arg("name", "The context name to show").StringVar(&c.name)
-	show.Flag("json", "Show the context in JSON format").Short('j').BoolVar(&c.json)
-	show.Flag("connect", "Attempts to connect to NATS using the context while validating").BoolVar(&c.activate)
+	info := context.Command("info", "Display information on the current or named context").Alias("show").Action(c.showCommand)
+	info.Arg("name", "The context name to show").StringVar(&c.name)
+	info.Flag("json", "Show the context in JSON format").Short('j').BoolVar(&c.json)
+	info.Flag("connect", "Attempts to connect to NATS using the context while validating").BoolVar(&c.activate)
 
 	validate := context.Command("validate", "Validate one or all contexts").Action(c.validateCommand)
 	validate.Arg("name", "Validate a specific context, validates all when not supplied").StringVar(&c.name)
@@ -76,7 +76,7 @@ nats context edit development [standard connection properties]
 
 # View contexts
 nats context ls
-nats context show development --json
+nats context info development --json
 
 # Validate all connections are valid and that connections can be established
 nats context validate --connect

--- a/cli/errors_command.go
+++ b/cli/errors_command.go
@@ -30,10 +30,10 @@ func configureErrCommand(app commandHost) {
 	cmd := app.Command("errors", "Error code documentation").Alias("err").Alias("error")
 	cmd.Flag("errors", "The errors.json file to use as input").PlaceHolder("FILE").ExistingFileVar(&c.file)
 
-	list := cmd.Command("list", "List all known error codes").Alias("ls").Action(c.listAction)
-	list.Arg("match", "Regular expression match to limit the displayed results").StringVar(&c.match)
-	list.Arg("sort", "Sorts by a specific field (code, http, description, d, desc)").Default("code").EnumVar(&c.sort, "code", "http", "description", "descr", "d")
-	list.Flag("reverse", "Reverse sort").Short('R').BoolVar(&c.reverse)
+	ls := cmd.Command("ls", "List all known error codes").Alias("list").Action(c.listAction)
+	ls.Arg("match", "Regular expression match to limit the displayed results").StringVar(&c.match)
+	ls.Arg("sort", "Sorts by a specific field (code, http, description, d, desc)").Default("code").EnumVar(&c.sort, "code", "http", "description", "descr", "d")
+	ls.Flag("reverse", "Reverse sort").Short('R').BoolVar(&c.reverse)
 
 	lookup := cmd.Command("lookup", "Looks up an error by it's code").Alias("find").Alias("get").Alias("l").Alias("view").Alias("show").Action(c.lookupAction)
 	lookup.Arg("code", "The code to retrieve").Required().Uint16Var(&c.code)
@@ -49,7 +49,7 @@ func configureErrCommand(app commandHost) {
 nats errors lookup 1000
 
 # To list all errors mentioning stream using regular expression matches
-nats errors list stream
+nats errors ls stream
 
 # As a NATS Server developer edit an existing code in errors.json
 nats errors edit errors.json 10013

--- a/cli/kv_command.go
+++ b/cli/kv_command.go
@@ -112,7 +112,7 @@ NOTE: This is an experimental feature.
 	watch.Arg("bucket", "The bucket to act on").Required().StringVar(&c.bucket)
 	watch.Arg("key", "The key to act on").StringVar(&c.key)
 
-	ls := kv.Command("list", "List available Buckets").Alias("ls").Action(c.lsAction)
+	ls := kv.Command("ls", "List available Buckets").Alias("list").Action(c.lsAction)
 	ls.Flag("names", "Show just the bucket names").Short('n').BoolVar(&c.listNames)
 
 	rmHistory := kv.Command("compact", "Removes all historic values from the store where the last value is a delete").Action(c.compactAction)

--- a/cli/schema_command.go
+++ b/cli/schema_command.go
@@ -20,14 +20,14 @@ func configureSchemaCommand(app commandHost) {
 nats schema search 'response|request'
 
 # To view a specific schema
-nats schema show io.nats.jetstream.api.v1.stream_msg_get_request --yaml
+nats schema info io.nats.jetstream.api.v1.stream_msg_get_request --yaml
 
 # To validate a JSON input against a specific schema
 nats schema validate io.nats.jetstream.api.v1.stream_msg_get_request request.json
 `
 
 	configureSchemaSearchCommand(schema)
-	configureSchemaShowCommand(schema)
+	configureSchemaInfoCommand(schema)
 	configureSchemaValidateCommand(schema)
 }
 

--- a/cli/schema_info_command.go
+++ b/cli/schema_info_command.go
@@ -21,22 +21,22 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-type schemaShowCmd struct {
+type schemaInfoCmd struct {
 	schema string
 	yaml   bool
 }
 
-func configureSchemaShowCommand(schema *kingpin.CmdClause) {
-	c := &schemaShowCmd{}
-	show := schema.Command("show", "Show the contents of a schema").Action(c.show)
-	show.Arg("schema", "Schema ID to show").Required().StringVar(&c.schema)
-	show.Flag("yaml", "Produce YAML format output").BoolVar(&c.yaml)
+func configureSchemaInfoCommand(schema *kingpin.CmdClause) {
+	c := &schemaInfoCmd{}
+	info := schema.Command("info", "Display schema contents").Alias("show").Action(c.info)
+	info.Arg("schema", "Schema ID to show").Required().StringVar(&c.schema)
+	info.Flag("yaml", "Produce YAML format output").BoolVar(&c.yaml)
 }
 
-func (c *schemaShowCmd) show(_ *kingpin.ParseContext) error {
+func (c *schemaInfoCmd) info(_ *kingpin.ParseContext) error {
 	schema, err := api.Schema(c.schema)
 	if err != nil {
-		return fmt.Errorf("could not load schame %q: %s", c.schema, err)
+		return fmt.Errorf("could not load schema %q: %s", c.schema, err)
 	}
 
 	if c.yaml {

--- a/cli/server_list_command.go
+++ b/cli/server_list_command.go
@@ -46,7 +46,7 @@ type srvListCluster struct {
 func configureServerListCommand(srv *kingpin.CmdClause) {
 	c := &SrvLsCmd{}
 
-	ls := srv.Command("list", "List known servers").Alias("ls").Action(c.list)
+	ls := srv.Command("ls", "List known servers").Alias("list").Action(c.list)
 	ls.Arg("expect", "How many servers to expect").Uint32Var(&c.expect)
 	ls.Flag("json", "Produce JSON output").Short('j').BoolVar(&c.json)
 	ls.Flag("sort", "Sort servers by a specific key (name,conns,subs,routes,gws,mem,cpu,slow,uptime,rtt").Default("rtt").EnumVar(&c.sort, strings.Split("name,conns,conn,subs,sub,routes,route,gw,mem,cpu,slow,uptime,rtt", ",")...)


### PR DESCRIPTION
Closes #336 

Includes the following changes:

- Use on info vs show
- Use on ls vs list
- Fix minor spelling issue on schema

Commands changed from `show` to `info` were aliased to maintain backward compatibility.