### PR TITLE
Supports --json for jetstream report

### DIFF
--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -172,6 +172,11 @@ func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 		cNames = names
 	}
 
+	if c.json {
+		printJSON(jszResponses)
+		return nil
+	}
+
 	var table *tbl
 	if c.account != "" {
 		table = newTableWriter(fmt.Sprintf("JetStream Summary for Account %s", c.account))


### PR DESCRIPTION
Quick fix for #715: renders as json the output of the command `server report --json jetstream`