### PR TITLE
Improve help output

### DIFF
--- a/cli/account_command.go
+++ b/cli/account_command.go
@@ -19,10 +19,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type actCmd struct {

--- a/cli/backup_command.go
+++ b/cli/backup_command.go
@@ -14,7 +14,7 @@
 package cli
 
 import (
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 )
 
 type backupCmd struct {

--- a/cli/bench_command.go
+++ b/cli/bench_command.go
@@ -21,11 +21,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/gosuri/uiprogress"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/bench"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type benchCmd struct {

--- a/cli/cheat_command.go
+++ b/cli/cheat_command.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 )
 
 type cheatCmd struct {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type command struct {

--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -27,11 +27,11 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/google/go-cmp/cmp"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/nats-io/jsm.go"
 )

--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/alecthomas/kingpin"
 	"github.com/fatih/color"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/nats.go"

--- a/cli/errors_command.go
+++ b/cli/errors_command.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/fatih/color"
 	"github.com/nats-io/jsm.go/schemas"
 	"github.com/nats-io/nats-server/v2/server"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type errCmd struct {

--- a/cli/events_command.go
+++ b/cli/events_command.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type eventsCmd struct {

--- a/cli/governor_command.go
+++ b/cli/governor_command.go
@@ -8,10 +8,10 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/kballard/go-shellquote"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/jsm.go/governor"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type govCmd struct {

--- a/cli/kv_command.go
+++ b/cli/kv_command.go
@@ -23,11 +23,11 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type kvCommand struct {

--- a/cli/latency_command.go
+++ b/cli/latency_command.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	"github.com/HdrHistogram/hdrhistogram-go"
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/nats.go"
 	histwriter "github.com/tylertreat/hdrhistogram-writer"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type latencyCmd struct {

--- a/cli/object_command.go
+++ b/cli/object_command.go
@@ -24,12 +24,12 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/gosuri/uiprogress"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type objCommand struct {

--- a/cli/optional_boolean.go
+++ b/cli/optional_boolean.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 )
 
 // OptionalBoolValue is contains a *bool and implements kingpin.Value

--- a/cli/pub_command.go
+++ b/cli/pub_command.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/gosuri/uiprogress"
 	"github.com/nats-io/nats.go"
 	terminal "golang.org/x/term"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type pubCmd struct {

--- a/cli/reply_command.go
+++ b/cli/reply_command.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/kballard/go-shellquote"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type replyCmd struct {

--- a/cli/restore_command.go
+++ b/cli/restore_command.go
@@ -16,7 +16,7 @@ package cli
 import (
 	"fmt"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 )
 
 type restoreCmd struct {

--- a/cli/rtt_command.go
+++ b/cli/rtt_command.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type rttCmd struct {

--- a/cli/schema_info_command.go
+++ b/cli/schema_info_command.go
@@ -16,9 +16,9 @@ package cli
 import (
 	"fmt"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/ghodss/yaml"
 	"github.com/nats-io/jsm.go/api"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type schemaInfoCmd struct {

--- a/cli/schema_search_command.go
+++ b/cli/schema_search_command.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/jsm.go/api"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type schemaSearchCmd struct {

--- a/cli/schema_validate_command.go
+++ b/cli/schema_validate_command.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 )
 
 type schemaValidateCmd struct {

--- a/cli/server_check_command.go
+++ b/cli/server_check_command.go
@@ -23,12 +23,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvCheckCmd struct {
@@ -85,14 +85,14 @@ type SrvCheckCmd struct {
 func configureServerCheckCommand(srv *kingpin.CmdClause) {
 	c := &SrvCheckCmd{}
 
-	help := `Nagios protocol health check for NATS servers
+	help := `Health check for NATS servers
 
    connection  - connects and does a request-reply check
    stream      - checks JetStream streams for source, mirror and cluster health
    meta        - JetStream Meta Cluster health
 `
 	check := srv.Command("check", help)
-	check.Flag("format", "Render the check in a specific format").Default("nagios").EnumVar(&checkRenderFormat, "nagios", "json", "prometheus", "text")
+	check.Flag("format", "Render the check in a specific format (nagios, json, prometheus, text)").Default("nagios").EnumVar(&checkRenderFormat, "nagios", "json", "prometheus", "text")
 	check.Flag("outfile", "Save output to a file rather than STDOUT").StringVar(&checkRenderOutFile)
 
 	conn := check.Command("connection", "Checks basic server connection").Alias("conn").Default().Action(c.checkConnection)

--- a/cli/server_info_command.go
+++ b/cli/server_info_command.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/nats-io/nats-server/v2/server"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvInfoCmd struct {

--- a/cli/server_list_command.go
+++ b/cli/server_list_command.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/nats-io/nats-server/v2/server"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvLsCmd struct {

--- a/cli/server_mkpasswd_command.go
+++ b/cli/server_mkpasswd_command.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/alecthomas/kingpin"
 	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvPasswdCmd struct {

--- a/cli/server_ping_command.go
+++ b/cli/server_ping_command.go
@@ -24,10 +24,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/guptarohit/asciigraph"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvPingCmd struct {

--- a/cli/server_raft_command.go
+++ b/cli/server_raft_command.go
@@ -19,9 +19,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats-server/v2/server"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvRaftCmd struct {

--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -18,12 +18,12 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/xlab/tablewriter"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvReportCmd struct {

--- a/cli/server_request_command.go
+++ b/cli/server_request_command.go
@@ -16,9 +16,9 @@ package cli
 import (
 	"fmt"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvRequestCmd struct {

--- a/cli/server_run_command.go
+++ b/cli/server_run_command.go
@@ -12,10 +12,10 @@ import (
 	"syscall"
 	"text/template"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/nats-server/v2/server"
 	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type SrvRunCmd struct {

--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/emicklei/dot"
 	"github.com/google/go-cmp/cmp"
@@ -40,7 +41,6 @@ import (
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats.go"
 	"github.com/xlab/tablewriter"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type streamCmd struct {

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -23,9 +23,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type subCmd struct {

--- a/cli/traffic_command.go
+++ b/cli/traffic_command.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/nats-io/nats.go"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type trafficCmd struct {

--- a/cli/util.go
+++ b/cli/util.go
@@ -37,6 +37,7 @@ import (
 	"unicode"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/alecthomas/kingpin"
 	"github.com/dustin/go-humanize"
 	"github.com/gosuri/uiprogress"
 	"github.com/klauspost/compress/s2"
@@ -45,7 +46,6 @@ import (
 	"github.com/nats-io/nuid"
 	"github.com/xlab/tablewriter"
 	terminal "golang.org/x/term"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/nats-io/jsm.go"
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
+	github.com/alecthomas/kingpin v1.3.8-0.20211026191244-551b91efb557
 	github.com/dustin/go-humanize v1.0.0
 	github.com/emicklei/dot v0.16.0
 	github.com/fatih/color v1.13.0
@@ -25,7 +26,6 @@ require (
 	github.com/xlab/tablewriter v0.0.0-20160610135559-80b567a11ad5
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXY
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alecthomas/kingpin v1.3.8-0.20211026191244-551b91efb557 h1:hfelGG92c5gGjbBTNFg5soC4Q5uiP3bp450MaXUG/KU=
+github.com/alecthomas/kingpin v1.3.8-0.20211026191244-551b91efb557/go.mod h1:b6br6/pDFSfMkBgC96TbpOji05q5pa+v5rIlS0Y6XtI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -557,7 +559,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This uses master of kingpin to get some additional
features around templates, use those to inject some
helper function into the templates and create a new
help template

The basic idea is that just typing nats must give a
overview and doing --help on any sub command will show
flags (including common ones) and more

This is a quick stop gap, we can do better but for now
this is already a huge step up.  Technically a breaking
change due to making it incompatible with the blessed
kingpin, but meh.

Signed-off-by: R.I.Pienaar <rip@devco.net>