### PR TITLE
fixed re-enter password confusion, fixed password expose.

### DIFF
--- a/cli/server_mkpasswd_command.go
+++ b/cli/server_mkpasswd_command.go
@@ -88,7 +88,7 @@ func (c *SrvPasswdCmd) askPassword() (string, error) {
 	fmt.Println()
 
 	if bp1 != bp2 {
-		return "", fmt.Errorf("entered and re-entered passwords do not match")
+		return "", fmt.Errorf("Entered and re-entered passwords do not match")
 	}
 
 	return bp1, nil

--- a/cli/server_mkpasswd_command.go
+++ b/cli/server_mkpasswd_command.go
@@ -80,7 +80,7 @@ func (c *SrvPasswdCmd) askPassword() (string, error) {
 		return "", fmt.Errorf("could not read password: %w", err)
 	}
 	fmt.Println()
-	err = askOne(&survey.Password{Message: "Reenter password", Help: "Enter the same password again"}, &bp2)
+	err = askOne(&survey.Password{Message: "Re-enter password", Help: "Enter the same password again"}, &bp2)
 	if err != nil {
 		return "", fmt.Errorf("could not read password: %w", err)
 	}
@@ -88,7 +88,7 @@ func (c *SrvPasswdCmd) askPassword() (string, error) {
 	fmt.Println()
 
 	if bp1 != bp2 {
-		return "", fmt.Errorf("passwords do not match (%s != %s)", bp1, bp2)
+		return "", fmt.Errorf("entered and re-entered passwords do not match")
 	}
 
 	return bp1, nil


### PR DESCRIPTION
Fixed UI/UX for password encryption

1. The word 'Reenter' is creating confusion when encrypting a password, changed it to 'Re-enter'.
2. When Re-entered password does not match entered password, typed password is being exposed.
![image](https://github.com/nats-io/natscli/assets/26119949/5d48d156-89a3-46f2-b365-42caa01153b2)

changed the error line to a user-friendly sentence.