### PR TITLE
Fix incorrect JetStream store dir when using $XDG_DATA_HOME #962.

### DIFF
--- a/cli/server_run_command.go
+++ b/cli/server_run_command.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -160,21 +159,7 @@ func (c *SrvRunCmd) getRandomPort() (string, error) {
 }
 
 func (c *SrvRunCmd) dataParentDir() (string, error) {
-	parent := os.Getenv("XDG_DATA_HOME")
-	if parent != "" {
-		return filepath.Join(parent, ".local", "share"), nil
-	}
-
-	u, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-
-	if u.HomeDir == "" {
-		return "", fmt.Errorf("cannot determine home directory")
-	}
-
-	return filepath.Join(u.HomeDir, ".local", "share"), nil
+	return xdgShareHome()
 }
 
 func (c *SrvRunCmd) validate() error {

--- a/cli/server_run_command.go
+++ b/cli/server_run_command.go
@@ -158,10 +158,6 @@ func (c *SrvRunCmd) getRandomPort() (string, error) {
 	return port, err
 }
 
-func (c *SrvRunCmd) dataParentDir() (string, error) {
-	return xdgShareHome()
-}
-
 func (c *SrvRunCmd) validate() error {
 	if c.config.ExtendWithContext {
 		if opts.Config.ServerURL() == "" {
@@ -254,7 +250,7 @@ func (c *SrvRunCmd) prepareConfig() error {
 	c.config.ServicePasswordCrypt = string(b)
 
 	if c.config.JetStream {
-		parent, err := c.dataParentDir()
+		parent, err := xdgShareHome()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Eliminated duplicate (and incorrect) function to determine the per-user data directory based on `$XDG_DATA_HOME`.
Kept `dataParentDir()` function to maintain concept, but delegated to correct implementation `xdgShareHome()`.