### PR TITLE
improve reverse sorting UX

### DIFF
--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -56,7 +56,7 @@ func configureServerReportCommand(srv *fisk.CmdClause) {
 	c := &SrvReportCmd{}
 
 	report := srv.Command("report", "Report on various server metrics").Alias("rep")
-	report.Flag("reverse", "Reverse sort connections").Short('R').Default("true").BoolVar(&c.reverse)
+	report.Flag("reverse", "Reverse sort connections").Short('R').UnNegatableBoolVar(&c.reverse)
 
 	addFilterOpts := func(cmd *fisk.CmdClause) {
 		cmd.Flag("host", "Limit the report to a specific NATS server").StringVar(&c.server)
@@ -480,7 +480,7 @@ func (c *SrvReportCmd) reportConnections(_ *fisk.ParseContext) error {
 }
 
 func (c *SrvReportCmd) boolReverse(v bool) bool {
-	if !c.reverse {
+	if c.reverse {
 		return !v
 	}
 


### PR DESCRIPTION
Today reverse sort in report conns is default, this means passing -R is a noop and people need to figure out to pass --no-reverse.

It is less confusing if we make it so -R does the right thing and make that bool unnegatable