### PR TITLE
[fixed] close on closed channel error of ui bar on second stream

### DIFF
--- a/cli/account_command.go
+++ b/cli/account_command.go
@@ -169,7 +169,7 @@ func (c *actCmd) restoreAction(kp *kingpin.ParseContext) error {
 		_, err := os.Stat(filepath.Join(c.backupDirectory, d.Name(), "backup.json"))
 		kingpin.FatalIfError(err, "expected backup.json")
 	}
-	fmt.Printf("Restoring backup of all %d streams in directory %q\n\n", len(streams), c.backupDirectory)
+	fmt.Printf("Restoring backup of all %d streams in directory %q\n\n", len(de), c.backupDirectory)
 	s := &streamCmd{msgID: -1, showProgress: c.showProgress, placementCluster: c.placementCluster, placementTags: c.placementTags}
 	for _, d := range de {
 		s.backupDirectory = filepath.Join(c.backupDirectory, d.Name())


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

I was betrayed by the UI progress bar. 
The second stream would end up closing an already closed (default progress) channel.

```
 ~/test/restore  nats account restore --server localhost:4222 ../acct_backup --progress
Restoring backup of all 3 streams in directory "../acct_backup"

Starting restore of Stream "KV_clients" from file "../acct_backup/KV_clients"

[16319] 2022/05/05 20:32:27.875168 [INF] Starting restore for stream '$G > KV_clients'
[16319] 2022/05/05 20:32:27.877898 [INF] Completed restore of 5.29 KB for stream 'KV_clients > $G' in 2.7ms
5.3 KiB/s [================================================================================================================================================================================================================================================] 100%

Restored stream "KV_clients" in 0s

Information for Stream  created 2022-05-01T10:46:52-04:00

Configuration:

             Subjects: $KV.clients.>
     Acknowledgements: true
            Retention: File - Limits
             Replicas: 1
       Discard Policy: New
     Duplicate Window: 2m0s
    Allows Msg Delete: false
         Allows Purge: true
       Allows Rollups: true
     Maximum Messages: unlimited
  Maximum Per Subject: 1
        Maximum Bytes: 10 MiB
          Maximum Age: unlimited
 Maximum Message Size: unlimited
    Maximum Consumers: unlimited


State:

             Messages: 24
                Bytes: 2.7 KiB
             FirstSeq: 8 @ 2022-05-01T16:42:59 UTC
              LastSeq: 130 @ 2022-05-03T02:10:00 UTC
     Deleted Messages: 99
     Active Consumers: 0
Starting restore of Stream "s1" from file "../acct_backup/s1"

[16319] 2022/05/05 20:32:27.881504 [INF] Starting restore for stream '$G > s1'
[16319] 2022/05/05 20:32:27.885892 [INF] Completed restore of 1.23 KB for stream 's1 > $G' in 4.356ms
1.2 KiB/s [================================================================================================================================================================================================================================================] 100%

Restored stream "s1" in 0s

Information for Stream  created 2022-05-03T13:04:48-04:00

Configuration:

             Subjects: s1
     Acknowledgements: true
            Retention: File - Limits
             Replicas: 1
       Discard Policy: Old
     Duplicate Window: 2m0s
    Allows Msg Delete: true
         Allows Purge: true
       Allows Rollups: false
     Maximum Messages: unlimited
        Maximum Bytes: 256 MiB
          Maximum Age: unlimited
 Maximum Message Size: unlimited
    Maximum Consumers: unlimited


State:

             Messages: 2
                Bytes: 76 B
             FirstSeq: 1 @ 2022-05-03T17:05:04 UTC
              LastSeq: 2 @ 2022-05-03T17:05:10 UTC
     Active Consumers: 1
Starting restore of Stream "s2" from file "../acct_backup/s2"

[16319] 2022/05/05 20:32:27.889084 [INF] Starting restore for stream '$G > s2'
[16319] 2022/05/05 20:32:27.892606 [INF] Completed restore of 1.20 KB for stream 's2 > $G' in 3.499ms
1.2 KiB/s [================================================================================================================================================================================================================================================] 100%

Restored stream "s2" in 0s

Information for Stream  created 2022-05-03T13:04:57-04:00

Configuration:

             Subjects: s2
     Acknowledgements: true
            Retention: File - Limits
             Replicas: 1
       Discard Policy: Old
     Duplicate Window: 2m0s
    Allows Msg Delete: true
         Allows Purge: true
       Allows Rollups: false
     Maximum Messages: unlimited
        Maximum Bytes: 256 MiB
          Maximum Age: unlimited
 Maximum Message Size: unlimited
    Maximum Consumers: unlimited


State:

             Messages: 1
                Bytes: 39 B
             FirstSeq: 1 @ 2022-05-03T17:05:28 UTC
              LastSeq: 1 @ 2022-05-03T17:05:28 UTC
     Active Consumers: 1
 ~/test/restore 
```