### PR TITLE
Ensure selectedConsumer by requesting ConsumerInfo, when calling selectConsumer

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -99,7 +99,11 @@ func selectConsumer(mgr *jsm.Manager, stream string, consumer string, force bool
 			return "", nil, err
 		}
 
-		return c, nil, nil
+		con, err := mgr.LoadConsumer(stream, c)
+		if err != nil {
+			return "", nil, err
+		}
+		return con.Name(), con, err
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/nats-io/natscli/issues/999

Before:
```
$ ./nats consumer pause
[localhost] ? Select a Stream stream
[localhost] ? Select a Consumer consumer
[localhost] ? Pause until (time or duration) 30s
[localhost] ? Really pause Consumer stream > consumer until 2024-03-02 17:32:51 Yes
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xca3ff5]

goroutine 1 [running]:
github.com/nats-io/jsm%2ego.(*Consumer).StreamName(...)
        /home/mavenir/Documents/opensource/natscli/vendor/github.com/nats-io/jsm.go/consumers.go:942
github.com/nats-io/jsm%2ego.(*Consumer).Pause(0x0, {0x0?, 0x0?, 0x1c28340?})
        /home/mavenir/Documents/opensource/natscli/vendor/github.com/nats-io/jsm.go/consumers.go:907 +0x95
github.com/nats-io/natscli/cli.(*consumerCmd).pauseAction(0xc000422000, 0x0?)
        /home/mavenir/Documents/opensource/natscli/cli/consumer_command.go:1379 +0x3b1
github.com/choria-io/fisk.(*actionMixin).applyActions(...)
        /home/mavenir/Documents/opensource/natscli/vendor/github.com/choria-io/fisk/actions.go:28
github.com/choria-io/fisk.(*Application).applyActions(0xc0000dd180?, 0xc0000c8090)
        /home/mavenir/Documents/opensource/natscli/vendor/github.com/choria-io/fisk/app.go:827 +0xdf
github.com/choria-io/fisk.(*Application).execute(0xc0000dd180, 0xc0000c8090?, {0xc00059c660, 0x2, 0x2})
        /home/mavenir/Documents/opensource/natscli/vendor/github.com/choria-io/fisk/app.go:613 +0x65
github.com/choria-io/fisk.(*Application).Parse(0xc0000dd180, {0xc000118160?, 0xc0000f8001?, 0xc000173cc8?})
        /home/mavenir/Documents/opensource/natscli/vendor/github.com/choria-io/fisk/app.go:276 +0x18a
github.com/choria-io/fisk.(*Application).MustParseWithUsage(0xc0000dd180, {0xc000118160, 0x2, 0x2})
        /home/mavenir/Documents/opensource/natscli/vendor/github.com/choria-io/fisk/app.go:893 +0x45
main.main()
        /home/mavenir/Documents/opensource/natscli/nats/main.go:81 +0x2bf8
```

After: 
```
$ ./nats con pause
[localhost] ? Select a Stream stream
[localhost] ? Select a Consumer consumer
[localhost] ? Pause until (time or duration) 30s
[localhost] ? Really pause Consumer stream > consumer until 2024-03-02 17:42:25 Yes
Paused stream > consumer until 2024-03-02 17:42:25 (29s)
```