### PR TITLE
fix: deny-delete in interactive prompts overriding deny-purge

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -2021,7 +2021,7 @@ func (c *streamCmd) prepareConfig(pc *fisk.ParseContext, requireSize bool) api.S
 	}
 
 	if !c.denyDeleteSet {
-		c.denyPurge, err = askConfirmation("Allow message deletion", true)
+		c.denyDelete, err = askConfirmation("Allow message deletion", true)
 		fisk.FatalIfError(err, "invalid input")
 	}
 


### PR DESCRIPTION
Fixes #529

This PR fixes a typo in the assignment of our interactive prompts in `nats stream add`. The "Allow message deletion" prompt was incorrectly assigning to `c.denyPurge` instead of `c.denyDelete`.
