### PR TITLE
Add a connection flush before interrupting

### DIFF
--- a/cli/reply_command.go
+++ b/cli/reply_command.go
@@ -197,6 +197,7 @@ func (c *replyCmd) reply(_ *fisk.ParseContext) error {
 		i++
 
 		if c.limit != 0 && uint(i) == c.limit {
+			nc.Flush()
 			ic <- os.Interrupt
 		}
 	})


### PR DESCRIPTION
I noticed that sometimes the nats CLI process would exit before the reply command response was sent; this resolves that issue.