### PR TITLE
Check for empty Leader

### DIFF
--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -227,6 +227,10 @@ func (c *consumerCmd) leaderStandDown(_ *fisk.ParseContext) error {
 	}
 
 	leader := info.Cluster.Leader
+	if leader == "" {
+		return fmt.Errorf("consumer has no current leader")
+	}
+
 	log.Printf("Requesting leader step down of %q in a %d peer RAFT group", leader, len(info.Cluster.Replicas)+1)
 	err = consumer.LeaderStepDown()
 	if err != nil {

--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -411,6 +411,10 @@ func (c *streamCmd) leaderStandDown(_ *fisk.ParseContext) error {
 	}
 
 	leader := info.Cluster.Leader
+	if leader == "" {
+		return fmt.Errorf("stream has no current leader")
+	}
+
 	log.Printf("Requesting leader step down of %q in a %d peer RAFT group", leader, len(info.Cluster.Replicas)+1)
 	err = stream.LeaderStepDown()
 	if err != nil {


### PR DESCRIPTION
For stream and consumer cluster step-down, check for empty leader before proceeding with step-down command.  

In a case where there is no current leader (not a happy path case albeit), the CLI message is mis-formatted under this condition, e.g. `Requesting leader step down of "" in a 4 peer RAFT group
nats: error: JetStream system temporarily unavailable (10008), try --help`  (where it's actually an R3).



