### PR TITLE
Humanize stream byte parameters

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -1875,7 +1875,11 @@ func (c *streamCmd) prepareConfig(pc *kingpin.ParseContext, requireSize bool) ap
 	}
 
 	if c.maxBytesLimit == "" {
-		c.maxBytesLimit, err = askOneBytes("Total Stream Size", "256MB", "Defines the combined size of all messages in a Stream, when exceeded messages are removed or new ones are rejected, -1 for unlimited. Settable using --max-bytes", "MaxBytes is required per Account Settings")
+		var required string
+		if requireSize {
+			required = "MaxBytes is required per Account Settings"
+		}
+		c.maxBytesLimit, err = askOneBytes("Total Stream Size", "256MB", "Defines the combined size of all messages in a Stream, when exceeded messages are removed or new ones are rejected, -1 for unlimited. Settable using --max-bytes", required)
 		kingpin.FatalIfError(err, "invalid input")
 	}
 

--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -1876,10 +1876,14 @@ func (c *streamCmd) prepareConfig(pc *kingpin.ParseContext, requireSize bool) ap
 
 	if c.maxBytesLimit == "" {
 		var required string
+		var defaultSize string
 		if requireSize {
 			required = "MaxBytes is required per Account Settings"
+			defaultSize = "256MB"
+		} else {
+			defaultSize = "-1"
 		}
-		c.maxBytesLimit, err = askOneBytes("Total Stream Size", "256MB", "Defines the combined size of all messages in a Stream, when exceeded messages are removed or new ones are rejected, -1 for unlimited. Settable using --max-bytes", required)
+		c.maxBytesLimit, err = askOneBytes("Total Stream Size", defaultSize, "Defines the combined size of all messages in a Stream, when exceeded messages are removed or new ones are rejected, -1 for unlimited. Settable using --max-bytes", required)
 		kingpin.FatalIfError(err, "invalid input")
 	}
 

--- a/cli/util.go
+++ b/cli/util.go
@@ -307,9 +307,9 @@ func askConfirmation(prompt string, dflt bool) (bool, error) {
 	return ans, err
 }
 
-func askOneBytes(prompt string, dflt string, help string, required string) (int64, error) {
+func askOneBytes(prompt string, dflt string, help string, required string) (string, error) {
 	if !isTerminal() {
-		return 0, fmt.Errorf("cannot ask for confirmation without a terminal")
+		return "", fmt.Errorf("cannot ask for confirmation without a terminal")
 	}
 
 	for {
@@ -320,23 +320,13 @@ func askOneBytes(prompt string, dflt string, help string, required string) (int6
 			Help:    help,
 		}, &val, survey.WithValidator(survey.Required))
 		if err != nil {
-			return 0, err
+			return "", err
 		}
-
-		if val == "-1" {
-			val = "0"
-		}
-
-		i, err := humanize.ParseBytes(val)
-		if err != nil {
-			return 0, err
-		}
-
-		if required != "" && i <= 0 {
+		if required != "" && val == "" {
 			fmt.Println(required)
 			continue
 		}
-		return int64(i), nil
+		return val, nil
 	}
 }
 


### PR DESCRIPTION
Set a default stream size of 256MB and humanize the stream parameters (stream size, max msgs size).

```text
$ nats s create colin
? Subjects colin
? Storage file
? Replication 1
? Retention Policy Limits
? Discard Policy Old
? Stream Messages Limit -1
? Per Subject Messages Limit -1
? Total Stream Size 256MB
? Message TTL -1
? Max Message Size -1
? Duplicate tracking time window 2m0s
? Allow message Roll-ups No
? Allow message deletion Yes
? Allow purging subjects or the entire stream Yes
Stream colin was created

Information for Stream colin created 2022-04-16T17:52:17-06:00

Configuration:

             Subjects: colin
     Acknowledgements: true
            Retention: File - Limits
             Replicas: 1
       Discard Policy: Old
     Duplicate Window: 2m0s
    Allows Msg Delete: true
         Allows Purge: true
       Allows Rollups: false
     Maximum Messages: unlimited
        Maximum Bytes: 244 MiB
          Maximum Age: unlimited
 Maximum Message Size: unlimited
    Maximum Consumers: unlimited


Cluster Information:

                 Name: ngsprod-aws-uswest2
               Leader: aws-uswest2-natsjs-1

State:

             Messages: 0
                Bytes: 0 B
             FirstSeq: 0
              LastSeq: 0
     Active Consumers: 0
```

Editing:

```
$ nats s edit colin --max-bytes=10MB
Differences (-old +new):
  api.StreamConfig{
  	... // 5 identical fields
  	MaxMsgsPer: -1,
  	MaxMsgs:    -1,
- 	MaxBytes:   256000000,
+ 	MaxBytes:   10000000,
  	MaxAge:     s"0s",
  	MaxMsgSize: -1,
  	... // 13 identical fields
  }
? Really edit Stream colin Yes
Stream colin was updated

Information for Stream colin created 2022-04-16T17:52:17-06:00

Configuration:

             Subjects: colin
     Acknowledgements: true
            Retention: File - Limits
             Replicas: 1
       Discard Policy: Old
     Duplicate Window: 2m0s
    Allows Msg Delete: true
         Allows Purge: true
       Allows Rollups: false
     Maximum Messages: unlimited
        Maximum Bytes: 9.5 MiB
          Maximum Age: unlimited
 Maximum Message Size: unlimited
    Maximum Consumers: unlimited


Cluster Information:

                 Name: ngsprod-aws-uswest2
               Leader: aws-uswest2-natsjs-1

State:

             Messages: 0
                Bytes: 0 B
             FirstSeq: 0
              LastSeq: 0
     Active Consumers: 0
```
Signed-off-by: Colin Sullivan <colin@synadia.com>