### PR TITLE
server report js: add an "Err %" column

### DIFF
--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -268,6 +268,11 @@ func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 		if renderDomain {
 			row = append(row, js.Data.Config.Domain)
 		}
+		errCol := f(jss.API.Errors)
+		if jss.API.Total > 0 && jss.API.Errors > 0 {
+			errRate := float64(jss.API.Errors) * 100 / float64(jss.API.Total)
+			errCol += " / " + f(errRate) + "%"
+		}
 		row = append(row,
 			f(rStreams),
 			f(rConsumers),
@@ -276,7 +281,8 @@ func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 			humanize.IBytes(jss.Memory),
 			humanize.IBytes(jss.Store),
 			f(jss.API.Total),
-			f(jss.API.Errors))
+			errCol,
+		)
 
 		table.AddRow(row...)
 	}


### PR DESCRIPTION
When one server is much busier, the "API Err" cell might look uncommonly high,
but the actual error rate is not higher.  Having an "Err %" column should make
that much clearer.