### PR TITLE
Issues with following Match requests and replies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ hello headers
 ### match requests and replies
 We can print matching replay-requests together
 ```
-sub --match-replies subject.name
+nats sub --match-replies cli.demo
 ```
 Output
 ```


### PR DESCRIPTION
I updated line 194 so that it can be copied to the terminal.

for the output of the first command line - nats sub --match-replies cli.demo, I am getting the below, so not the same as stated.  And I am having trouble following the rest of this section. (base) marthapena@Marthas-MacBook-Pro ~ % nats sub --match-replies cli.demo 10:15:57 Matching replies with inbox prefix _INBOX.> 10:15:57 Subscribing on cli.demo