### PR TITLE
Adding the possibility to translate the msg.Data before output.

### DIFF
--- a/cli/filter_data_through_cmd.go
+++ b/cli/filter_data_through_cmd.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/google/shlex"
+	"os/exec"
+	"strings"
+	"text/template"
+)
+
+func outPutMSGBody(data []byte, filter, subject, stream string) {
+	if len(data) == 0 {
+		fmt.Println("nil body")
+		return
+	}
+
+	data, err := filterDataThroughCmd(data, filter, subject, stream)
+	if err != nil {
+		// using q here so raw binary data will be escaped
+		fmt.Printf("%q\nError while translating msg body: %s\n\n", data, err.Error())
+		return
+	}
+	output := string(data)
+	fmt.Println(output)
+	if !strings.HasSuffix(output, "\n") {
+		fmt.Println()
+	}
+}
+
+func filterDataThroughCmd(data []byte, filter, subject, stream string) ([]byte, error) {
+	if filter == "" {
+		return data, nil
+	}
+	funcMap := template.FuncMap{
+		"Subject": func() string { return subject },
+		"Stream":  func() string { return stream },
+	}
+
+	tmpl, err := template.New("translate").Funcs(funcMap).Parse(filter)
+	if err != nil {
+		return nil, err
+	}
+	var builder strings.Builder
+	err = tmpl.Execute(&builder, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	parts, err := shlex.Split(builder.String())
+	if err != nil {
+		return nil, fmt.Errorf("the filter command line could not be parsed: %w", err)
+	}
+	cmd := parts[0]
+	args := parts[1:]
+
+	runner := exec.Command(cmd, args...)
+	// pass the message as string to stdin
+	runner.Stdin = bytes.NewReader(data)
+	// maybe we want to do something on error?
+	return runner.CombinedOutput()
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -26,6 +26,7 @@ This file lists the dependencies used in this repository.
 | github.com/nats-io/nats.go | Apache License 2.0 |
 | github.com/nats-io/nkeys | Apache License 2.0 |
 | github.com/nats-io/nuid | Apache License 2.0 |
+| github.com/google/shlex | Apache License 2.0 |
 | github.com/tylertreat/hdrhistogram-writer | Apache License 2.0 |
 | github.com/xeipuuv/gojsonpointer | Apache License 2.0 |
 | github.com/xeipuuv/gojsonreference | Apache License 2.0 |

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.9
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gosuri/uiprogress v0.0.1
 	github.com/guptarohit/asciigraph v0.5.5
 	github.com/jedib0t/go-pretty/v6 v6.4.6
@@ -33,8 +34,8 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDe
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
-github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/choria-io/fisk v0.4.0 h1:V+mh3OpcmE0uBcihUA18dRJeL1J8YUCCLbZZQRa7GMY=
 github.com/choria-io/fisk v0.4.0/go.mod h1:3Rc9XxqKC4y9wBf2GfQ4ovJ1VKELAWcU0J33M/Zgjvs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -34,12 +34,14 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGw
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
 github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
 github.com/gosuri/uiprogress v0.0.1 h1:0kpv/XY/qTmFWl/SkaJykZXrBBzwwadmW8fRb7RJSxw=


### PR DESCRIPTION
We have decided to use the nats-cli tool to assist in debugging and monitoring NATS stream messages stored in cbor format. However, we would prefer the messages displayed in an easier-to-read formatting. The same goes for JSON, which we would like to have a better readable representation too.

In response to my inquiry #636 about adding an encoder/decoder, @ripienaar suggested that this could be achieved by passing the output through a CLI utility that performs the translation. This would allow users to add their own translators or formatters as needed.

I have created a proof of concept implementation for this approach, and I hope that it will be incorporated into the tool in the future.

I added a template for `{{subject}}` which can be used to let the translator know about the subject, so one could write it in a way that it uses internal knowledge to assist in decoding the data without the need to add information to the messages. There could also be a template for header fields or maybe also other information (the stream name, for example). I didn't want to add much more until the general idea gets the green light.