### PR TITLE
allow shell installers to download latest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,12 @@ archives:
     files:
       - README.md
       - LICENSE
+  - name_template: "nats-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"
+    wrap_in_directory: true
+    format: zip
+    files:
+      - README.md
+      - LICENSE
 
 checksum:
   name_template: "SHA256SUMS"


### PR DESCRIPTION
Added a second build artifact that doesn't sport the version this is friendly to shell installer scripts that want to install 'latest'

FIX #341