### PR TITLE
Display cluster size in "nats server report jetstream"

### DIFF
--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -267,6 +267,13 @@ func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 			cNames = names
 		}
 
+		metaClusterTable := newTableWriter("RAFT Meta Cluster Information")
+		metaClusterTable.AddHeaders("Name", "Leader", "Peer", "Size")
+		metaClusterTable.AddRow(cluster.Name, cluster.Leader, cluster.Peer, cluster.Size)
+
+		fmt.Print(metaClusterTable.Render())
+		fmt.Println()
+
 		table := newTableWriter("RAFT Meta Group Information")
 		table.AddHeaders("Name", "ID", "Leader", "Current", "Online", "Active", "Lag")
 		for i, replica := range cluster.Replicas {


### PR DESCRIPTION
Add a new table "RAFT Meta Cluster Information" to display this.

Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>

Inspired by discussion here:
https://natsio.slack.com/archives/CM3T6T7JQ/p1671467758952119?thread_ts=1671465211.070579&cid=CM3T6T7JQ