### PR TITLE
Allow to ignore prompt for stream info

### DIFF
--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -163,6 +163,7 @@ func configureConsumerCommand(app commandHost) {
 	consInfo.Arg("stream", "Stream name").StringVar(&c.stream)
 	consInfo.Arg("consumer", "Consumer name").StringVar(&c.consumer)
 	consInfo.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
+	consInfo.Flag("force", "Force info without prompting").Short('f').UnNegatableBoolVar(&c.force)
 
 	consAdd := cons.Command("add", "Creates a new Consumer").Alias("create").Alias("new").Action(c.createAction)
 	consAdd.Arg("stream", "Stream name").StringVar(&c.stream)

--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -250,6 +250,7 @@ func configureStreamCommand(app commandHost) {
 	strInfo.Arg("stream", "Stream to retrieve information for").StringVar(&c.stream)
 	strInfo.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
 	strInfo.Flag("state", "Shows only the stream state").UnNegatableBoolVar(&c.showStateOnly)
+	strInfo.Flag("force", "Force info without prompting").Short('f').UnNegatableBoolVar(&c.force)
 
 	strState := str.Command("state", "Stream state").Action(c.stateAction)
 	strState.Arg("stream", "Stream to retrieve state information for").StringVar(&c.stream)


### PR DESCRIPTION
If the stream that we want retrieve information doesn't exist, we prompt with a list of multiple stream. 
Adding the force command that is already implemented but the c.force never be populated.

```go
	if force {
		return "", nil, fmt.Errorf("unknown stream %q", stream)
	}
```