### PR TITLE
Feature: RTT command verbose mode

### DIFF
--- a/cli/rtt_command.go
+++ b/cli/rtt_command.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/choria-io/fisk"
 	"github.com/nats-io/nats.go"
-	"github.com/nats-io/natscli/columns"
 )
 
 type rttCmd struct {
@@ -155,7 +154,7 @@ func (c *rttCmd) calcRTT(server string, copts []nats.Option) (string, time.Durat
 
 		totalTime += rtt
 		if opts.Trace {
-			fmt.Printf("#%d:\trtt=%s\n", i, columns.HumanizeDuration(rtt))
+			fmt.Printf("#%d:\trtt=%s\n", i, rtt)
 			if i == c.iterations {
 				fmt.Println()
 			}

--- a/cli/rtt_command.go
+++ b/cli/rtt_command.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/choria-io/fisk"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/natscli/columns"
 )
 
 type rttCmd struct {
@@ -154,7 +155,7 @@ func (c *rttCmd) calcRTT(server string, copts []nats.Option) (string, time.Durat
 
 		totalTime += rtt
 		if opts.Trace {
-			fmt.Printf("#%d:\trtt=%s\n", i, rtt)
+			fmt.Printf("#%d:\trtt=%s\n", i, columns.HumanizeDuration(rtt))
 			if i == c.iterations {
 				fmt.Println()
 			}

--- a/cli/rtt_command.go
+++ b/cli/rtt_command.go
@@ -143,6 +143,9 @@ func (c *rttCmd) calcRTT(server string, copts []nats.Option) (string, time.Durat
 
 	var totalTime time.Duration
 
+	if opts.Trace {
+		fmt.Printf("RTT iterations for server: %s\n", server)
+	}
 	for i := 1; i <= c.iterations; i++ {
 		rtt, err := nc.RTT()
 		if err != nil {
@@ -150,6 +153,12 @@ func (c *rttCmd) calcRTT(server string, copts []nats.Option) (string, time.Durat
 		}
 
 		totalTime += rtt
+		if opts.Trace {
+			fmt.Printf("#%d:\trtt=%s\n", i, rtt)
+			if i == c.iterations {
+				fmt.Println()
+			}
+		}
 	}
 
 	return nc.ConnectedUrl(), totalTime / time.Duration(c.iterations), nil


### PR DESCRIPTION
RTT command examines the final result with few iterations (default is 5).
It should be handy to be able to see RTT for each iteration, and for that purpose `--trace` switch is reused. This PR adds that logic.

Example:
```
nats rtt --trace 8  
                                                                                                                                             
RTT iterations for server: nats://127.0.0.1:4222
#1:	rtt=1.514372ms
#2:	rtt=1.924859ms
#3:	rtt=1.322852ms
#4:	rtt=1.31299ms
#5:	rtt=1.120805ms
#6:	rtt=1.121725ms
#7:	rtt=1.133196ms
#8:	rtt=1.321921ms

nats://127.0.0.1:4222:

   127.0.0.1: 1.34659ms
```