### PR TITLE
Rollback context if edit invalid

### DIFF
--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -174,7 +174,15 @@ func (c *ctxCommand) editCommand(pc *fisk.ParseContext) error {
 		return err
 	}
 
-	return c.showCommand(pc)
+	// There was an error with some data in the modified config
+	// Save the known clean version and show the error
+	err = c.showCommand(pc)
+	if err != nil {
+		ctx.Save(c.name)
+		return err
+	}
+
+	return nil
 }
 
 func (c *ctxCommand) renderListCompletion(current string, known []*natscontext.Context) {

--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -179,7 +179,7 @@ func (c *ctxCommand) editCommand(pc *fisk.ParseContext) error {
 	err = c.showCommand(pc)
 	if err != nil {
 		ctx.Save(c.name)
-		return err
+		return fmt.Errorf("updated context validation failed - rolling back changes\n%w", err)
 	}
 
 	return nil

--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -179,7 +179,7 @@ func (c *ctxCommand) editCommand(pc *fisk.ParseContext) error {
 	err = c.showCommand(pc)
 	if err != nil {
 		ctx.Save(c.name)
-		return fmt.Errorf("updated context validation failed - rolling back changes\n%w", err)
+		return fmt.Errorf("updated context validation failed - rolling back changes: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Since the `cli` launches an external editor validation of the updated context cannot be done until after it has already been saved to disk. The result is when you enter bad data (e.g. invalid `nsc` path) it will get persisted before the cli notifies you of the error. If you then try to run the edit command again it will fail due to validation checks failing when attempting to load the now bad context. The only solution is to manually edit the context `.json` file on disk.

This PR will check for errors when loading the context after the editor command has returned. If the context fails to validate it will attempt to save the known clean context so that the `nats edit context` command will run in the future. It then returns the error to let the user know what part of the updated context failed validation.

This is not a perfect solution: if you have made multiple changes to the context config they all get reverted instead of just the invalid ones. However, this will at least solve the frustrating situation of making a mistake in the context edit and then getting "locked out" of editing it again.