### PR TITLE
Improve help output

### DIFF
--- a/cli/account_command.go
+++ b/cli/account_command.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats.go"
@@ -77,11 +77,11 @@ func init() {
 	registerCommand("account", 0, configureActCommand)
 }
 
-func (c *actCmd) backupAction(_ *kingpin.ParseContext) error {
+func (c *actCmd) backupAction(_ *fisk.ParseContext) error {
 	var err error
 
 	_, mgr, err := prepareHelper("", natsOpts()...)
-	kingpin.FatalIfError(err, "setup failed")
+	fisk.FatalIfError(err, "setup failed")
 
 	streams, err := mgr.Streams()
 	if err != nil {
@@ -144,9 +144,9 @@ func (c *actCmd) backupAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *actCmd) restoreAction(kp *kingpin.ParseContext) error {
+func (c *actCmd) restoreAction(kp *fisk.ParseContext) error {
 	_, mgr, err := prepareHelper("", natsOpts()...)
-	kingpin.FatalIfError(err, "setup failed")
+	fisk.FatalIfError(err, "setup failed")
 	streams, err := mgr.StreamNames(nil)
 	if err != nil {
 		return err
@@ -156,28 +156,28 @@ func (c *actCmd) restoreAction(kp *kingpin.ParseContext) error {
 		existingStreams[n] = struct{}{}
 	}
 	de, err := os.ReadDir(c.backupDirectory)
-	kingpin.FatalIfError(err, "setup failed")
+	fisk.FatalIfError(err, "setup failed")
 	for _, d := range de {
 		if !d.IsDir() {
-			kingpin.FatalIfError(err, "expected a directory")
+			fisk.FatalIfError(err, "expected a directory")
 		}
 		if _, ok := existingStreams[d.Name()]; ok {
-			kingpin.Fatalf("stream %q exists already", d.Name())
+			fisk.Fatalf("stream %q exists already", d.Name())
 		}
 		_, err := os.Stat(filepath.Join(c.backupDirectory, d.Name(), "backup.json"))
-		kingpin.FatalIfError(err, "expected backup.json")
+		fisk.FatalIfError(err, "expected backup.json")
 	}
 	fmt.Printf("Restoring backup of all %d streams in directory %q\n\n", len(de), c.backupDirectory)
 	s := &streamCmd{msgID: -1, showProgress: false, placementCluster: c.placementCluster, placementTags: c.placementTags}
 	for _, d := range de {
 		s.backupDirectory = filepath.Join(c.backupDirectory, d.Name())
 		err := s.restoreAction(kp)
-		kingpin.FatalIfError(err, "restore for %s failed", d.Name())
+		fisk.FatalIfError(err, "restore for %s failed", d.Name())
 	}
 	return nil
 }
 
-func (c *actCmd) reportConnectionsAction(pc *kingpin.ParseContext) error {
+func (c *actCmd) reportConnectionsAction(pc *fisk.ParseContext) error {
 	cmd := SrvReportCmd{
 		topk:    c.topk,
 		sort:    c.sort,
@@ -240,9 +240,9 @@ func (c *actCmd) renderTier(name string, tier *api.JetStreamTier) {
 	fmt.Println()
 }
 
-func (c *actCmd) infoAction(_ *kingpin.ParseContext) error {
+func (c *actCmd) infoAction(_ *fisk.ParseContext) error {
 	nc, mgr, err := prepareHelper("", natsOpts()...)
-	kingpin.FatalIfError(err, "setup failed")
+	fisk.FatalIfError(err, "setup failed")
 
 	id, _ := nc.GetClientID()
 	ip, _ := nc.GetClientIP()

--- a/cli/backup_command.go
+++ b/cli/backup_command.go
@@ -16,7 +16,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 )
 
 type backupCmd struct {
@@ -36,7 +36,7 @@ func init() {
 	registerCommand("backup", 1, configureBackupCommand)
 }
 
-func (c *backupCmd) backupAction(_ *kingpin.ParseContext) error {
+func (c *backupCmd) backupAction(_ *fisk.ParseContext) error {
 	_, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/bench_command.go
+++ b/cli/bench_command.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/gosuri/uiprogress"
 	"github.com/nats-io/nats.go"
@@ -140,7 +140,7 @@ func init() {
 	registerCommand("bench", 2, configureBenchCommand)
 }
 
-func (c *benchCmd) bench(_ *kingpin.ParseContext) error {
+func (c *benchCmd) bench(_ *fisk.ParseContext) error {
 	// first check the sanity of the arguments
 	if c.numMsg <= 0 {
 		return fmt.Errorf("number of messages should be greater than 0")
@@ -250,7 +250,7 @@ func (c *benchCmd) bench(_ *kingpin.ParseContext) error {
 			// There is no way to purge all the keys in a KV bucket in a single operation so deleting the bucket instead
 			if c.purge {
 				err = js.PurgeStream("KV_" + c.subject)
-				//err = js.DeleteKeyValue(c.subject)
+				// err = js.DeleteKeyValue(c.subject)
 				if err != nil {
 					log.Fatalf("Can not purge the bucket: %v", err)
 				}

--- a/cli/cheat_command.go
+++ b/cli/cheat_command.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 )
 
 type cheatCmd struct {
@@ -83,7 +83,7 @@ func (c *cheatCmd) saveCheats() error {
 	return nil
 }
 
-func (c *cheatCmd) cheat(_ *kingpin.ParseContext) error {
+func (c *cheatCmd) cheat(_ *fisk.ParseContext) error {
 	if c.save != "" {
 		return c.saveCheats()
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/nats.go"
@@ -21,7 +21,7 @@ type command struct {
 }
 
 type commandHost interface {
-	Command(name string, help string) *kingpin.CmdClause
+	Command(name string, help string) *fisk.CmdClause
 }
 
 // Logger provides a plugable logger implementation
@@ -160,7 +160,7 @@ func commonConfigure(cmd commandHost, cliOpts *Options, disable ...string) error
 
 // ConfigureInCommand attaches the cli commands to cmd, prepare will load the context on demand and should be true unless override nats,
 // manager and js context is given in a custom PreAction in the caller.  Disable is a list of command names to skip.
-func ConfigureInCommand(cmd *kingpin.CmdClause, cliOpts *Options, prepare bool, disable ...string) (*Options, error) {
+func ConfigureInCommand(cmd *fisk.CmdClause, cliOpts *Options, prepare bool, disable ...string) (*Options, error) {
 	err := commonConfigure(cmd, cliOpts, disable...)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func ConfigureInCommand(cmd *kingpin.CmdClause, cliOpts *Options, prepare bool, 
 
 // ConfigureInApp attaches the cli commands to app, prepare will load the context on demand and should be true unless override nats,
 // manager and js context is given in a custom PreAction in the caller.  Disable is a list of command names to skip.
-func ConfigureInApp(app *kingpin.Application, cliOpts *Options, prepare bool, disable ...string) (*Options, error) {
+func ConfigureInApp(app *fisk.Application, cliOpts *Options, prepare bool, disable ...string) (*Options, error) {
 	err := commonConfigure(app, cliOpts, disable...)
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func ConfigureInApp(app *kingpin.Application, cliOpts *Options, prepare bool, di
 	return opts, nil
 }
 
-func preAction(_ *kingpin.ParseContext) (err error) {
+func preAction(_ *fisk.ParseContext) (err error) {
 	loadContext()
 
 	rand.Seed(time.Now().UnixNano())

--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/fatih/color"
 
 	"github.com/nats-io/jsm.go/natscontext"
@@ -117,7 +117,7 @@ func (c *ctxCommand) overrideVars() []string {
 
 	return list
 }
-func (c *ctxCommand) validateCommand(pc *kingpin.ParseContext) error {
+func (c *ctxCommand) validateCommand(pc *fisk.ParseContext) error {
 	var contexts []string
 	if c.name == "" {
 		contexts = natscontext.KnownContexts()
@@ -142,7 +142,7 @@ func (c *ctxCommand) validateCommand(pc *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *ctxCommand) copyCommand(pc *kingpin.ParseContext) error {
+func (c *ctxCommand) copyCommand(pc *fisk.ParseContext) error {
 	if !natscontext.IsKnown(c.source) {
 		return fmt.Errorf("unknown context %q", c.source)
 	}
@@ -156,7 +156,7 @@ func (c *ctxCommand) copyCommand(pc *kingpin.ParseContext) error {
 	return c.createCommand(pc)
 }
 
-func (c *ctxCommand) editCommand(pc *kingpin.ParseContext) error {
+func (c *ctxCommand) editCommand(pc *fisk.ParseContext) error {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		return fmt.Errorf("set EDITOR environment variable to your chosen editor")
@@ -228,7 +228,7 @@ func (c *ctxCommand) renderListTable(current string, known []*natscontext.Contex
 	fmt.Println(table.Render())
 
 }
-func (c *ctxCommand) listCommand(_ *kingpin.ParseContext) error {
+func (c *ctxCommand) listCommand(_ *fisk.ParseContext) error {
 	names := natscontext.KnownContexts()
 	current := natscontext.SelectedContext()
 	var contexts []*natscontext.Context
@@ -254,7 +254,7 @@ func (c *ctxCommand) listCommand(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *ctxCommand) showCommand(_ *kingpin.ParseContext) error {
+func (c *ctxCommand) showCommand(_ *fisk.ParseContext) error {
 	if c.name == "" {
 		c.name = natscontext.SelectedContext()
 	}
@@ -339,7 +339,7 @@ func (c *ctxCommand) showCommand(_ *kingpin.ParseContext) error {
 
 	return nil
 }
-func (c *ctxCommand) createCommand(pc *kingpin.ParseContext) error {
+func (c *ctxCommand) createCommand(pc *fisk.ParseContext) error {
 	lname := ""
 	load := false
 
@@ -384,7 +384,7 @@ func (c *ctxCommand) createCommand(pc *kingpin.ParseContext) error {
 	return c.showCommand(pc)
 }
 
-func (c *ctxCommand) removeCommand(_ *kingpin.ParseContext) error {
+func (c *ctxCommand) removeCommand(_ *fisk.ParseContext) error {
 	if !c.force {
 		ok, err := askConfirmation(fmt.Sprintf("Really delete context %q", c.name), false)
 		if err != nil {
@@ -399,7 +399,7 @@ func (c *ctxCommand) removeCommand(_ *kingpin.ParseContext) error {
 	return natscontext.DeleteContext(c.name)
 }
 
-func (c *ctxCommand) selectCommand(pc *kingpin.ParseContext) error {
+func (c *ctxCommand) selectCommand(pc *fisk.ParseContext) error {
 	known := natscontext.KnownContexts()
 
 	if len(known) == 0 {

--- a/cli/errors_command.go
+++ b/cli/errors_command.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/fatih/color"
 	"github.com/nats-io/jsm.go/schemas"
 	"github.com/nats-io/nats-server/v2/server"
@@ -63,7 +63,7 @@ func init() {
 	registerCommand("errors", 6, configureErrCommand)
 }
 
-func (c *errCmd) validateAction(_ *kingpin.ParseContext) error {
+func (c *errCmd) validateAction(_ *fisk.ParseContext) error {
 	if c.file == "" {
 		return fmt.Errorf("errors file is required")
 	}
@@ -89,7 +89,7 @@ func (c *errCmd) validateAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *errCmd) listAction(_ *kingpin.ParseContext) error {
+func (c *errCmd) listAction(_ *fisk.ParseContext) error {
 	re := regexp.MustCompile(".")
 	if c.match != "" {
 		re = regexp.MustCompile(strings.ToLower(c.match))
@@ -120,7 +120,7 @@ func (c *errCmd) listAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *errCmd) editAction(pc *kingpin.ParseContext) error {
+func (c *errCmd) editAction(pc *fisk.ParseContext) error {
 	if os.Getenv("EDITOR") == "" {
 		return fmt.Errorf("EDITOR variable is not set")
 	}
@@ -215,7 +215,7 @@ func (c *errCmd) editAction(pc *kingpin.ParseContext) error {
 	return c.validateAction(pc)
 }
 
-func (c *errCmd) lookupAction(_ *kingpin.ParseContext) error {
+func (c *errCmd) lookupAction(_ *fisk.ParseContext) error {
 	errs, err := c.loadErrors(nil)
 	if err != nil {
 		return err

--- a/cli/events_command.go
+++ b/cli/events_command.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats.go"
@@ -131,16 +131,16 @@ func (c *eventsCmd) Printf(f string, arg ...interface{}) {
 	}
 }
 
-func (c *eventsCmd) eventsAction(_ *kingpin.ParseContext) error {
+func (c *eventsCmd) eventsAction(_ *fisk.ParseContext) error {
 	if c.ce {
 		c.json = true
 	}
 
 	nc, _, err := prepareHelper("", natsOpts()...)
-	kingpin.FatalIfError(err, "setup failed")
+	fisk.FatalIfError(err, "setup failed")
 
 	c.bodyFRe, err = regexp.Compile(strings.ToUpper(c.bodyF))
-	kingpin.FatalIfError(err, "invalid body regular expression")
+	fisk.FatalIfError(err, "invalid body regular expression")
 
 	if !c.showAll && !c.showJsAdvisories && !c.showJsMetrics && !c.showServerAdvisories && len(c.extraSubjects) == 0 {
 		return fmt.Errorf("no events were chosen")

--- a/cli/governor_command.go
+++ b/cli/governor_command.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/kballard/go-shellquote"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/jsm.go/governor"
@@ -97,7 +97,7 @@ func init() {
 	registerCommand("governor", 8, configureGovernorCommand)
 }
 
-func (c *govCmd) rmAction(_ *kingpin.ParseContext) error {
+func (c *govCmd) rmAction(_ *fisk.ParseContext) error {
 	_, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func (c *govCmd) rmAction(_ *kingpin.ParseContext) error {
 	return gmgr.Stream().Delete()
 }
 
-func (c *govCmd) addAction(pc *kingpin.ParseContext) error {
+func (c *govCmd) addAction(pc *fisk.ParseContext) error {
 	_, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -154,7 +154,7 @@ func (c *govCmd) addAction(pc *kingpin.ParseContext) error {
 	return c.viewAction(pc)
 }
 
-func (c *govCmd) viewAction(_ *kingpin.ParseContext) error {
+func (c *govCmd) viewAction(_ *fisk.ParseContext) error {
 	nc, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -227,7 +227,7 @@ func (c *govCmd) viewAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *govCmd) resetAction(pc *kingpin.ParseContext) error {
+func (c *govCmd) resetAction(pc *fisk.ParseContext) error {
 	_, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -251,7 +251,7 @@ func (c *govCmd) resetAction(pc *kingpin.ParseContext) error {
 	return gmgr.Reset()
 }
 
-func (c *govCmd) evictAction(pc *kingpin.ParseContext) error {
+func (c *govCmd) evictAction(pc *fisk.ParseContext) error {
 	_, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -291,7 +291,7 @@ func (c *govCmd) evictAction(pc *kingpin.ParseContext) error {
 	return err
 }
 
-func (c *govCmd) runAction(_ *kingpin.ParseContext) error {
+func (c *govCmd) runAction(_ *fisk.ParseContext) error {
 	_, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/kv_command.go
+++ b/cli/kv_command.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/nats-io/jsm.go"
@@ -168,7 +168,7 @@ func init() {
 	registerCommand("kv", 9, configureKVCommand)
 }
 
-func (c *kvCommand) parseLimitStrings(_ *kingpin.ParseContext) (err error) {
+func (c *kvCommand) parseLimitStrings(_ *fisk.ParseContext) (err error) {
 	if c.maxValueSizeString != "" {
 		c.maxValueSize, err = parseStringAsBytes(c.maxValueSizeString)
 		if err != nil {
@@ -199,7 +199,7 @@ func (c *kvCommand) strForOp(op nats.KeyValueOp) string {
 	}
 }
 
-func (c *kvCommand) lsAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) lsAction(_ *fisk.ParseContext) error {
 	_, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -247,7 +247,7 @@ func (c *kvCommand) lsAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *kvCommand) upgradeAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) upgradeAction(_ *fisk.ParseContext) error {
 	_, js, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -281,7 +281,7 @@ func (c *kvCommand) upgradeAction(_ *kingpin.ParseContext) error {
 	return c.showStatus(store)
 }
 
-func (c *kvCommand) historyAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) historyAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -308,7 +308,7 @@ func (c *kvCommand) historyAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *kvCommand) compactAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) compactAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -329,7 +329,7 @@ func (c *kvCommand) compactAction(_ *kingpin.ParseContext) error {
 	return store.PurgeDeletes()
 }
 
-func (c *kvCommand) deleteAction(pc *kingpin.ParseContext) error {
+func (c *kvCommand) deleteAction(pc *fisk.ParseContext) error {
 	if c.key == "" {
 		return c.rmBucketAction(pc)
 	}
@@ -354,7 +354,7 @@ func (c *kvCommand) deleteAction(pc *kingpin.ParseContext) error {
 	return store.Delete(c.key)
 }
 
-func (c *kvCommand) addAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) addAction(_ *fisk.ParseContext) error {
 	_, js, err := prepareJSHelper()
 	if err != nil {
 		return err
@@ -388,7 +388,7 @@ func (c *kvCommand) addAction(_ *kingpin.ParseContext) error {
 	return c.showStatus(store)
 }
 
-func (c *kvCommand) getAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) getAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -420,7 +420,7 @@ func (c *kvCommand) getAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *kvCommand) putAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) putAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -441,7 +441,7 @@ func (c *kvCommand) putAction(_ *kingpin.ParseContext) error {
 	return err
 }
 
-func (c *kvCommand) createAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) createAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -462,7 +462,7 @@ func (c *kvCommand) createAction(_ *kingpin.ParseContext) error {
 	return err
 }
 
-func (c *kvCommand) updateAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) updateAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -546,7 +546,7 @@ func (c *kvCommand) knownBuckets(nc *nats.Conn) ([]string, error) {
 	return found, nil
 }
 
-func (c *kvCommand) infoAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) infoAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -555,7 +555,7 @@ func (c *kvCommand) infoAction(_ *kingpin.ParseContext) error {
 	return c.showStatus(store)
 }
 
-func (c *kvCommand) watchAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) watchAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -585,7 +585,7 @@ func (c *kvCommand) watchAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *kvCommand) purgeAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) purgeAction(_ *fisk.ParseContext) error {
 	_, _, store, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -606,7 +606,7 @@ func (c *kvCommand) purgeAction(_ *kingpin.ParseContext) error {
 	return store.Purge(c.key)
 }
 
-func (c *kvCommand) rmBucketAction(_ *kingpin.ParseContext) error {
+func (c *kvCommand) rmBucketAction(_ *fisk.ParseContext) error {
 	if !c.force {
 		ok, err := askConfirmation(fmt.Sprintf("Deleted bucket %s?", c.bucket), false)
 		if err != nil {

--- a/cli/latency_command.go
+++ b/cli/latency_command.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/HdrHistogram/hdrhistogram-go"
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/nats.go"
 	histwriter "github.com/tylertreat/hdrhistogram-writer"
 )
@@ -60,7 +60,7 @@ func init() {
 	registerCommand("latency", 11, configureLatencyCommand)
 }
 
-func (c *latencyCmd) latencyAction(_ *kingpin.ParseContext) error {
+func (c *latencyCmd) latencyAction(_ *fisk.ParseContext) error {
 	start := time.Now()
 	c.numPubs = int(c.testDuration/time.Second) * c.targetPubRate
 

--- a/cli/object_command.go
+++ b/cli/object_command.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/gosuri/uiprogress"
@@ -157,7 +157,7 @@ func init() {
 	registerCommand("object", 10, configureObjectCommand)
 }
 
-func (c *objCommand) parseLimitStrings(_ *kingpin.ParseContext) (err error) {
+func (c *objCommand) parseLimitStrings(_ *fisk.ParseContext) (err error) {
 	if c.maxBucketSizeString != "" {
 		c.maxBucketSize, err = parseStringAsBytes(c.maxBucketSizeString)
 		if err != nil {
@@ -168,7 +168,7 @@ func (c *objCommand) parseLimitStrings(_ *kingpin.ParseContext) (err error) {
 	return nil
 }
 
-func (c *objCommand) watchAction(_ *kingpin.ParseContext) error {
+func (c *objCommand) watchAction(_ *fisk.ParseContext) error {
 	_, _, obj, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -195,10 +195,10 @@ func (c *objCommand) watchAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *objCommand) sealAction(_ *kingpin.ParseContext) error {
+func (c *objCommand) sealAction(_ *fisk.ParseContext) error {
 	if !c.force {
 		ok, err := askConfirmation(fmt.Sprintf("Really seal Bucket %s, sealed buckets can not be unsealed or modified", c.bucket), false)
-		kingpin.FatalIfError(err, "could not obtain confirmation")
+		fisk.FatalIfError(err, "could not obtain confirmation")
 
 		if !ok {
 			return nil
@@ -220,7 +220,7 @@ func (c *objCommand) sealAction(_ *kingpin.ParseContext) error {
 	return c.showBucketInfo(obj)
 }
 
-func (c *objCommand) delAction(_ *kingpin.ParseContext) error {
+func (c *objCommand) delAction(_ *fisk.ParseContext) error {
 	_, _, obj, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -274,7 +274,7 @@ func (c *objCommand) delAction(_ *kingpin.ParseContext) error {
 	}
 }
 
-func (c *objCommand) infoAction(_ *kingpin.ParseContext) error {
+func (c *objCommand) infoAction(_ *fisk.ParseContext) error {
 	_, _, obj, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -428,7 +428,7 @@ func (c *objCommand) listBuckets() error {
 	return nil
 }
 
-func (c *objCommand) lsAction(_ *kingpin.ParseContext) error {
+func (c *objCommand) lsAction(_ *fisk.ParseContext) error {
 	if c.bucket == "" {
 		return c.listBuckets()
 	}
@@ -460,7 +460,7 @@ func (c *objCommand) lsAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *objCommand) putAction(_ *kingpin.ParseContext) error {
+func (c *objCommand) putAction(_ *fisk.ParseContext) error {
 	_, _, obj, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -480,7 +480,7 @@ func (c *objCommand) putAction(_ *kingpin.ParseContext) error {
 		c.showObjectInfo(nfo)
 		fmt.Println()
 		ok, err := askConfirmation(fmt.Sprintf("Replace existing file %s > %s", c.bucket, name), false)
-		kingpin.FatalIfError(err, "could not obtain confirmation")
+		fisk.FatalIfError(err, "could not obtain confirmation")
 
 		if !ok {
 			return nil
@@ -547,7 +547,7 @@ func (c *objCommand) putAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *objCommand) getAction(_ *kingpin.ParseContext) error {
+func (c *objCommand) getAction(_ *fisk.ParseContext) error {
 	_, _, obj, err := c.loadBucket()
 	if err != nil {
 		return err
@@ -581,7 +581,7 @@ func (c *objCommand) getAction(_ *kingpin.ParseContext) error {
 		_, err = os.Stat(out)
 		if !os.IsNotExist(err) {
 			ok, err := askConfirmation(fmt.Sprintf("Replace existing target file %s", out), false)
-			kingpin.FatalIfError(err, "could not obtain confirmation")
+			fisk.FatalIfError(err, "could not obtain confirmation")
 
 			if !ok {
 				return nil
@@ -638,7 +638,7 @@ func (c *objCommand) getAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *objCommand) addAction(_ *kingpin.ParseContext) error {
+func (c *objCommand) addAction(_ *fisk.ParseContext) error {
 	_, js, err := prepareJSHelper()
 	if err != nil {
 		return err

--- a/cli/optional_boolean.go
+++ b/cli/optional_boolean.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 )
 
-// OptionalBoolValue is contains a *bool and implements kingpin.Value
+// OptionalBoolValue is contains a *bool and implements fisk.Value
 type OptionalBoolValue struct {
 	val *bool
 }
 
-func OptionalBoolean(s kingpin.Settings) *OptionalBoolValue {
+func OptionalBoolean(s fisk.Settings) *OptionalBoolValue {
 	target := &OptionalBoolValue{}
 	s.SetValue(target)
 	return target

--- a/cli/pub_command.go
+++ b/cli/pub_command.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/gosuri/uiprogress"
 	"github.com/nats-io/nats.go"
 	terminal "golang.org/x/term"
@@ -43,9 +43,8 @@ type pubCmd struct {
 
 func configurePubCommand(app commandHost) {
 	c := &pubCmd{}
-	pubHelp := `Generic data publish utility
 
-Body and Header values of the messages may use Go templates to 
+	pubHelp := `Body and Header values of the messages may use Go templates to 
 create unique messages.
 
    nats pub test --count 10 "Message {{Count}} @ {{Time}}"
@@ -62,10 +61,11 @@ Available template functions are:
    UnixNano         nano seconds since 1970 in UTC
    Time             the current time
    ID               an unique ID
-   Random(min, max) random string at least min long, at most max 
-
+   Random(min, max) random string at least min long, at most max
 `
-	pub := app.Command("publish", pubHelp).Alias("pub").Action(c.publish)
+
+	pub := app.Command("publish", "Generic data publish utility").Alias("pub").Action(c.publish)
+	pub.HelpLong(pubHelp)
 	pub.Arg("subject", "Subject to subscribe to").Required().StringVar(&c.subject)
 	pub.Arg("body", "Message body").Default("!nil!").StringVar(&c.body)
 	pub.Flag("reply", "Sets a custom reply to subject").StringVar(&c.replyTo)
@@ -87,9 +87,7 @@ echo "hello world" | nats pub --force-stdin destination.subject
 nats request destination.subject "hello world" -H "Content-type:text/plain" --raw
 `
 
-	requestHelp := `Generic request-reply request utility
-
-Body and Header values of the messages may use Go templates to 
+	requestHelp := `Body and Header values of the messages may use Go templates to 
 create unique messages.
 
    nats request test --count 10 "Message {{Count}} @ {{Time}}"
@@ -106,10 +104,11 @@ Available template functions are:
    UnixNano         nano seconds since 1970 in UTC
    Time             the current time
    ID               an unique ID
-   Random(min, max) random string at least min long, at most max 
-
+   Random(min, max) random string at least min long, at most max
 `
-	req := app.Command("request", requestHelp).Alias("req").Action(c.publish)
+
+	req := app.Command("request", "Generic request-reply request utility").Alias("req").Action(c.publish)
+	req.HelpLong(requestHelp)
 	req.Arg("subject", "Subject to subscribe to").Required().StringVar(&c.subject)
 	req.Arg("body", "Message body").Default("!nil!").StringVar(&c.body)
 	req.Flag("wait", "Wait for a reply from a service").Short('w').Default("true").Hidden().BoolVar(&c.req)
@@ -248,7 +247,7 @@ func (c *pubCmd) doReq(nc *nats.Conn, progress *uiprogress.Bar) error {
 	return nil
 }
 
-func (c *pubCmd) publish(_ *kingpin.ParseContext) error {
+func (c *pubCmd) publish(_ *fisk.ParseContext) error {
 	nc, err := newNatsConn("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/reply_command.go
+++ b/cli/reply_command.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/kballard/go-shellquote"
 	"github.com/nats-io/nats.go"
 )
@@ -41,9 +41,7 @@ type replyCmd struct {
 
 func configureReplyCommand(app commandHost) {
 	c := &replyCmd{}
-	help := `Generic service reply utility
-
-The "command" supports extracting some information from the subject the request came in on.
+	help := `The "command" supports extracting some information from the subject the request came in on.
 
 When the subject being listened on is "weather.>" a request on "weather.london" can extract
 the "london" part and use it in the command string:
@@ -70,11 +68,11 @@ Available template functions are:
    UnixNano         nano seconds since 1970 in UTC
    Time             the current time
    ID               an unique ID
-   Random(min, max) random string at least min long, at most max 
-
+   Random(min, max) random string at least min long, at most max
 `
 
-	act := app.Command("reply", help).Action(c.reply)
+	act := app.Command("reply", "Generic service reply utility").Action(c.reply)
+	act.HelpLong(help)
 	act.Arg("subject", "Subject to subscribe to").Required().StringVar(&c.subject)
 	act.Arg("body", "Reply body").StringVar(&c.body)
 	act.Flag("echo", "Echo back what is received").BoolVar(&c.echo)
@@ -97,7 +95,7 @@ func init() {
 	registerCommand("reply", 12, configureReplyCommand)
 }
 
-func (c *replyCmd) reply(_ *kingpin.ParseContext) error {
+func (c *replyCmd) reply(_ *fisk.ParseContext) error {
 	nc, err := newNatsConn("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/restore_command.go
+++ b/cli/restore_command.go
@@ -16,7 +16,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 )
 
 type restoreCmd struct {
@@ -38,7 +38,7 @@ func init() {
 	registerCommand("restore", 12, configureRestoreCommand)
 }
 
-func (c *restoreCmd) restoreAction(_ *kingpin.ParseContext) error {
+func (c *restoreCmd) restoreAction(_ *fisk.ParseContext) error {
 	fmt.Println("Please note this method of backup does not backup stream data")
 	fmt.Println()
 	fmt.Println("We now have the ability to backup a single stream data or all streams in")

--- a/cli/rtt_command.go
+++ b/cli/rtt_command.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/nats.go"
 )
 
@@ -55,7 +55,7 @@ func init() {
 	registerCommand("rtt", 13, configureRTTCommand)
 }
 
-func (c *rttCmd) rtt(_ *kingpin.ParseContext) error {
+func (c *rttCmd) rtt(_ *fisk.ParseContext) error {
 	targets, err := c.targets()
 	if err != nil {
 		return err

--- a/cli/schema_info_command.go
+++ b/cli/schema_info_command.go
@@ -16,7 +16,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/ghodss/yaml"
 	"github.com/nats-io/jsm.go/api"
 )
@@ -26,14 +26,14 @@ type schemaInfoCmd struct {
 	yaml   bool
 }
 
-func configureSchemaInfoCommand(schema *kingpin.CmdClause) {
+func configureSchemaInfoCommand(schema *fisk.CmdClause) {
 	c := &schemaInfoCmd{}
 	info := schema.Command("info", "Display schema contents").Alias("show").Alias("view").Action(c.info)
 	info.Arg("schema", "Schema ID to show").Required().StringVar(&c.schema)
 	info.Flag("yaml", "Produce YAML format output").BoolVar(&c.yaml)
 }
 
-func (c *schemaInfoCmd) info(_ *kingpin.ParseContext) error {
+func (c *schemaInfoCmd) info(_ *fisk.ParseContext) error {
 	schema, err := api.Schema(c.schema)
 	if err != nil {
 		return fmt.Errorf("could not load schema %q: %s", c.schema, err)

--- a/cli/schema_search_command.go
+++ b/cli/schema_search_command.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/jsm.go/api"
 )
 
@@ -26,14 +26,14 @@ type schemaSearchCmd struct {
 	json   bool
 }
 
-func configureSchemaSearchCommand(schema *kingpin.CmdClause) {
+func configureSchemaSearchCommand(schema *fisk.CmdClause) {
 	c := &schemaSearchCmd{}
 	search := schema.Command("search", "Search schemas using a pattern").Alias("find").Alias("list").Alias("ls").Action(c.search)
 	search.Arg("pattern", "Regular expression to search for").Default(".").StringVar(&c.filter)
 	search.Flag("json", "Produce JSON format output").BoolVar(&c.json)
 }
 
-func (c *schemaSearchCmd) search(_ *kingpin.ParseContext) error {
+func (c *schemaSearchCmd) search(_ *fisk.ParseContext) error {
 	found, err := api.SchemaSearch(c.filter)
 	if err != nil {
 		return fmt.Errorf("search failed: %s", err)

--- a/cli/schema_validate_command.go
+++ b/cli/schema_validate_command.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 )
 
 type schemaValidateCmd struct {
@@ -28,7 +28,7 @@ type schemaValidateCmd struct {
 	json   bool
 }
 
-func configureSchemaValidateCommand(schema *kingpin.CmdClause) {
+func configureSchemaValidateCommand(schema *fisk.CmdClause) {
 	c := &schemaValidateCmd{}
 	validate := schema.Command("validate", "Validates a JSON file against a schema").Alias("check").Action(c.validate)
 	validate.Arg("schema", "Schema ID to validate against").Required().StringVar(&c.schema)
@@ -37,7 +37,7 @@ func configureSchemaValidateCommand(schema *kingpin.CmdClause) {
 
 }
 
-func (c *schemaValidateCmd) validate(_ *kingpin.ParseContext) error {
+func (c *schemaValidateCmd) validate(_ *fisk.ParseContext) error {
 	file, err := ioutil.ReadFile(c.file)
 	if err != nil {
 		return err

--- a/cli/server_check_command.go
+++ b/cli/server_check_command.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
@@ -82,7 +82,7 @@ type SrvCheckCmd struct {
 	kvKey        string
 }
 
-func configureServerCheckCommand(srv *kingpin.CmdClause) {
+func configureServerCheckCommand(srv *fisk.CmdClause) {
 	c := &SrvCheckCmd{}
 
 	help := `Health check for NATS servers
@@ -535,7 +535,7 @@ func (c *SrvCheckCmd) checkKVStatusAndBucket(check *result, nc *nats.Conn) {
 	}
 }
 
-func (c *SrvCheckCmd) checkKV(_ *kingpin.ParseContext) error {
+func (c *SrvCheckCmd) checkKV(_ *fisk.ParseContext) error {
 	check := &result{Name: c.kvBucket, Check: "kv"}
 	defer check.GenericExit()
 
@@ -547,7 +547,7 @@ func (c *SrvCheckCmd) checkKV(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *SrvCheckCmd) checkSrv(_ *kingpin.ParseContext) error {
+func (c *SrvCheckCmd) checkSrv(_ *fisk.ParseContext) error {
 	check := &result{Name: c.srvName, Check: "server"}
 	defer check.GenericExit()
 
@@ -705,7 +705,7 @@ func (c *SrvCheckCmd) fetchVarz() (*server.Varz, error) {
 	return varz, nil
 }
 
-func (c *SrvCheckCmd) checkJS(_ *kingpin.ParseContext) error {
+func (c *SrvCheckCmd) checkJS(_ *fisk.ParseContext) error {
 	check := &result{Name: "JetStream", Check: "jetstream"}
 	defer check.GenericExit()
 
@@ -770,7 +770,7 @@ func (c *SrvCheckCmd) checkAccountInfo(check *result, info *api.JetStreamAccount
 	return nil
 }
 
-func (c *SrvCheckCmd) checkRaft(_ *kingpin.ParseContext) error {
+func (c *SrvCheckCmd) checkRaft(_ *fisk.ParseContext) error {
 	check := &result{Name: "JetStream Meta Cluster", Check: "meta"}
 	defer check.GenericExit()
 
@@ -900,7 +900,7 @@ func (c *SrvCheckCmd) checkClusterInfo(check *result, ci *server.ClusterInfo) er
 	return nil
 }
 
-func (c *SrvCheckCmd) checkStream(_ *kingpin.ParseContext) error {
+func (c *SrvCheckCmd) checkStream(_ *fisk.ParseContext) error {
 	check := &result{Name: c.sourcesStream, Check: "stream"}
 	defer check.GenericExit()
 
@@ -1019,7 +1019,7 @@ func (c *SrvCheckCmd) checkSources(check *result, info *api.StreamInfo) error {
 	return nil
 }
 
-func (c *SrvCheckCmd) checkConnection(_ *kingpin.ParseContext) error {
+func (c *SrvCheckCmd) checkConnection(_ *fisk.ParseContext) error {
 	check := &result{Name: "Connection", Check: "connections"}
 	defer check.GenericExit()
 

--- a/cli/server_info_command.go
+++ b/cli/server_info_command.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/nats-io/nats-server/v2/server"
@@ -30,14 +30,14 @@ type SrvInfoCmd struct {
 	id string
 }
 
-func configureServerInfoCommand(srv *kingpin.CmdClause) {
+func configureServerInfoCommand(srv *fisk.CmdClause) {
 	c := &SrvInfoCmd{}
 
 	info := srv.Command("info", "Show information about a single server").Alias("i").Action(c.info)
 	info.Arg("server", "Server ID or Name to inspect").StringVar(&c.id)
 }
 
-func (c *SrvInfoCmd) info(_ *kingpin.ParseContext) error {
+func (c *SrvInfoCmd) info(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/server_list_command.go
+++ b/cli/server_list_command.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/nats-io/nats-server/v2/server"
 )
@@ -43,7 +43,7 @@ type srvListCluster struct {
 	conns int
 }
 
-func configureServerListCommand(srv *kingpin.CmdClause) {
+func configureServerListCommand(srv *fisk.CmdClause) {
 	c := &SrvLsCmd{}
 
 	ls := srv.Command("ls", "List known servers").Alias("list").Action(c.list)
@@ -54,7 +54,7 @@ func configureServerListCommand(srv *kingpin.CmdClause) {
 	ls.Flag("compact", "Compact server names").Default("true").BoolVar(&c.compact)
 }
 
-func (c *SrvLsCmd) list(_ *kingpin.ParseContext) error {
+func (c *SrvLsCmd) list(_ *fisk.ParseContext) error {
 	nc, err := newNatsConn("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/server_mapping_command.go
+++ b/cli/server_mapping_command.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/nats-server/v2/server"
 )
 
@@ -27,7 +27,7 @@ type SrvMappingCmd struct {
 	subj string
 }
 
-func configureServerMappingCommand(srv *kingpin.CmdClause) {
+func configureServerMappingCommand(srv *fisk.CmdClause) {
 	c := &SrvMappingCmd{}
 
 	m := srv.Command("mappings", "Test subject mapping patterns").Alias("mapping").Action(c.mappingAction)
@@ -36,7 +36,7 @@ func configureServerMappingCommand(srv *kingpin.CmdClause) {
 	m.Arg("subject", "Subject to transform").StringVar(&c.subj)
 }
 
-func (c *SrvMappingCmd) mappingAction(_ *kingpin.ParseContext) error {
+func (c *SrvMappingCmd) mappingAction(_ *fisk.ParseContext) error {
 	if c.src == "" {
 		err := askOne(&survey.Input{
 			Message: "Source subject pattern",

--- a/cli/server_mkpasswd_command.go
+++ b/cli/server_mkpasswd_command.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -27,7 +27,7 @@ type SrvPasswdCmd struct {
 	generate bool
 }
 
-func configureServerPasswdCommand(srv *kingpin.CmdClause) {
+func configureServerPasswdCommand(srv *fisk.CmdClause) {
 	c := &SrvPasswdCmd{}
 
 	passwd := srv.Command("passwd", "Creates encrypted passwords for use in NATS Server").Alias("mkpasswd").Alias("pass").Alias("password").Action(c.mkpasswd)
@@ -36,7 +36,7 @@ func configureServerPasswdCommand(srv *kingpin.CmdClause) {
 	passwd.Flag("generate", "Generates a secure passphrase and encrypt it").Short('g').Default("false").BoolVar(&c.generate)
 }
 
-func (c *SrvPasswdCmd) mkpasswd(_ *kingpin.ParseContext) error {
+func (c *SrvPasswdCmd) mkpasswd(_ *fisk.ParseContext) error {
 	if int(c.cost) < bcrypt.MinCost || int(c.cost) > bcrypt.MaxCost {
 		return fmt.Errorf("bcrypt cost should be between %d and %d", bcrypt.MinCost, bcrypt.MaxCost)
 	}

--- a/cli/server_ping_command.go
+++ b/cli/server_ping_command.go
@@ -24,7 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/guptarohit/asciigraph"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
@@ -36,7 +36,7 @@ type SrvPingCmd struct {
 	showId bool
 }
 
-func configureServerPingCommand(srv *kingpin.CmdClause) {
+func configureServerPingCommand(srv *fisk.CmdClause) {
 	c := &SrvPingCmd{}
 
 	ls := srv.Command("ping", "Ping all servers").Action(c.ping)
@@ -45,7 +45,7 @@ func configureServerPingCommand(srv *kingpin.CmdClause) {
 	ls.Flag("id", "Include the Server ID in the output").BoolVar(&c.showId)
 }
 
-func (c *SrvPingCmd) ping(_ *kingpin.ParseContext) error {
+func (c *SrvPingCmd) ping(_ *fisk.ParseContext) error {
 	nc, err := newNatsConn("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/server_raft_command.go
+++ b/cli/server_raft_command.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/nats-server/v2/server"
 )
@@ -31,7 +31,7 @@ type SrvRaftCmd struct {
 	placementCluster string
 }
 
-func configureServerRaftCommand(srv *kingpin.CmdClause) {
+func configureServerRaftCommand(srv *fisk.CmdClause) {
 	c := &SrvRaftCmd{}
 
 	raft := srv.Command("raft", "Manage JetStream Clustering").Alias("r")
@@ -45,7 +45,7 @@ func configureServerRaftCommand(srv *kingpin.CmdClause) {
 	rm.Flag("force", "Force removal without prompting").Short('f').BoolVar(&c.force)
 }
 
-func (c *SrvRaftCmd) metaPeerRemove(_ *kingpin.ParseContext) error {
+func (c *SrvRaftCmd) metaPeerRemove(_ *fisk.ParseContext) error {
 	nc, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func (c *SrvRaftCmd) metaPeerRemove(_ *kingpin.ParseContext) error {
 		fmt.Printf("Removing %s can not be reversed, data on this node will be\ninaccessible and another one called %s can not join again.\n\n", c.peer, c.peer)
 
 		remove, err := askConfirmation(fmt.Sprintf("Really remove peer %s", c.peer), false)
-		kingpin.FatalIfError(err, "Could not prompt for confirmation")
+		fisk.FatalIfError(err, "Could not prompt for confirmation")
 		if !remove {
 			fmt.Println("Removal canceled")
 			os.Exit(0)
@@ -97,12 +97,12 @@ func (c *SrvRaftCmd) metaPeerRemove(_ *kingpin.ParseContext) error {
 	}
 
 	err = mgr.MetaPeerRemove(c.peer)
-	kingpin.FatalIfError(err, "Could not remove %s", c.peer)
+	fisk.FatalIfError(err, "Could not remove %s", c.peer)
 
 	return nil
 }
 
-func (c *SrvRaftCmd) metaLeaderStandDown(_ *kingpin.ParseContext) error {
+func (c *SrvRaftCmd) metaLeaderStandDown(_ *fisk.ParseContext) error {
 	nc, mgr, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/nats-io/nats-server/v2/server"
@@ -50,7 +50,7 @@ type srvReportAccountInfo struct {
 	Server      []*server.ServerInfo `json:"server"`
 }
 
-func configureServerReportCommand(srv *kingpin.CmdClause) {
+func configureServerReportCommand(srv *fisk.CmdClause) {
 	c := &SrvReportCmd{}
 
 	report := srv.Command("report", "Report on various server metrics").Alias("rep")
@@ -77,7 +77,7 @@ func configureServerReportCommand(srv *kingpin.CmdClause) {
 	jsz.Flag("compact", "Compact server names").Default("true").BoolVar(&c.compact)
 }
 
-func (c *SrvReportCmd) reportJetStream(_ *kingpin.ParseContext) error {
+func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -288,7 +288,7 @@ func (c *SrvReportCmd) reportJetStream(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *SrvReportCmd) reportAccount(_ *kingpin.ParseContext) error {
+func (c *SrvReportCmd) reportAccount(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -407,7 +407,7 @@ type connInfo struct {
 	Info *server.ServerInfo `json:"server"`
 }
 
-func (c *SrvReportCmd) reportConnections(_ *kingpin.ParseContext) error {
+func (c *SrvReportCmd) reportConnections(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/server_request_command.go
+++ b/cli/server_request_command.go
@@ -16,7 +16,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 )
@@ -49,7 +49,7 @@ type SrvRequestCmd struct {
 	nameFilter    string
 }
 
-func configureServerRequestCommand(srv *kingpin.CmdClause) {
+func configureServerRequestCommand(srv *fisk.CmdClause) {
 	c := &SrvRequestCmd{}
 
 	req := srv.Command("request", "Request monitoring data from a specific server").Alias("req")
@@ -107,7 +107,7 @@ func configureServerRequestCommand(srv *kingpin.CmdClause) {
 	jsz.Flag("all", "Include accounts, streams, consumers and configuration").BoolVar(&c.includeAll)
 }
 
-func (c *SrvRequestCmd) jsz(_ *kingpin.ParseContext) error {
+func (c *SrvRequestCmd) jsz(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -153,7 +153,7 @@ func (c *SrvRequestCmd) reqFilter() server.EventFilterOptions {
 	}
 }
 
-func (c *SrvRequestCmd) accountz(_ *kingpin.ParseContext) error {
+func (c *SrvRequestCmd) accountz(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func (c *SrvRequestCmd) accountz(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *SrvRequestCmd) leafz(_ *kingpin.ParseContext) error {
+func (c *SrvRequestCmd) leafz(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -199,7 +199,7 @@ func (c *SrvRequestCmd) leafz(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *SrvRequestCmd) gwyz(_ *kingpin.ParseContext) error {
+func (c *SrvRequestCmd) gwyz(_ *fisk.ParseContext) error {
 	if c.accountFilter != "" {
 		c.detail = true
 	}
@@ -230,7 +230,7 @@ func (c *SrvRequestCmd) gwyz(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *SrvRequestCmd) routez(_ *kingpin.ParseContext) error {
+func (c *SrvRequestCmd) routez(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -256,7 +256,7 @@ func (c *SrvRequestCmd) routez(_ *kingpin.ParseContext) error {
 	return nil
 
 }
-func (c *SrvRequestCmd) conns(_ *kingpin.ParseContext) error {
+func (c *SrvRequestCmd) conns(_ *fisk.ParseContext) error {
 	opts := &server.ConnzEventOptions{
 		ConnzOptions: server.ConnzOptions{
 			Sort:                server.SortOpt(c.sortOpt),
@@ -300,7 +300,7 @@ func (c *SrvRequestCmd) conns(_ *kingpin.ParseContext) error {
 
 }
 
-func (c *SrvRequestCmd) varz(_ *kingpin.ParseContext) error {
+func (c *SrvRequestCmd) varz(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -324,7 +324,7 @@ func (c *SrvRequestCmd) varz(_ *kingpin.ParseContext) error {
 
 }
 
-func (c *SrvRequestCmd) subs(_ *kingpin.ParseContext) error {
+func (c *SrvRequestCmd) subs(_ *fisk.ParseContext) error {
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/server_run_command.go
+++ b/cli/server_run_command.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"text/template"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/nats-server/v2/server"
 	"golang.org/x/crypto/bcrypt"
@@ -115,7 +115,7 @@ leafnodes {
 }
 `
 
-func configureServerRunCommand(srv *kingpin.CmdClause) {
+func configureServerRunCommand(srv *fisk.CmdClause) {
 	c := &SrvRunCmd{}
 
 	run := srv.Command("run", "Runs a local development NATS server").Hidden().Action(c.runAction)
@@ -217,7 +217,7 @@ func (c *SrvRunCmd) prepareConfig() error {
 		}
 		c.config.StoreDir = filepath.Join(parent, "nats", c.config.Name)
 		if runtime.GOOS == "windows" {
-			//escape path separator in file
+			// escape path separator in file
 			c.config.StoreDir = strings.ReplaceAll(c.config.StoreDir, "\\", "\\\\")
 		}
 		if c.config.ExtendWithContext || c.config.ExtendDemoNetwork {
@@ -321,7 +321,7 @@ func (c *SrvRunCmd) configureContexts(url string) (string, string, string, error
 	return c.config.Name, svcName, sysName, nil
 }
 
-func (c *SrvRunCmd) runAction(_ *kingpin.ParseContext) error {
+func (c *SrvRunCmd) runAction(_ *fisk.ParseContext) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/nats.go"
 )
@@ -82,7 +82,7 @@ func init() {
 	registerCommand("sub", 17, configureSubCommand)
 }
 
-func (c *subCmd) subscribe(_ *kingpin.ParseContext) error {
+func (c *subCmd) subscribe(_ *fisk.ParseContext) error {
 	nc, err := newNatsConn("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/traffic_command.go
+++ b/cli/traffic_command.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/nats-io/nats.go"
 )
@@ -82,7 +82,7 @@ func init() {
 	registerCommand("traffic", 18, configureTrafficCommand)
 }
 
-func (c *trafficCmd) monitor(_ *kingpin.ParseContext) error {
+func (c *trafficCmd) monitor(_ *fisk.ParseContext) error {
 	nc, err := newNatsConn("", natsOpts()...)
 	if err != nil {
 		return err

--- a/cli/util.go
+++ b/cli/util.go
@@ -37,7 +37,7 @@ import (
 	"unicode"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/gosuri/uiprogress"
 	"github.com/klauspost/compress/s2"
@@ -393,7 +393,7 @@ func natsOpts() []nats.Option {
 	}
 
 	copts, err := opts.Config.NATSOptions()
-	kingpin.FatalIfError(err, "configuration error")
+	fisk.FatalIfError(err, "configuration error")
 
 	connectionName := strings.TrimSpace(opts.ConnectionName)
 	if len(connectionName) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
-	github.com/alecthomas/kingpin v1.3.8-0.20211026191244-551b91efb557
+	github.com/choria-io/fisk v0.1.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/emicklei/dot v0.16.0
 	github.com/fatih/color v1.13.0
@@ -29,8 +29,6 @@ require (
 )
 
 require (
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,16 +41,11 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXY
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/alecthomas/kingpin v1.3.8-0.20211026191244-551b91efb557 h1:hfelGG92c5gGjbBTNFg5soC4Q5uiP3bp450MaXUG/KU=
-github.com/alecthomas/kingpin v1.3.8-0.20211026191244-551b91efb557/go.mod h1:b6br6/pDFSfMkBgC96TbpOji05q5pa+v5rIlS0Y6XtI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
-github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -59,6 +54,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/choria-io/fisk v0.1.0 h1:eQxRjOLoimA3rCuRsFx4JHOEBgJwr0cyGBWPAyWYYyQ=
+github.com/choria-io/fisk v0.1.0/go.mod h1:S+NQ8qIofXvjz4zT4t69xRudzMYNfOG3uC0lOzGNjHA=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -260,8 +257,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tylertreat/hdrhistogram-writer v0.0.0-20210816161836-2e440612a39f h1:SGznmvCovewbaSgBsHgdThtWsLj5aCLX/3ZXMLd1UD0=
 github.com/tylertreat/hdrhistogram-writer v0.0.0-20210816161836-2e440612a39f/go.mod h1:IY84XkhrEJTdHYLNy/zObs8mXuUAp9I65VyarbPSCCY=
 github.com/xlab/tablewriter v0.0.0-20160610135559-80b567a11ad5 h1:gmD7q6cCJfBbcuobWQe/KzLsd9Cd3amS1Mq5f3uU1qo=

--- a/nats/main.go
+++ b/nats/main.go
@@ -14,74 +14,15 @@
 package main
 
 import (
-	"bufio"
 	"log"
 	"os"
 	"runtime/debug"
-	"strings"
-	"text/template"
 
-	"github.com/alecthomas/kingpin"
+	"github.com/choria-io/fisk"
 	"github.com/nats-io/natscli/cli"
 )
 
 var version = "development"
-
-var usageTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
-{{end}}\
-
-{{define "FormatCommands"}}\
-{{range .Commands}}\
-{{if not .Hidden}}\
-  {{.FullCommand}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
-{{.Help|Wrap 4}}
-{{end}}\
-{{end}}\
-{{end}}\
-
-{{ define "FormatCommandsForTopLevel" }}\
-{{range .Commands}}\
-{{if not .Hidden}}\
-{{if not (eq .FullCommand "help")}}\
-  {{.FullCommand}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
-{{.Help|FirstLine|Wrap 4}}
-{{end}}\
-{{end}}\
-{{end}}\
-{{end}}\
-
-{{define "FormatUsage"}}\
-{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
-{{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
-{{end}}\
-
-{{if .Context.SelectedCommand}}\
-usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
-{{else}}\
-usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{end}}\
-{{if .Context.SelectedCommand}}\
-{{if .Context.Flags}}\
-Flags:
-{{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
-Args:
-{{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if len .Context.SelectedCommand.Commands}}\
-Subcommands:
-{{template "FormatCommands" .Context.SelectedCommand}}
-{{end}}\
-{{else if .App.Commands}}\
-Commands:
-{{template "FormatCommandsForTopLevel" .App}}
-{{end}}\
-`
 
 func main() {
 	help := `NATS Utility
@@ -90,23 +31,11 @@ NATS Server and JetStream administration.
 
 See 'nats cheat' for a quick cheatsheet of commands`
 
-	ncli := kingpin.New("nats", help)
+	ncli := fisk.New("nats", help)
 	ncli.Author("NATS Authors <info@nats.io>")
 	ncli.UsageWriter(os.Stdout)
 	ncli.Version(getVersion())
 	ncli.HelpFlag.Short('h')
-	ncli.UsageTemplate(usageTemplate)
-	ncli.UsageFuncs(template.FuncMap{
-		"FirstLine": func(v string) string {
-			if v == "" {
-				return v
-			}
-
-			scanner := bufio.NewScanner(strings.NewReader(v))
-			scanner.Scan()
-			return scanner.Text()
-		},
-	})
 
 	opts, err := cli.ConfigureInApp(ncli, nil, true)
 	if err != nil {
@@ -134,7 +63,7 @@ See 'nats cheat' for a quick cheatsheet of commands`
 
 	log.SetFlags(log.Ltime)
 
-	kingpin.MustParse(ncli.Parse(os.Args[1:]))
+	fisk.MustParse(ncli.Parse(os.Args[1:]))
 }
 
 func getVersion() string {


### PR DESCRIPTION
This moves to a fork of Kingpin that has a more
friendly help template for large CLIs.

It also adopts the CLI to use new Long form help
settings to minimise the output for help from pub
reply and request to single lines when needed and
full examples when needed

Signed-off-by: R.I.Pienaar <rip@devco.net>