### PR TITLE
fixed typo in confirmation question

### DIFF
--- a/cli/kv_command.go
+++ b/cli/kv_command.go
@@ -696,7 +696,7 @@ func (c *kvCommand) purgeAction(_ *fisk.ParseContext) error {
 
 func (c *kvCommand) rmBucketAction(_ *fisk.ParseContext) error {
 	if !c.force {
-		ok, err := askConfirmation(fmt.Sprintf("Deleted bucket %s?", c.bucket), false)
+		ok, err := askConfirmation(fmt.Sprintf("Delete bucket %s?", c.bucket), false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixed typo in confirmation question for ```nats kv del bucketname```: Delete~~d~~ bucket bucketname?