### PR TITLE
Propagate timeout from the CLI flags to the JetStream client

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -415,6 +415,7 @@ func prepareJSHelper() (*nats.Conn, nats.JetStreamContext, error) {
 	jso := []nats.JSOpt{
 		nats.Domain(opts.JsDomain),
 		nats.APIPrefix(opts.JsApiPrefix),
+		nats.MaxWait(opts.Timeout),
 	}
 
 	if opts.Trace {


### PR DESCRIPTION
## Description
Propagate the timeout command line flag to wait time value of JetStream client.

## Motivation and Context
We need this change in order to be able to perform the delete from ObjectStore because now this wait time is set by default to 5s and we are not able to modify it from the command line.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

