### PR TITLE
[FIXED] Discard Policy was incorrectly displayed.

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -1611,7 +1611,7 @@ func (c *streamCmd) showStreamConfig(cfg api.StreamConfig) {
 	if cfg.DiscardNewPer {
 		dnp = "New Per Subject"
 	}
-	fmt.Printf("       Discard Policy: %s%s\n", cfg.Discard.String(), dnp)
+	fmt.Printf("       Discard Policy: %s\n", dnp)
 	fmt.Printf("     Duplicate Window: %v\n", cfg.Duplicates)
 	if cfg.AllowDirect {
 		fmt.Printf("    Allows Direct Get: %v\n", cfg.AllowDirect)


### PR DESCRIPTION
For instance, a discard "new" policy was displayed as:
```
Discard Policy: NewNew
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>