### PR TITLE
Feature: Context's command for switching to previous (old) nats context

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ Known contexts:
 
 The context is selected as default, use `nats context --help` to see how to add, remove and edit contexts.
 
+To switch to another context we can use:
+```
+nats ctx select localhost
+```
+To switch context back to previous one, we can use `context previous` subcommand:
+```
+nats ctx -- -
+```
+
 ### Configuration file
 
 nats-cli stores contextes in `~/.config/nats/context`. Those contextes are stored as JSON documents. You can find the description and expected value for this configuration file by running `nats --help` and look for the global flags.

--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -87,7 +87,7 @@ func configureCtxCommand(app commandHost) {
 	validate.Arg("name", "Validate a specific context, validates all when not supplied").StringVar(&c.name)
 	validate.Flag("connect", "Attempts to connect to NATS using the context while validating").UnNegatableBoolVar(&c.activate)
 
-	context.Command("previous", "switch to the previous context").Alias("-").Action(c.switchOldCtx)
+	context.Command("previous", "switch to the previous context").Alias("-").Action(c.switchPreviousCtx)
 }
 
 func init() {
@@ -570,8 +570,8 @@ func (c *ctxCommand) removeCommand(_ *fisk.ParseContext) error {
 	return natscontext.DeleteContext(c.name)
 }
 
-func (c *ctxCommand) switchOldCtx(pc *fisk.ParseContext) error {
-	ctxToSwitch := natscontext.OldCtx()
+func (c *ctxCommand) switchPreviousCtx(pc *fisk.ParseContext) error {
+	ctxToSwitch := natscontext.PreviousContext()
 	if ctxToSwitch == "" {
 		return c.showCommand(pc)
 	}

--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -86,6 +86,8 @@ func configureCtxCommand(app commandHost) {
 	validate := context.Command("validate", "Validate one or all contexts").Action(c.validateCommand)
 	validate.Arg("name", "Validate a specific context, validates all when not supplied").StringVar(&c.name)
 	validate.Flag("connect", "Attempts to connect to NATS using the context while validating").UnNegatableBoolVar(&c.activate)
+
+	context.Command("previous", "switch to the previous context").Alias("-").Action(c.switchOldCtx)
 }
 
 func init() {
@@ -566,6 +568,19 @@ func (c *ctxCommand) removeCommand(_ *fisk.ParseContext) error {
 	}
 
 	return natscontext.DeleteContext(c.name)
+}
+
+func (c *ctxCommand) switchOldCtx(pc *fisk.ParseContext) error {
+	ctxToSwitch := natscontext.OldCtx()
+	if ctxToSwitch == "" {
+		return c.showCommand(pc)
+	}
+
+	if err := natscontext.SelectContext(ctxToSwitch); err != nil {
+		return err
+	}
+
+	return c.showCommand(pc)
 }
 
 func (c *ctxCommand) selectCommand(pc *fisk.ParseContext) error {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.17.0
 	github.com/mattn/go-isatty v0.0.19
-	github.com/nats-io/jsm.go v0.1.1-0.20230929093219-c157aaec4932
+	github.com/nats-io/jsm.go v0.1.1-0.20231002155422-ec2ddc62d18e
 	github.com/nats-io/jwt/v2 v2.5.2
 	github.com/nats-io/nats-server/v2 v2.10.1
 	github.com/nats-io/nats.go v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
-github.com/nats-io/jsm.go v0.1.1-0.20230929093219-c157aaec4932 h1:qZy9YlK9iw6we9cOhwz9KcSXozhuVPkNKlK1ZOA0Jwo=
-github.com/nats-io/jsm.go v0.1.1-0.20230929093219-c157aaec4932/go.mod h1:hB4Qd+IKoRvAAWTOI1HkCy4wotjFwOIT+codHCFOZqk=
+github.com/nats-io/jsm.go v0.1.1-0.20231002155422-ec2ddc62d18e h1:sSdswSrXLmxZ2gT37lmBizmqGw3QiHHi5+0zjJ8MIYc=
+github.com/nats-io/jsm.go v0.1.1-0.20231002155422-ec2ddc62d18e/go.mod h1:hB4Qd+IKoRvAAWTOI1HkCy4wotjFwOIT+codHCFOZqk=
 github.com/nats-io/jwt/v2 v2.5.2 h1:DhGH+nKt+wIkDxM6qnVSKjokq5t59AZV5HRcFW0zJwU=
 github.com/nats-io/jwt/v2 v2.5.2/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
 github.com/nats-io/nats-server/v2 v2.10.1 h1:MIJ614dhOIdo71iSzY8ln78miXwrYvlvXHUyS+XdKZQ=


### PR DESCRIPTION
New nats context subcommand that allows `cd -` or `git checkout -` type of operation but for NATS context.
This PR implements the logic for switching to the previous (old) nats context using:
- `nats ctx previous`
- `nats ctx -- -` (unfortunately wasn't able to make `nats ctx -` to work)

Example:
```
$ nats ctx select local-sys                                                                                                                                       
NATS Configuration Context "local-sys"

  Description: localhost sys
  Server URLs: nats://127.0.0.1:4222
     Username: admin
     Password: ********
         Path: /Users/boris/.config/nats/context/local-sys.json

$ nats ctx -- -                                                                                                                                         
NATS Configuration Context "local"

   Description: Localhost
   Server URLs: nats://127.0.0.1:4222
      Username: ruser
      Password: *********
          Path: /Users/boris/.config/nats/context/local.json
  Color Scheme: yellow

$ nats ctx -- -                                                                                                                                               
NATS Configuration Context "local-sys"

  Description: localhost sys
  Server URLs: nats://127.0.0.1:4222
     Username: admin
     Password: ********
         Path: /Users/boris/.config/nats/context/local-sys.json
```
This PR is still not ready and requires:
- merging https://github.com/nats-io/jsm.go/pull/485 and updating its dependency
- fixing natscli@main due to breaking changes within jsm.go@main which is present at this moment and is not related to this PR (so please ignore changes within `stream_command.go`)