### PR TITLE
Humanize byte arguments on the cli and prompts

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -60,8 +60,10 @@ type streamCmd struct {
 	storage               string
 	maxMsgLimit           int64
 	maxMsgPerSubjectLimit int64
+	maxBytesLimitString   string
 	maxBytesLimit         int64
 	maxAgeLimit           string
+	maxMsgSizeString      string
 	maxMsgSize            int64
 	maxConsumers          int
 	reportSortConsumers   bool
@@ -141,9 +143,9 @@ func configureStreamCommand(app commandHost) {
 		f.Flag("dupe-window", "Window size for duplicate tracking").Default("").StringVar(&c.dupeWindow)
 		f.Flag("json", "Produce JSON output").Short('j').BoolVar(&c.json)
 		f.Flag("max-age", "Maximum age of messages to keep").Default("").StringVar(&c.maxAgeLimit)
-		f.Flag("max-bytes", "Maximum bytes to keep").Int64Var(&c.maxBytesLimit)
+		f.Flag("max-bytes", "Maximum bytes to keep").StringVar(&c.maxBytesLimitString)
 		f.Flag("max-consumers", "Maximum number of consumers to allow").Default("-1").IntVar(&c.maxConsumers)
-		f.Flag("max-msg-size", "Maximum size any 1 message may be").Int64Var(&c.maxMsgSize)
+		f.Flag("max-msg-size", "Maximum size any 1 message may be").StringVar(&c.maxMsgSizeString)
 		f.Flag("max-msgs", "Maximum amount of messages to keep").Default("0").Int64Var(&c.maxMsgLimit)
 		f.Flag("max-msgs-per-subject", "Maximum amount of messages to keep per subject").Default("0").Int64Var(&c.maxMsgPerSubjectLimit)
 		f.Flag("mirror", "Completely mirror another stream").StringVar(&c.mirror)
@@ -159,6 +161,8 @@ func configureStreamCommand(app commandHost) {
 		OptionalBoolean(f.Flag("allow-rollup", "(--no-allow-rollup) Allows roll-ups to be done by publishing messages with special headers"))
 		OptionalBoolean(f.Flag("deny-delete", "(--no-deny-delete) Deny messages from being deleted via the API"))
 		OptionalBoolean(f.Flag("deny-purge", "(--no-deny-purge) Deny entire stream or subject purges via the API"))
+
+		f.PreAction(c.parseLimitStrings)
 	}
 
 	str := app.Command("stream", "JetStream Stream management").Alias("str").Alias("st").Alias("ms").Alias("s")
@@ -340,6 +344,24 @@ stream cluster peer-remove ORDERS nats1.example.net
 
 func init() {
 	registerCommand("stream", 16, configureStreamCommand)
+}
+
+func (c *streamCmd) parseLimitStrings(_ *kingpin.ParseContext) (err error) {
+	if c.maxBytesLimitString != "" {
+		c.maxBytesLimit, err = parseStringAsBytes(c.maxBytesLimitString)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.maxMsgSizeString != "" {
+		c.maxMsgSize, err = parseStringAsBytes(c.maxMsgSizeString)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (c *streamCmd) findAction(_ *kingpin.ParseContext) (err error) {
@@ -1849,12 +1871,19 @@ func (c *streamCmd) prepareConfig(pc *kingpin.ParseContext, requireSize bool) ap
 
 	var maxAge time.Duration
 	if c.maxBytesLimit == 0 {
-		c.maxBytesLimit, err = askOneBytes("Total Stream Size", "-1", "Defines the combined size of all messages in a Stream, when exceeded messages are removed or new ones are rejected, -1 for unlimited. Settable using --max-bytes", "MaxBytes is required per Account Settings")
-		kingpin.FatalIfError(err, "invalid input")
-
-		if c.maxBytesLimit <= 0 {
-			c.maxBytesLimit = -1
+		reqd := ""
+		defltSize := "-1"
+		if requireSize {
+			reqd = "MaxBytes is required per Account Settings"
+			defltSize = "256MB"
 		}
+
+		c.maxBytesLimit, err = askOneBytes("Total Stream Size", defltSize, "Defines the combined size of all messages in a Stream, when exceeded messages are removed or new ones are rejected, -1 for unlimited. Settable using --max-bytes", reqd)
+		kingpin.FatalIfError(err, "invalid input")
+	}
+
+	if c.maxBytesLimit <= 0 {
+		c.maxBytesLimit = -1
 	}
 
 	if c.maxAgeLimit == "" {

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -14,6 +14,7 @@
 package cli
 
 import (
+	"errors"
 	"sort"
 	"testing"
 
@@ -54,6 +55,56 @@ func assertListEquals(t *testing.T, list []string, crits ...string) {
 
 	if !cmp.Equal(list, crits) {
 		t.Fatalf("invalid items: %v", list)
+	}
+}
+
+func TestParseStringAsBytes(t *testing.T) {
+	cases := []struct {
+		input  string
+		expect int64
+		error  bool
+	}{
+		{input: "1", expect: 1},
+		{input: "1000", expect: 1000},
+		{input: "1K", expect: 1024},
+		{input: "1k", expect: 1024},
+		{input: "1KB", expect: 1024},
+		{input: "1KiB", expect: 1024},
+		{input: "1kb", expect: 1024},
+		{input: "1M", expect: 1024 * 1024},
+		{input: "1MB", expect: 1024 * 1024},
+		{input: "1MiB", expect: 1024 * 1024},
+		{input: "1m", expect: 1024 * 1024},
+		{input: "1G", expect: 1024 * 1024 * 1024},
+		{input: "1GB", expect: 1024 * 1024 * 1024},
+		{input: "1GiB", expect: 1024 * 1024 * 1024},
+		{input: "1g", expect: 1024 * 1024 * 1024},
+		{input: "1T", expect: 1024 * 1024 * 1024 * 1024},
+		{input: "1TB", expect: 1024 * 1024 * 1024 * 1024},
+		{input: "1TiB", expect: 1024 * 1024 * 1024 * 1024},
+		{input: "1t", expect: 1024 * 1024 * 1024 * 1024},
+		{input: "-1", expect: -1},
+		{input: "-10", expect: -1},
+		{input: "-10GB", expect: -1},
+		{input: "1B", error: true},
+		{input: "1FOO", error: true},
+		{input: "FOO", error: true},
+	}
+
+	for _, c := range cases {
+		v, err := parseStringAsBytes(c.input)
+		if c.error {
+			if !errors.Is(err, errInvalidByteString) {
+				t.Fatalf("expected an invalid bytes error got: %v", err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("did not expect an error parsing %v: %v", c.input, err)
+			}
+			if v != c.expect {
+				t.Fatalf("expected %v to parse as %d got %d", c.input, c.expect, v)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This uses a bytes parser derived from, and compatible with,
the server options parser but additionally supports TB, tb and
t as aliases for T. All are 1024 based.

We use that in cli arguments and update all other bytes
parsing to be the same, this means 1GB is consistent with
the rendering of 1GiB - all 1024 based.

Do the same on stream, kv and object.

Fixes a bug that required a size be set on accounts
that do not require it and default to 256MB when it is
required

Signed-off-by: R.I.Pienaar <rip@devco.net>