### PR TITLE
add revision to kv get trace output

### DIFF
--- a/cli/kv_command.go
+++ b/cli/kv_command.go
@@ -492,7 +492,7 @@ func (c *kvCommand) getAction(_ *fisk.ParseContext) error {
 		return nil
 	}
 
-	fmt.Printf("%s > %s created @ %s\n", res.Bucket(), res.Key(), res.Created().Format(time.RFC822))
+	fmt.Printf("%s > %s revision: %d created @ %s\n", res.Bucket(), res.Key(), res.Revision(), res.Created().Format(time.RFC822))
 	fmt.Println()
 	pv := base64IfNotPrintable(res.Value())
 	lpv := len(pv)


### PR DESCRIPTION
This PR adds the sequence number of a message to the output of `nats kv get <bucket> <key> --trace`

The timestamp of the message was already present but I missed the sequence number. 
I'm aware that the history command shows this information but for me this is the right place as well for this information.