### PR TITLE
[ADDED] `consumer add` when prompting for subject filter(s) can parse the user input as a comma or space separated list of subject filters

### DIFF
--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -1128,12 +1128,12 @@ func (c *consumerCmd) prepareConfig(pc *fisk.ParseContext) (cfg *api.ConsumerCon
 	case len(c.filterSubjects) == 0 && !c.acceptDefaults:
 		sub := ""
 		err = askOne(&survey.Input{
-			Message: "Filter Stream by subject (blank for all)",
+			Message: "Filter Stream by subjects (blank for all)",
 			Default: "",
-			Help:    "Stream can consume more than one subject - or a wildcard - this allows you to filter out just a single subject from all the ones entering the Stream for delivery to the Consumer. Settable using --filter",
+			Help:    "Consumers can filter messages from the stream, this is a space or comma separated list that can include wildcards. Settable using --filter",
 		}, &sub)
 		fisk.FatalIfError(err, "could not ask for filtering subject")
-		c.filterSubjects = []string{sub}
+		c.filterSubjects = splitString(sub)
 	}
 
 	switch {


### PR DESCRIPTION
Added to `consumer add`: when prompting for subject filter(s) can parse the user input as a comma or space separated list of subject filters.