### PR TITLE
Make `Acknowledgment` spelling consistent

### DIFF
--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -658,9 +658,9 @@ func (c *consumerCmd) showInfo(config api.ConsumerConfig, state api.ConsumerInfo
 
 	if config.AckPolicy != api.AckNone {
 		if state.AckFloor.Last == nil {
-			fmt.Printf("     Acknowledgment floor: Consumer sequence: %s Stream sequence: %s\n", humanize.Comma(int64(state.AckFloor.Consumer)), humanize.Comma(int64(state.AckFloor.Stream)))
+			fmt.Printf("     Acknowledgement floor: Consumer sequence: %s Stream sequence: %s\n", humanize.Comma(int64(state.AckFloor.Consumer)), humanize.Comma(int64(state.AckFloor.Stream)))
 		} else {
-			fmt.Printf("     Acknowledgment floor: Consumer sequence: %s Stream sequence: %s Last Ack: %s ago\n", humanize.Comma(int64(state.AckFloor.Consumer)), humanize.Comma(int64(state.AckFloor.Stream)), humanizeDuration(time.Since(*state.AckFloor.Last)))
+			fmt.Printf("     Acknowledgement floor: Consumer sequence: %s Stream sequence: %s Last Ack: %s ago\n", humanize.Comma(int64(state.AckFloor.Consumer)), humanize.Comma(int64(state.AckFloor.Stream)), humanizeDuration(time.Since(*state.AckFloor.Last)))
 		}
 		if config.MaxAckPending > 0 {
 			fmt.Printf("         Outstanding Acks: %s out of maximum %s\n", humanize.Comma(int64(state.NumAckPending)), humanize.Comma(int64(config.MaxAckPending)))

--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -97,7 +97,7 @@ func configureConsumerCommand(app commandHost) {
 
 	addCreateFlags := func(f *fisk.CmdClause, edit bool) {
 		if !edit {
-			f.Flag("ack", "Acknowledgement policy (none, all, explicit)").StringVar(&c.ackPolicy)
+			f.Flag("ack", "Acknowledgment policy (none, all, explicit)").StringVar(&c.ackPolicy)
 			f.Flag("bps", "Restrict message delivery to a certain bit per second").Default("0").Uint64Var(&c.bpsRateLimit)
 		}
 		f.Flag("backoff", "Creates a consumer backoff policy using a specific pre-written algorithm (none, linear)").PlaceHolder("MODE").EnumVar(&c.backoffMode, "linear", "none")
@@ -132,7 +132,7 @@ func configureConsumerCommand(app commandHost) {
 		}
 		f.Flag("sample", "Percentage of requests to sample for monitoring purposes").Default("-1").IntVar(&c.samplePct)
 		f.Flag("target", "Push based delivery target subject").PlaceHolder("SUBJECT").StringVar(&c.delivery)
-		f.Flag("wait", "Acknowledgement waiting time").Default("-1s").DurationVar(&c.ackWait)
+		f.Flag("wait", "Acknowledgment waiting time").Default("-1s").DurationVar(&c.ackWait)
 		if !edit {
 			f.Flag("inactive-threshold", "How long to allow an ephemeral consumer to be idle before removing it").PlaceHolder("THRESHOLD").DurationVar(&c.inactiveThreshold)
 			f.Flag("memory", "Force the consumer state to be stored in memory rather than inherit from the stream").UnNegatableBoolVar(&c.memory)
@@ -658,9 +658,9 @@ func (c *consumerCmd) showInfo(config api.ConsumerConfig, state api.ConsumerInfo
 
 	if config.AckPolicy != api.AckNone {
 		if state.AckFloor.Last == nil {
-			fmt.Printf("     Acknowledgement floor: Consumer sequence: %s Stream sequence: %s\n", humanize.Comma(int64(state.AckFloor.Consumer)), humanize.Comma(int64(state.AckFloor.Stream)))
+			fmt.Printf("     Acknowledgment floor: Consumer sequence: %s Stream sequence: %s\n", humanize.Comma(int64(state.AckFloor.Consumer)), humanize.Comma(int64(state.AckFloor.Stream)))
 		} else {
-			fmt.Printf("     Acknowledgement floor: Consumer sequence: %s Stream sequence: %s Last Ack: %s ago\n", humanize.Comma(int64(state.AckFloor.Consumer)), humanize.Comma(int64(state.AckFloor.Stream)), humanizeDuration(time.Since(*state.AckFloor.Last)))
+			fmt.Printf("     Acknowledgment floor: Consumer sequence: %s Stream sequence: %s Last Ack: %s ago\n", humanize.Comma(int64(state.AckFloor.Consumer)), humanize.Comma(int64(state.AckFloor.Stream)), humanizeDuration(time.Since(*state.AckFloor.Last)))
 		}
 		if config.MaxAckPending > 0 {
 			fmt.Printf("         Outstanding Acks: %s out of maximum %s\n", humanize.Comma(int64(state.NumAckPending)), humanize.Comma(int64(config.MaxAckPending)))
@@ -1029,7 +1029,7 @@ func (c *consumerCmd) prepareConfig(pc *fisk.ParseContext) (cfg *api.ConsumerCon
 		}
 
 		err = askOne(&survey.Select{
-			Message: "Acknowledgement policy",
+			Message: "Acknowledgment policy",
 			Options: valid,
 			Default: dflt,
 			Help:    "Messages that are not acknowledged will be redelivered at a later time. 'none' means no acknowledgement is needed only 1 delivery ever, 'all' means acknowledging message 10 will also acknowledge 0-9 and 'explicit' means each has to be acknowledged specifically. Settable using --ack",
@@ -1110,7 +1110,7 @@ func (c *consumerCmd) prepareConfig(pc *fisk.ParseContext) (cfg *api.ConsumerCon
 
 	if c.maxAckPending == -1 && cfg.AckPolicy != api.AckNone {
 		err = askOne(&survey.Input{
-			Message: "Maximum Acknowledgements Pending",
+			Message: "Maximum Acknowledgments Pending",
 			Default: "0",
 			Help:    "The maximum number of messages without acknowledgement that can be outstanding, once this limit is reached message delivery will be suspended. Settable using --max-pending.",
 		}, &c.maxAckPending)

--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -1500,7 +1500,7 @@ func (c *streamCmd) showStreamConfig(cfg api.StreamConfig) {
 	fmt.Println()
 
 	fmt.Printf("            Retention: %s\n", cfg.Retention.String())
-	fmt.Printf("     Acknowledgements: %v\n", !cfg.NoAck)
+	fmt.Printf("     Acknowledgments: %v\n", !cfg.NoAck)
 	dnp := cfg.Discard.String()
 	if cfg.DiscardNewPer {
 		dnp = "New Per Subject"


### PR DESCRIPTION
Found a typo in the Consumer state. `Acknowledgment` -> `Acknowledgement`.