### PR TITLE
fix: changing context name in one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To enable this we'll create a `demo` configuration and set it as default.
 
 First we add a configuration to capture the default `localhost` configuration.
 ```
-nats context add local --description "Localhost"
+nats context add localhost --description "Localhost"
 ```
 Output
 ```


### PR DESCRIPTION
Changing context name in example, since first is named "local" but then is referenced as "localhost". This might benefit new users of this CLI.