### PR TITLE
Feature: Ignored Subjects for Sub Command

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1284,7 +1283,7 @@ func (c *streamCmd) copyAndEditStream(cfg api.StreamConfig, pc *fisk.ParseContex
 	}
 
 	if len(c.subjects) > 0 {
-		cfg.Subjects = c.splitCLISubjects()
+		cfg.Subjects = splitCLISubjects(c.subjects)
 	}
 
 	if c.storage != "" {
@@ -1808,21 +1807,6 @@ func (c *streamCmd) infoAction(_ *fisk.ParseContext) error {
 	return nil
 }
 
-func (c *streamCmd) splitCLISubjects() []string {
-	new := []string{}
-
-	re := regexp.MustCompile(`,|\t|\s`)
-	for _, s := range c.subjects {
-		if re.MatchString(s) {
-			new = append(new, splitString(s)...)
-		} else {
-			new = append(new, s)
-		}
-	}
-
-	return new
-}
-
 func (c *streamCmd) discardPolicyFromString() api.DiscardPolicy {
 	switch strings.ToLower(c.discardPolicy) {
 	case "new":
@@ -1902,7 +1886,7 @@ func (c *streamCmd) prepareConfig(pc *fisk.ParseContext, requireSize bool) api.S
 			c.subjects = splitString(subjects)
 		}
 
-		c.subjects = c.splitCLISubjects()
+		c.subjects = splitCLISubjects(c.subjects)
 	}
 
 	if c.mirror != "" && len(c.subjects) > 0 {

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -48,7 +48,7 @@ type subCmd struct {
 	headersOnly           bool
 	stream                string
 	jetStream             bool
-	excludeSubjets        []string
+	excludeSubjects       []string
 }
 
 func configureSubCommand(app commandHost) {
@@ -73,7 +73,7 @@ func configureSubCommand(app commandHost) {
 	act.Flag("since", "Delivers messages received since a duration (requires JetStream)").PlaceHolder("DURATION").StringVar(&c.deliverSince)
 	act.Flag("last-per-subject", "Deliver the most recent messages for each subject in the Stream (requires JetStream)").UnNegatableBoolVar(&c.deliverLastPerSubject)
 	act.Flag("stream", "Subscribe to a specific stream (required JetStream)").PlaceHolder("STREAM").StringVar(&c.stream)
-	act.Flag("exclude-subjects", "Subjects for which corresponding messages will be excluded and therefore not shown in the output").StringsVar(&c.excludeSubjets)
+	act.Flag("exclude-subjects", "Subjects for which corresponding messages will be excluded and therefore not shown in the output").StringsVar(&c.excludeSubjects)
 }
 
 func init() {
@@ -111,7 +111,7 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 		mu              = sync.Mutex{}
 		dump            = c.dump != ""
 		ctr             = uint(0)
-		excludeSubjects = splitCLISubjects(c.excludeSubjets)
+		excludeSubjects = splitCLISubjects(c.excludeSubjects)
 		ctx, cancel     = context.WithCancel(ctx)
 
 		replySub *nats.Subscription

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -275,7 +275,7 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 			}
 
 			start := time.Now().Add(-1 * d)
-			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with messages since %s %s", subMsg, humanizeDuration(d), ignoreSubjects)
+			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with messages since %s %s", subMsg, humanizeDuration(d), ignoredSubjInfo)
 
 			opts = append(opts, nats.StartTime(start))
 		case c.deliverLastPerSubject:

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/choria-io/fisk"
 	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 )
 
@@ -47,6 +48,7 @@ type subCmd struct {
 	headersOnly           bool
 	stream                string
 	jetStream             bool
+	excludeSubjets        string
 }
 
 func configureSubCommand(app commandHost) {
@@ -71,6 +73,7 @@ func configureSubCommand(app commandHost) {
 	act.Flag("since", "Delivers messages received since a duration (requires JetStream)").PlaceHolder("DURATION").StringVar(&c.deliverSince)
 	act.Flag("last-per-subject", "Deliver the most recent messages for each subject in the Stream (requires JetStream)").UnNegatableBoolVar(&c.deliverLastPerSubject)
 	act.Flag("stream", "Subscribe to a specific stream (required JetStream)").PlaceHolder("STREAM").StringVar(&c.stream)
+	act.Flag("exclude-subjects", "Subjects for which corresponding messages will be excluded and therefore not shown in the output").StringVar(&c.excludeSubjets)
 }
 
 func init() {
@@ -104,11 +107,12 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 	}
 
 	var (
-		sub         *nats.Subscription
-		mu          = sync.Mutex{}
-		dump        = c.dump != ""
-		ctr         = uint(0)
-		ctx, cancel = context.WithCancel(ctx)
+		sub             *nats.Subscription
+		mu              = sync.Mutex{}
+		dump            = c.dump != ""
+		ctr             = uint(0)
+		excludeSubjects = splitString(c.excludeSubjets)
+		ctx, cancel     = context.WithCancel(ctx)
 
 		replySub *nats.Subscription
 		matchMap map[string]*nats.Msg
@@ -141,6 +145,14 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 			} else if stalled := m.Header.Get("Nats-Consumer-Stalled"); stalled != "" {
 				nc.Publish(stalled, nil)
 				log.Printf("Resuming stalled consumer")
+			}
+		}
+
+		if len(excludeSubjects) > 0 {
+			for _, excludeSubj := range excludeSubjects {
+				if server.SubjectsCollide(m.Subject, excludeSubj) {
+					return
+				}
 			}
 		}
 
@@ -192,14 +204,19 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 		}
 	}
 
+	var excludedSubjInfo string
+	if len(excludeSubjects) > 0 {
+		excludedSubjInfo = fmt.Sprintf("\nExcluded subjects: %s", strings.Join(excludeSubjects, ", "))
+	}
+
 	if (!c.raw && c.dump == "") || c.inbox {
 		switch {
 		case c.jetStream:
 			// logs later depending on settings
 		case c.jsAck:
-			log.Printf("Subscribing on %s with acknowledgement of JetStream messages", c.subject)
+			log.Printf("Subscribing on %s with acknowledgement of JetStream messages %s", c.subject, excludedSubjInfo)
 		default:
-			log.Printf("Subscribing on %s", c.subject)
+			log.Printf("Subscribing on %s %s", c.subject, excludedSubjInfo)
 		}
 	}
 
@@ -239,17 +256,17 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 
 		switch {
 		case c.sseq > 0:
-			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with sequence %d", subMsg, c.sseq)
+			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with sequence %d %s", subMsg, c.sseq, excludedSubjInfo)
 			opts = append(opts, nats.StartSequence(c.sseq))
 		case c.deliverLast:
-			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with the last message received", subMsg)
+			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with the last message received %s", subMsg, excludedSubjInfo)
 			opts = append(opts, nats.DeliverLast())
 		case c.deliverAll:
-			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with the first message received", subMsg)
+			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with the first message received %s", subMsg, excludedSubjInfo)
 
 			opts = append(opts, nats.DeliverAll())
 		case c.deliverNew:
-			log.Printf("Subscribing to JetStream Stream holding messages with subject %s delivering any new messages received", subMsg)
+			log.Printf("Subscribing to JetStream Stream holding messages with subject %s delivering any new messages received %s", subMsg, excludedSubjInfo)
 
 			opts = append(opts, nats.DeliverNew())
 		case c.deliverSince != "":
@@ -260,11 +277,11 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 			}
 
 			start := time.Now().Add(-1 * d)
-			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with messages since %s", subMsg, humanizeDuration(d))
+			log.Printf("Subscribing to JetStream Stream holding messages with subject %s starting with messages since %s %s", subMsg, humanizeDuration(d), excludeSubjects)
 
 			opts = append(opts, nats.StartTime(start))
 		case c.deliverLastPerSubject:
-			log.Printf("Subscribing to JetStream Stream holding messages with subject %s for the last messages for each subject in the Stream", subMsg)
+			log.Printf("Subscribing to JetStream Stream holding messages with subject %s for the last messages for each subject in the Stream %s", subMsg, excludedSubjInfo)
 			opts = append(opts, nats.DeliverLastPerSubject())
 		}
 

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -48,7 +48,7 @@ type subCmd struct {
 	headersOnly           bool
 	stream                string
 	jetStream             bool
-	excludeSubjets        string
+	excludeSubjets        []string
 }
 
 func configureSubCommand(app commandHost) {
@@ -73,7 +73,7 @@ func configureSubCommand(app commandHost) {
 	act.Flag("since", "Delivers messages received since a duration (requires JetStream)").PlaceHolder("DURATION").StringVar(&c.deliverSince)
 	act.Flag("last-per-subject", "Deliver the most recent messages for each subject in the Stream (requires JetStream)").UnNegatableBoolVar(&c.deliverLastPerSubject)
 	act.Flag("stream", "Subscribe to a specific stream (required JetStream)").PlaceHolder("STREAM").StringVar(&c.stream)
-	act.Flag("exclude-subjects", "Subjects for which corresponding messages will be excluded and therefore not shown in the output").StringVar(&c.excludeSubjets)
+	act.Flag("exclude-subjects", "Subjects for which corresponding messages will be excluded and therefore not shown in the output").StringsVar(&c.excludeSubjets)
 }
 
 func init() {
@@ -111,7 +111,7 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 		mu              = sync.Mutex{}
 		dump            = c.dump != ""
 		ctr             = uint(0)
-		excludeSubjects = splitString(c.excludeSubjets)
+		excludeSubjects = splitCLISubjects(c.excludeSubjets)
 		ctx, cancel     = context.WithCancel(ctx)
 
 		replySub *nats.Subscription

--- a/cli/util.go
+++ b/cli/util.go
@@ -341,6 +341,21 @@ func splitString(s string) []string {
 	})
 }
 
+func splitCLISubjects(subjects []string) []string {
+	new := []string{}
+
+	re := regexp.MustCompile(`,|\t|\s`)
+	for _, s := range subjects {
+		if re.MatchString(s) {
+			new = append(new, splitString(s)...)
+		} else {
+			new = append(new, s)
+		}
+	}
+
+	return new
+}
+
 func natsOpts() []nats.Option {
 	if opts.Config == nil {
 		return []nats.Option{}


### PR DESCRIPTION
## Context 
Wiretapping is a popular pattern also in the phase of developing/debugging an application. In that case, we create NATS  subscription to include all subjects and can preview which messages are published on NATS by various application producers.

## Problem
Sometimes there are too noisy subjects (e.g. pings, heartbeats, alive messages) that frequently produce NATS messages and prevent us from seeing core/useful communication when we have a wiretap subscription.

## Solution 
Provide the way to use wiretap subscription and ignore 'noisy' subjects. So we want to be subscribed to all subjects, but we also want to exclude a few of them just to remove noisy traffic.

### Requirements
Expand `sub` command with `--ignore-subject` flag. Within the flag it is possible to specify:
- One or many subjects
- Subject literal, single or multiple wildcards

### Example
Create `natscli` wiretap subscription with `--ignore-subject` flag:
```
nats sub 'appx.>' --ignore-subject 'appx.beat, appx.alive.*, appx.ping.>'
```
Publish messages which will be caught with the subscription, but some of them will be excluded from the output:
```
nats pub appx.hey.you msg 
nats pub appx.beat msg # will be excluded
nats pub appx.alive.123 msg # will be excluded
nats pub appx.ping.client.123 msg # will be excluded
```

Output:
```
Subscribing on appx.>
Ignored subjects: appx.beat, appx.alive.*, appx.ping.>

[#1] Received on "appx.hey.you"
msg
```