### PR TITLE
Add back filter subject to nats sub when --stream is specified

### DIFF
--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -288,11 +288,7 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 		}
 
 		c.jsAck = false
-		if c.stream != "" {
-			sub, err = js.Subscribe("", handler, opts...)
-		} else {
-			sub, err = js.Subscribe(c.subject, handler, opts...)
-		}
+		sub, err = js.Subscribe(c.subject, handler, opts...)
 
 	case c.queue != "":
 		sub, err = nc.QueueSubscribe(c.subject, c.queue, handler)


### PR DESCRIPTION
This PR adds subject filtering back to the `nats sub` command when
`--stream` is specified. Currently whenever `--stream` is specified we
pass "" as the subject, which I don't think was intended functionality,
as it doesn't filter the stream consumer by the subject and also breaks
things like `--last-per-subject`.

Looking at f379dd226d6034dc951994a683465faa74e59ce0 it wasn't clear to
me why we would pass "" as the subject to support this use case.
@ripienaar feel free to add flavor if this fix does in fact break
introduced in that commit.
