### PR TITLE
[FIXED] consumer edit going from 1 subject filter to more than one

### DIFF
--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -375,8 +375,10 @@ func (c *consumerCmd) editAction(pc *fisk.ParseContext) error {
 
 		if len(c.filterSubjects) == 1 {
 			ncfg.FilterSubject = c.filterSubjects[0]
+			ncfg.FilterSubjects = nil
 		} else if len(c.filterSubjects) > 1 {
 			ncfg.FilterSubjects = c.filterSubjects
+			ncfg.FilterSubject = ""
 		}
 
 		if c.replicas > 0 {


### PR DESCRIPTION
Fixes consumer edit going from 1 subject filter to more than one that would move the filters to the `FilterSubjects` array, but not remove the initial single filter from FilterSubject.