### PR TITLE
Remove the default command for "nats server check"

### DIFF
--- a/cli/server_check_command.go
+++ b/cli/server_check_command.go
@@ -101,7 +101,7 @@ func configureServerCheckCommand(srv *fisk.CmdClause) {
 	check.Flag("outfile", "Save output to a file rather than STDOUT").StringVar(&checkRenderOutFile)
 	check.PreAction(c.parseRenderFormat)
 
-	conn := check.Command("connection", "Checks basic server connection").Alias("conn").Default().Action(c.checkConnection)
+	conn := check.Command("connection", "Checks basic server connection").Alias("conn").Action(c.checkConnection)
 	conn.Flag("connect-warn", "Warning threshold to allow for establishing connections").Default("500ms").PlaceHolder("DURATION").DurationVar(&c.connectWarning)
 	conn.Flag("connect-critical", "Critical threshold to allow for establishing connections").Default("1s").PlaceHolder("DURATION").DurationVar(&c.connectCritical)
 	conn.Flag("rtt-warn", "Warning threshold to allow for server RTT").Default("500ms").PlaceHolder("DURATION").DurationVar(&c.rttWarning)

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/klauspost/compress v1.17.0
 	github.com/mattn/go-isatty v0.0.19
 	github.com/nats-io/jsm.go v0.0.36-0.20230919084053-863baf78b0ab
-	github.com/nats-io/nats-server/v2 v2.9.23-0.20230918205325-3dc06278119c
+	github.com/nats-io/nats-server/v2 v2.10.0
 	github.com/nats-io/nats.go v1.29.0
 	github.com/nats-io/nuid v1.0.1
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/nats-io/jsm.go v0.0.36-0.20230919084053-863baf78b0ab h1:imrBeI/4qGGWw
 github.com/nats-io/jsm.go v0.0.36-0.20230919084053-863baf78b0ab/go.mod h1:/lp3tYWC8DYa7XLxRICA57igfAYquPXEcZvCQ5L3zSk=
 github.com/nats-io/jwt/v2 v2.5.2 h1:DhGH+nKt+wIkDxM6qnVSKjokq5t59AZV5HRcFW0zJwU=
 github.com/nats-io/jwt/v2 v2.5.2/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
-github.com/nats-io/nats-server/v2 v2.9.23-0.20230918205325-3dc06278119c h1:yHb64vNSinDkZbBQRpoKR4cfTuAR57uJ9qW93oQCdbM=
-github.com/nats-io/nats-server/v2 v2.9.23-0.20230918205325-3dc06278119c/go.mod h1:3PMvMSu2cuK0J9YInRLWdFpFsswKKGUS77zVSAudRto=
+github.com/nats-io/nats-server/v2 v2.10.0 h1:rcU++Hzo+wARxtJugrV3J5z5iGdHeVG8tT8Chb3bKDg=
+github.com/nats-io/nats-server/v2 v2.10.0/go.mod h1:3PMvMSu2cuK0J9YInRLWdFpFsswKKGUS77zVSAudRto=
 github.com/nats-io/nats.go v1.29.1-0.20230919140757-2f5f7e0b1abc h1:j0nS76m51dEB5OZum7eSDtXzgxv0HSKpLYx08miZmvs=
 github.com/nats-io/nats.go v1.29.1-0.20230919140757-2f5f7e0b1abc/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
 github.com/nats-io/nkeys v0.4.5 h1:Zdz2BUlFm4fJlierwvGK+yl20IAKUm7eV6AAZXEhkPk=


### PR DESCRIPTION
We had this for backward compatability but it ended up making discoverability of new features impossible.

This introduce a breaking change, but, significantly improves UX