### PR TITLE
OCSP status: fix missing newlines

### DIFF
--- a/cli/account_tls_command.go
+++ b/cli/account_tls_command.go
@@ -148,13 +148,13 @@ func (c *ActTLSCmd) showOneOCSP(chain []*x509.Certificate, chain_number int, cs 
 
 	switch liveStaple.Status {
 	case ocsp.Good:
-		fmt.Printf("\n# OCSP: GOOD status=%v sn=%v producedAt=(%s) thisUpdate=(%s) nextUpdate=(%s)",
+		fmt.Printf("\n# OCSP: GOOD status=%v sn=%v producedAt=(%s) thisUpdate=(%s) nextUpdate=(%s)\n",
 			liveStaple.Status, liveStaple.SerialNumber,
 			liveStaple.ProducedAt, liveStaple.ThisUpdate, liveStaple.NextUpdate)
 	case ocsp.Revoked:
-		fmt.Printf("\n# OCSP: REVOKED status=%v RevokedAt=(%s)", liveStaple.Status, liveStaple.RevokedAt)
+		fmt.Printf("\n# OCSP: REVOKED status=%v RevokedAt=(%s)\n", liveStaple.Status, liveStaple.RevokedAt)
 	default:
-		fmt.Printf("\n# OCSP: BAD status=%v sn=%v", liveStaple.Status, liveStaple.SerialNumber)
+		fmt.Printf("\n# OCSP: BAD status=%v sn=%v\n", liveStaple.Status, liveStaple.SerialNumber)
 	}
 
 	// should we return an error for OCSP bad/revoked status?


### PR DESCRIPTION
My fault; my code I cribbed from was doing end-of-message newlines
automatically, and I missed the \n when switching to `fmt.Printf()`.  I just
today got an OCSP setup "working" at home, to see the message:

    # OCSP: GOOD status=0 sn=295101430811608931834342633074769021965446 producedAt=(2023-01-09 22:46:00 +0000 UTC) thisUpdate=(2023-01-09 22:00:00 +0000 UTC) nextUpdate=(2023-01-16 21:59:58 +0000 UTC)
