### PR TITLE
Bug: Fix RTT report when multiple servers are included

### DIFF
--- a/cli/rtt_command.go
+++ b/cli/rtt_command.go
@@ -120,7 +120,7 @@ func (c *rttCmd) performTest(targets []*rttTarget) (err error) {
 
 		for _, r := range target.Results {
 			r.Time = time.Now()
-			r.URL, r.RTT, err = c.calcRTT(target.URL, opts)
+			r.URL, r.RTT, err = c.calcRTT(r.Address, opts)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
When executing RTT command for NATS cluster setup, RTT is probably not reported correctly for all servers within the cluster.

E.g. after the following command is executed:
```
n rtt -s tls://connect.ngs.global
tls://connect.ngs.global:

    tls://34.159.142.0:4222: 15.005017ms
   tls://34.89.235.191:4222: 13.955248ms
    tls://34.107.15.96:4222: 14.124726ms
```
each RTT reported above was measured for `tls://connect.ngs.global` host (which can be resolved to any IP above) and not for each specific IP listed above. So the report is misleading: it is correct for at least one IP, but probably not for all 3 of them.

This PR fixes that issue.