### PR TITLE
Filter out non-JS enabled servers

### DIFF
--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -127,6 +127,11 @@ func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 			return err
 		}
 
+		// Ignore non JetStream-enabled servers.
+		if !response.Server.JetStream {
+			continue
+		}
+
 		// we may have a pre 2.7.0 machine and will try get data with old struct names, if all of these are
 		// 0 it might be that they are 0 or that we had data in the old format, so we try parse the old
 		// and set what is in there.  If it's not an old server 0s will stay 0s, otherwise we pull in old format values


### PR DESCRIPTION
The report for JetStream summary includes non-JS enabled servers. It is unclear if it should be filtered here or the upstream source of `$SYS.REQ.SERVER.PING.JSZ`, however this appears to be serviced by each server and the CLI is aggregating these responses, correct?