### PR TITLE
Remove check for repub source

### DIFF
--- a/cli/kv_command.go
+++ b/cli/kv_command.go
@@ -448,7 +448,7 @@ func (c *kvCommand) addAction(_ *fisk.ParseContext) error {
 		Placement:    placement,
 	}
 
-	if c.repubSource != "" && c.repubDest != "" {
+	if c.repubDest != "" {
 		cfg.RePublish = &nats.RePublish{
 			Source:      c.repubSource,
 			Destination: c.repubDest,


### PR DESCRIPTION
The server defaults to `>`, so only the dest is required.