### PR TITLE
sub  command handling jsOpts

### DIFF
--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -360,7 +360,7 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 
 	case c.jetStream:
 		var js nats.JetStreamContext
-		js, err = nc.JetStream(nats.MaxWait(opts.Timeout))
+		js, err = nc.JetStream(jsOpts()...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes the sub command creating a JS context without taking all options (e.g. --js-domain