### PR TITLE
When changing stream leadership wait 5 seconds

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -504,7 +504,7 @@ func (c *streamCmd) leaderStandDown(_ *fisk.ParseContext) error {
 
 	ctr := 0
 	start := time.Now()
-	for range time.NewTicker(1 * time.Millisecond).C {
+	for range time.NewTicker(500 * time.Millisecond).C {
 		if ctr == 10 {
 			return fmt.Errorf("stream did not elect a new leader in time")
 		}


### PR DESCRIPTION
It was incorrectly set to wait 10 milliseconds.

Signed-off-by: R.I.Pienaar <rip@devco.net>