### PR TITLE
Rework nats server run

### DIFF
--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -8,7 +8,7 @@ This allows for a quick path to local development and exploration of the NATS ec
 
 ## Starting a server
 
-Executing `nats server run [name]` will start a local NATS instance ready to work against.  At start it will list it's credentials, url and configuration contextx that can be used to access it
+Executing `nats server run [name]` will start a local NATS instance ready to work against.  At start it will list it's credentials, url and configuration contexts that can be used to access it
 
 ```nohighlight
 nats server run
@@ -180,7 +180,7 @@ This time we access it on the Demo network:
 
 ```nohighlight
 $ nats --server demo.nats.io req 'myname.weather.london' ''
-london: ⛅️  +15°C 
+london: ⛅️  +15°C
 ```
 
 What happened here is that the request for the service went to `demo.nats.io`, while the actual weather service was connected to your laptop. Since our laptop is extending the `demo.nats.io` service communication was possible.
@@ -194,7 +194,7 @@ First we need a context that configures access to NGS:
 ```nohighlight
 $ nats context add ngs.leafnode \
    --creds /home/me/.nkeys/creds/synadia/MyAccount/leafnode.creds \
-   --server nats://connect.ngs.global:7422 \ 
+   --server nats://connect.ngs.global:7422 \
    --description "NGS Leafnode"
 ```
 We can now run a server using these credentials:

--- a/cli/server_run_command.go
+++ b/cli/server_run_command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"os/signal"
 	"os/user"
@@ -40,6 +41,7 @@ type SrvRunConfig struct {
 	Debug                bool
 	StoreDir             string
 	Listen               string
+	Clean                bool
 	Context              *natscontext.Context
 }
 
@@ -124,6 +126,7 @@ func configureServerRunCommand(srv *fisk.CmdClause) {
 	run.Flag("extend", "Extends a NATS network using a context").UnNegatableBoolVar(&c.config.ExtendWithContext)
 	run.Flag("jetstream", "Enables JetStream support").UnNegatableBoolVar(&c.config.JetStream)
 	run.Flag("port", "Sets the local listening port").Default("-1").StringVar(&c.config.Port)
+	run.Flag("clean", "Remove contexts after exiting").UnNegatableBoolVar(&c.config.Clean)
 	run.Flag("verbose", "Log in debug mode").UnNegatableBoolVar(&c.config.Debug)
 }
 
@@ -180,6 +183,39 @@ func (c *SrvRunCmd) prepareConfig() error {
 		c.config.Verbose = true
 	}
 
+	// we use existing contexts to re-use previously generated
+	// passwords and ports
+	if natscontext.IsKnown(c.config.Name) {
+		nctx, err := natscontext.New(c.config.Name, true)
+		if err != nil {
+			return err
+		}
+		c.config.UserPassword = nctx.Password()
+		u, err := url.Parse(nctx.ServerURL())
+		if err != nil {
+			return err
+		}
+		c.config.Port = u.Port()
+	}
+
+	svcName := fmt.Sprintf("%s_service", c.config.Name)
+	if natscontext.IsKnown(svcName) {
+		nctx, err := natscontext.New(svcName, true)
+		if err != nil {
+			return err
+		}
+		c.config.ServicePassword = nctx.Password()
+	}
+
+	sysName := fmt.Sprintf("%s_system", c.config.Name)
+	if natscontext.IsKnown(sysName) {
+		nctx, err := natscontext.New(sysName, true)
+		if err != nil {
+			return err
+		}
+		c.config.SystemPassword = nctx.Password()
+	}
+
 	if c.config.Port == "-1" {
 		p, err := c.getRandomPort()
 		if err != nil {
@@ -189,21 +225,27 @@ func (c *SrvRunCmd) prepareConfig() error {
 		c.config.Port = p
 	}
 
-	c.config.UserPassword = randomString(32, 32)
+	if c.config.UserPassword == "" {
+		c.config.UserPassword = randomString(32, 32)
+	}
 	b, err := bcrypt.GenerateFromPassword([]byte(c.config.UserPassword), 5)
 	if err != nil {
 		return err
 	}
 	c.config.UserPasswordCrypt = string(b)
 
-	c.config.SystemPassword = randomString(32, 32)
+	if c.config.SystemPassword == "" {
+		c.config.SystemPassword = randomString(32, 32)
+	}
 	b, err = bcrypt.GenerateFromPassword([]byte(c.config.SystemPassword), 5)
 	if err != nil {
 		return err
 	}
 	c.config.SystemPasswordCrypt = string(b)
 
-	c.config.ServicePassword = randomString(32, 32)
+	if c.config.ServicePassword == "" {
+		c.config.ServicePassword = randomString(32, 32)
+	}
 	b, err = bcrypt.GenerateFromPassword([]byte(c.config.ServicePassword), 5)
 	if err != nil {
 		return err
@@ -270,52 +312,47 @@ func (c *SrvRunCmd) interruptWatcher(ctx context.Context, cancel context.CancelF
 }
 
 func (c *SrvRunCmd) configureContexts(url string) (string, string, string, error) {
+	if !natscontext.IsKnown(c.config.Name) {
+		nctx, _ := natscontext.New(c.config.Name, false,
+			natscontext.WithServerURL(url),
+			natscontext.WithUser("local"),
+			natscontext.WithPassword(c.config.UserPassword),
+			natscontext.WithDescription("Local user access for NATS Development instance"),
+			natscontext.WithJSDomain(c.config.JSDomain),
+		)
+		err := nctx.Save(nctx.Name)
+		if err != nil {
+			return "", "", "", err
+		}
+	}
+
 	svcName := fmt.Sprintf("%s_service", c.config.Name)
+	if !natscontext.IsKnown(svcName) {
+		nctx, _ := natscontext.New(svcName, false,
+			natscontext.WithServerURL(url),
+			natscontext.WithUser("service"),
+			natscontext.WithPassword(c.config.ServicePassword),
+			natscontext.WithDescription("Local service access for NATS Development instance"),
+			natscontext.WithJSDomain(c.config.JSDomain),
+		)
+		err := nctx.Save(svcName)
+		if err != nil {
+			return "", "", "", err
+		}
+	}
+
 	sysName := fmt.Sprintf("%s_system", c.config.Name)
-
-	if natscontext.IsKnown(c.config.Name) {
-		return "", "", "", fmt.Errorf("context %s already exist, choose a new instance name or remove it with 'nats context rm %s'", c.config.Name, c.config.Name)
-	}
-	if natscontext.IsKnown(svcName) {
-		return "", "", "", fmt.Errorf("context %s already exist, choose a new instance name or remove it with 'nats context rm %s'", svcName, svcName)
-	}
-	if natscontext.IsKnown(sysName) {
-		return "", "", "", fmt.Errorf("context %s already exist, choose a new instance name or remove it with 'nats context rm %s'", sysName, sysName)
-	}
-
-	nctx, _ := natscontext.New(c.config.Name, false,
-		natscontext.WithServerURL(url),
-		natscontext.WithUser("local"),
-		natscontext.WithPassword(c.config.UserPassword),
-		natscontext.WithDescription("Local user access for NATS Development instance"),
-		natscontext.WithJSDomain(c.config.JSDomain),
-	)
-	err := nctx.Save(nctx.Name)
-	if err != nil {
-		return "", "", "", err
-	}
-
-	nctx, _ = natscontext.New(svcName, false,
-		natscontext.WithServerURL(url),
-		natscontext.WithUser("service"),
-		natscontext.WithPassword(c.config.ServicePassword),
-		natscontext.WithDescription("Local service access for NATS Development instance"),
-		natscontext.WithJSDomain(c.config.JSDomain),
-	)
-	err = nctx.Save(svcName)
-	if err != nil {
-		return "", "", "", err
-	}
-
-	nctx, _ = natscontext.New(sysName, false,
-		natscontext.WithServerURL(url),
-		natscontext.WithUser("system"),
-		natscontext.WithPassword(c.config.SystemPassword),
-		natscontext.WithDescription("System user access for NATS Development instance"),
-	)
-	err = nctx.Save(nctx.Name)
-	if err != nil {
-		return "", "", "", err
+	if !natscontext.IsKnown(sysName) {
+		nctx, _ := natscontext.New(sysName, false,
+			natscontext.WithServerURL(url),
+			natscontext.WithUser("system"),
+			natscontext.WithPassword(c.config.SystemPassword),
+			natscontext.WithDescription("System user access for NATS Development instance"),
+		)
+		err := nctx.Save(nctx.Name)
+		if err != nil {
+			return "", "", "", err
+		}
 	}
 
 	return c.config.Name, svcName, sysName, nil
@@ -349,9 +386,6 @@ func (c *SrvRunCmd) runAction(_ *fisk.ParseContext) error {
 	if err != nil {
 		return err
 	}
-	defer natscontext.DeleteContext(u)
-	defer natscontext.DeleteContext(s)
-	defer natscontext.DeleteContext(svc)
 
 	fmt.Printf("Starting local development NATS Server instance: %s\n", c.config.Name)
 	fmt.Println()
@@ -368,6 +402,20 @@ func (c *SrvRunCmd) runAction(_ *fisk.ParseContext) error {
 		fmt.Printf("   Extending Remote NATS: %v\n", c.config.ExtendWithContext)
 	}
 	fmt.Printf("                     URL: %s\n", srv.ClientURL())
+
+	if c.config.Clean {
+		fmt.Println("           Clean on Exit: true")
+		defer natscontext.DeleteContext(u)
+		defer natscontext.DeleteContext(s)
+		defer natscontext.DeleteContext(svc)
+	} else {
+		fmt.Println("           Clean on Exit: false")
+	}
+
+	fmt.Println()
+	fmt.Println()
+	fmt.Println("NOTE: This is not a supported way to run a production NATS Server, view documentation")
+	fmt.Println("      at https://docs.nats.io/running-a-nats-service/introduction for production use.")
 
 	fmt.Println()
 


### PR DESCRIPTION
The behavior of always cleaning contexts after each
run and creating new random passwords and ports on
each start was too difficult to use, especially given
the lack of natscontext support in any other languages.

Now when the required contexts exist the passwords and
port is read from them and reused.  Cleaning behavior
can be enabled with --clean

Signed-off-by: R.I.Pienaar <rip@devco.net>