### PR TITLE
support loading contexts from a filename

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -759,7 +759,13 @@ func loadContext() error {
 
 	var err error
 
-	opts.Config, err = natscontext.New(opts.CfgCtx, !SkipContexts, ctxOpts...)
+	exist, _ := fileAccessible(opts.CfgCtx)
+
+	if exist {
+		opts.Config, err = natscontext.NewFromFile(opts.CfgCtx, ctxOpts...)
+	} else {
+		opts.Config, err = natscontext.New(opts.CfgCtx, !SkipContexts, ctxOpts...)
+	}
 
 	return err
 }


### PR DESCRIPTION
nats --context /some/file.json will use that file if accessible
else use the existing behavior.

Signed-off-by: R.I.Pienaar <rip@devco.net>