### PR TITLE
avoid printing names stream names list twice

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -2354,9 +2354,6 @@ func (c *streamCmd) renderStreamsAsList(streams []*jsm.Stream) string {
 	}
 
 	sort.Strings(names)
-	for _, n := range names {
-		fmt.Println(n)
-	}
 
 	return strings.Join(names, "\n")
 }


### PR DESCRIPTION
Signed-off-by: R.I.Pienaar <rip@devco.net>