### PR TITLE
Add (hidden) 'audit' command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,9 +40,6 @@ jobs:
         shell: bash --noprofile --norc -x -eo pipefail {0}
         run: |
           set -e
-          cd nats
-          go test -v --failfast -p=1 ./...
-          cd ../cli
           go test -v --failfast -p=1 ./...
 
       - name: Create GitHub App Token

--- a/archive/README.md
+++ b/archive/README.md
@@ -1,0 +1,94 @@
+# Audit archive Format Overview
+
+Archive is a utility (part of the `audit` package) to capture and store large number of artifacts related to a NATS deployment.
+
+For example, capture all 'monitor' endpoint for all servers in a given cluster. Or capture all details of all streams in a given account, or capture the streams state and configuration.
+
+Primary design choices for archive:
+ - Single file: easy to share over email, web, chat, etc.
+ - Compressed: most artifacts have a lot of redundancy
+ - Indexed: can be queried in a generic way
+ - Default to JSON: easy for humans to grok, and for programs to process
+
+An "archive" is a ZIP file that conforms to a specific schema convention.
+
+The `archive` package provides `Reader` and `Writer` classes.
+
+## Artifact tagging and manifest
+
+Rather than relying on path convention and contrived splitting, each artifact is added to the archive with a unique set of tags.
+
+For example, the capture of a server `VARZ` endpoint may be tagged with:
+ - `cluster:awseast_bar`
+ - `server:bar_1`
+ - `type:server_varz`
+
+A filename for is derived from it's tags, and may look something like:
+```
+capture/clusters/awseast_bar/bar_1/variables.json
+```
+
+In addition to capture artifacts, the archive contains a few special files.
+
+The most important special file is `manifest.json` which stores tags for each file in the archive.
+The manifest allows programmatic discovery of the archive content, and can be used to build indices at read time.
+
+An example usage is: list all streams discovered under a given account `A`.
+Rather than having to infer this information from iterating and parsing files paths, the manifest can be traversed filtering by `account:A` and `type:stream_info`, and all matching files in the archive can be processed.
+
+## Archive organization
+
+n.b. Do not rely on path parsing and path conventions, query using the manifest instead.
+
+n.b.: If a server does not belong to a cluster, then `cluster_name` is `unclustered` for all the paths below.
+
+## Server-specific artifacts
+
+
+`${prefix}/clusters/${cluster_name}/${server_name}/${artifact_type}.json`
+
+Example: snapshot of health endpoint
+
+## Account artifacts
+
+Each account artifact can appear multiple times as it is captured through different servers.
+
+`${prefix}/accounts/${account_name}/servers/${cluster_name}__${server_name}/${artifact_type}.json"`
+
+Example: account connections
+
+## Stream artifacts
+
+Each stream artifact can appear multiple times as it is captured through different replicas.
+
+`${prefix}/accounts/${account_name}/streams/${stream_name}/replicas/${server_name}/${artifact_type}.json`
+
+Example: stream details
+
+## Server profiles
+
+`${prefix}/profiles/${cluster_name}/${server_name}__${profile_name}.prof`
+
+Example: memory profile
+
+## Special files
+
+In addition to artifacts, each archive contains a few special files.
+
+## Capture metadata
+
+`${prefix}/capture_metadata.json`
+
+Contains information such as the date of capture, the username, the tool version, and more.
+
+## Manifest
+
+`${prefix}/manifest.json`
+
+Contains a list of all artifacts and a list of tags associated with each one.
+
+## Capture log
+
+`${prefix}/capture.log`
+
+A log file for the process that created the archive, in case it contains useful information about artifacts (and lack of thereof).

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -1,0 +1,495 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func Test_CreateThenReadArchive(t *testing.T) {
+	const SEED = 123456
+	rng := rand.New(rand.NewSource(SEED))
+
+	archivePath := filepath.Join(t.TempDir(), "archive.zip")
+	aw, err := NewWriter(archivePath)
+	if err != nil {
+		t.Fatalf("Failed to create archive: %s", err)
+	}
+
+	files := map[string][]byte{
+		"empty_file.txt": make([]byte, 0),
+		"2KB_file.bin":   make([]byte, 2048),
+		"2MB_file.bin":   make([]byte, 2048*1024),
+	}
+
+	for fileName, fileContent := range files {
+		_, err = rng.Read(fileContent)
+		if err != nil {
+			t.Fatalf("Failed to generate random file contents: %s", err)
+		}
+		err = aw.addArtifact(fileName, bytes.NewReader(fileContent))
+		if err != nil {
+			t.Fatalf("Failed to add file '%s': %s", fileName, err)
+		}
+	}
+
+	err = aw.Close()
+	if err != nil {
+		t.Fatalf("Error closing writer: %s", err)
+	}
+
+	fileInfo, err := os.Stat(archivePath)
+	if err != nil {
+		t.Fatalf("Failed to get archive stats: %s", err)
+	}
+	t.Logf("Archive file size: %d KiB", fileInfo.Size()/1024)
+
+	ar, err := NewReader(archivePath)
+	defer func(ar *Reader) {
+		err := ar.Close()
+		if err != nil {
+			t.Logf("Archive close error: %s", err)
+		}
+	}(ar)
+	if err != nil {
+		t.Fatalf("Failed to create archive: %s", err)
+	}
+
+	expectedArtifactsCount := len(files) + 1 // (+1 for manifest)
+	if expectedArtifactsCount != ar.rawFilesCount() {
+		t.Fatalf("Wrong number of artifacts. Expected: %d actual: %d", expectedArtifactsCount, ar.rawFilesCount())
+	}
+
+	for fileName, fileContent := range files {
+
+		fileReader, size, err := ar.getFileReader(fileName)
+		if err != nil {
+			t.Fatalf("Failed to get file: %s: %s", fileName, err)
+		}
+		defer fileReader.Close()
+
+		if uint64(len(fileContent)) != size {
+			t.Fatalf("File %s size mismatch: %d vs. %d", fileName, len(fileContent), size)
+		}
+
+		buf, err := io.ReadAll(fileReader)
+		if err != nil {
+			t.Fatalf("Failed to read content of %s: %s", fileName, err)
+		}
+
+		if !bytes.Equal(fileContent, buf) {
+			t.Fatalf("File %s content mismatch", fileName)
+		}
+
+		t.Logf("Verified file %s, uncompressed size: %dB", fileName, size)
+	}
+}
+
+func Test_CreateThenReadArchiveUsingTags(t *testing.T) {
+	const SEED = 123456
+	rng := rand.New(rand.NewSource(SEED))
+
+	archivePath := filepath.Join(t.TempDir(), "archive.zip")
+	aw, err := NewWriter(archivePath)
+	if err != nil {
+		t.Fatalf("Failed to create archive: %s", err)
+	}
+
+	clusters := map[string][]string{
+		"C1": {
+			"X",
+			"Y",
+			"Z",
+		},
+		"C2": {
+			"A",
+			"B",
+			"C",
+			"D",
+			"E",
+		},
+	}
+
+	type DummyRecord struct {
+		FooString string
+		BarInt    int
+		BazBytes  []byte
+	}
+
+	type DummyHealthStats DummyRecord
+	type DummyClusterInfo DummyRecord
+	type DummyServerInfo DummyRecord
+	type DummyStreamInfo DummyRecord
+	type DummyAccountInfo DummyRecord
+
+	expectedClusters := make([]string, 0, 2)
+	expectedServers := make([]string, 0, 8)
+
+	for clusterName, clusterServers := range clusters {
+		expectedClusters = append(expectedClusters, clusterName)
+
+		var err error
+		// Add one (dummy) cluster info for each cluster
+		ci := &DummyClusterInfo{
+			FooString: clusterName,
+			BarInt:    rng.Int(),
+			BazBytes:  make([]byte, 100),
+		}
+		rng.Read(ci.BazBytes)
+		err = aw.Add(ci, TagCluster(clusterName), TagServer(clusterServers[0]), TagArtifactType("cluster_info"))
+		if err != nil {
+			t.Fatalf("Failed to add cluster info: %s", err)
+		}
+
+		for _, serverName := range clusterServers {
+			expectedServers = append(expectedServers, serverName)
+
+			// Add one (dummy) health stats for each server
+			hs := &DummyHealthStats{
+				FooString: serverName,
+				BarInt:    rng.Int(),
+				BazBytes:  make([]byte, 50),
+			}
+			rng.Read(hs.BazBytes)
+
+			err = aw.Add(hs, TagCluster(clusterName), TagServer(serverName), TagServerHealth())
+			if err != nil {
+				t.Fatalf("Failed to add server health: %s", err)
+			}
+
+			// Add one (dummy) server info for each server
+			si := &DummyServerInfo{
+				FooString: serverName,
+				BarInt:    rng.Int(),
+				BazBytes:  make([]byte, 50),
+			}
+			rng.Read(si.BazBytes)
+
+			err = aw.Add(si, TagCluster(clusterName), TagServer(serverName), TagArtifactType("server_info"))
+			if err != nil {
+				t.Fatalf("Failed to add server health: %s", err)
+			}
+		}
+	}
+	slices.Sort(expectedClusters)
+	slices.Sort(expectedServers)
+
+	// Add account info
+	globalAccountName := "$G"
+	for _, serverName := range clusters["C1"] {
+
+		si := &DummyAccountInfo{
+			FooString: globalAccountName,
+			BarInt:    rng.Int(),
+			BazBytes:  make([]byte, 50),
+		}
+		rng.Read(si.BazBytes)
+		err = aw.Add(si, TagAccount(globalAccountName), TagCluster("C1"), TagServer(serverName), TagArtifactType("account_info"))
+		if err != nil {
+			t.Fatalf("Failed to add account info: %s", err)
+		}
+	}
+
+	// Add some stream artifacts
+	streamName := "ORDERS"
+	streamAccount := globalAccountName
+	streamReplicas := []string{"A", "B", "E"}
+	for _, streamReplicaServerName := range streamReplicas {
+		// Add one (dummy) health stats for each server
+		si := &DummyStreamInfo{
+			FooString: streamAccount + "_" + streamName + "_" + streamReplicaServerName,
+			BarInt:    rng.Int(),
+			BazBytes:  make([]byte, 50),
+		}
+		rng.Read(si.BazBytes)
+
+		tags := []*Tag{
+			TagAccount(streamAccount),
+			TagServer(streamReplicaServerName),
+			TagStream(streamName),
+			TagArtifactType("stream_info"),
+			TagCluster("C2"),
+		}
+
+		err = aw.Add(si, tags...)
+		if err != nil {
+			t.Fatalf("Failed to add stream info: %s", err)
+		}
+	}
+
+	expectedMessageBytes := []byte("Hello World!")
+	err = aw.AddRaw(bytes.NewReader(expectedMessageBytes), "txt", TagSpecial("message"))
+	if err != nil {
+		t.Fatalf("Failed to raw artifact: %s", err)
+	}
+
+	err = aw.Close()
+	if err != nil {
+		t.Fatalf("Error closing writer: %s", err)
+	}
+
+	fileInfo, err := os.Stat(archivePath)
+	if err != nil {
+		t.Fatalf("Failed to get archive stats: %s", err)
+	}
+	t.Logf("Archive file size: %d KiB", fileInfo.Size()/1024)
+
+	ar, err := NewReader(archivePath)
+	defer func(ar *Reader) {
+		err := ar.Close()
+		if err != nil {
+			t.Logf("Archive close error: %s", err)
+		}
+	}(ar)
+	if err != nil {
+		t.Fatalf("Failed to open archive: %s", err)
+	}
+
+	expectedFilesList := []string{
+		// Server health
+		"capture/clusters/C1/X/health.json",
+		"capture/clusters/C1/Y/health.json",
+		"capture/clusters/C1/Z/health.json",
+		"capture/clusters/C2/A/health.json",
+		"capture/clusters/C2/B/health.json",
+		"capture/clusters/C2/C/health.json",
+		"capture/clusters/C2/D/health.json",
+		"capture/clusters/C2/E/health.json",
+
+		// Server info
+		"capture/clusters/C1/X/server_info.json",
+		"capture/clusters/C1/Y/server_info.json",
+		"capture/clusters/C1/Z/server_info.json",
+		"capture/clusters/C2/A/server_info.json",
+		"capture/clusters/C2/B/server_info.json",
+		"capture/clusters/C2/C/server_info.json",
+		"capture/clusters/C2/D/server_info.json",
+		"capture/clusters/C2/E/server_info.json",
+
+		// Cluster info
+		"capture/clusters/C1/X/cluster_info.json",
+		"capture/clusters/C2/A/cluster_info.json",
+
+		// Stream info
+		"capture/accounts/$G/streams/ORDERS/replicas/C2__A/stream_info.json",
+		"capture/accounts/$G/streams/ORDERS/replicas/C2__B/stream_info.json",
+		"capture/accounts/$G/streams/ORDERS/replicas/C2__E/stream_info.json",
+
+		// Account info
+		"capture/accounts/$G/servers/C1__X/account_info.json",
+		"capture/accounts/$G/servers/C1__Y/account_info.json",
+		"capture/accounts/$G/servers/C1__Z/account_info.json",
+
+		// Misc
+		"capture/misc/message.txt",
+	}
+	expectedArtifactsCount := len(expectedFilesList) + 1 // +1 for manifest
+	if expectedArtifactsCount != ar.rawFilesCount() {
+		t.Fatalf("Wrong number of artifacts. Expected: %d actual: %d", expectedArtifactsCount, ar.rawFilesCount())
+	}
+
+	t.Logf("Listing archive contents:")
+	for fileName := range ar.filesMap {
+		t.Logf(" - %s", fileName)
+	}
+
+	for _, fileName := range expectedFilesList {
+		if fileName == "capture/misc/message.txt" {
+			// Don't try to deserialize text file
+			continue
+		}
+		var r DummyRecord
+		err := ar.loadFile(fileName, &r)
+		if err != nil {
+			t.Fatalf("Failed to load artifact: %s: %s", fileName, err)
+		}
+		//t.Logf("%s: %+v", fileName, r)
+		if r.FooString == "" {
+			t.Fatalf("Unexpected empty structure field for file %s", fileName)
+		}
+	}
+
+	fileReader, _, err := ar.getFileReader("capture/misc/message.txt")
+	if err != nil {
+		t.Fatalf("Failed to open message file reader: %s", err)
+	}
+	messageBytes, err := io.ReadAll(fileReader)
+	if err != nil {
+		t.Fatalf("Failed to read message: %s", err)
+	}
+	if !bytes.Equal(messageBytes, expectedMessageBytes) {
+		t.Fatalf("Expected message: %s, actual: %s", expectedMessageBytes, messageBytes)
+	}
+
+	uniqueAccountTags := ar.accountTags
+	if len(uniqueAccountTags) != 1 {
+		t.Fatalf("Expected 1 accounts, got %d: %v", len(uniqueAccountTags), uniqueAccountTags)
+	} else if uniqueAccountTags[0].Value != globalAccountName {
+		t.Fatalf("Expected account name %s, got %s", globalAccountName, uniqueAccountTags[0].Value)
+	}
+
+	uniqueClusterTags := ar.clusterTags
+	if len(expectedClusters) != len(uniqueClusterTags) {
+		t.Fatalf("Expected %d clusters, got %d: %v", len(expectedClusters), len(uniqueClusterTags), uniqueClusterTags)
+	}
+
+	uniqueServerTags := ar.serverTags
+	if len(expectedServers) != len(uniqueServerTags) {
+		t.Fatalf("Expected %d servers, got %d: %v", len(expectedServers), len(uniqueServerTags), uniqueServerTags)
+	}
+
+	for _, serverTag := range uniqueServerTags {
+		var si DummyServerInfo
+		err := ar.Load(&si, &serverTag, TagArtifactType("server_info"))
+		if err != nil {
+			t.Fatalf("Failed to load server info artifact for server %s: %s", serverTag.Value, err)
+		}
+		if serverTag.Value != si.FooString {
+			t.Fatalf("Unexpected value '%s' (should be: '%s')", si.FooString, serverTag.Value)
+		}
+	}
+
+	clusterNames := ar.GetClusterNames()
+	if slices.Compare(clusterNames, expectedClusters) != 0 {
+		t.Fatalf("Expected clusters: %v, got: %v", expectedClusters, clusterNames)
+	}
+
+	for _, clusterName := range clusterNames {
+		serverNames := ar.GetClusterServerNames(clusterName)
+		if slices.Compare(clusters[clusterName], serverNames) != 0 {
+			t.Fatalf("Expected cluster %s servers: %v, got: %v", clusterName, clusters[clusterName], serverNames)
+		}
+	}
+
+	expectedAccountNames := []string{globalAccountName}
+	accountNames := ar.GetAccountNames()
+	if slices.Compare(expectedAccountNames, accountNames) != 0 {
+		t.Fatalf("Expected accounts: %v, got: %v", expectedAccountNames, accountNames)
+	}
+
+	expectedStreamNames := []string{"ORDERS"}
+	streamNames := ar.GetAccountStreamNames(globalAccountName)
+	if slices.Compare(expectedStreamNames, streamNames) != 0 {
+		t.Fatalf("Expected account %s streams: %v, got: %v", globalAccountName, expectedStreamNames, streamNames)
+	}
+
+	expectedReplicaNames := []string{"A", "B", "E"}
+	replicaNames := ar.GetStreamServerNames(globalAccountName, "ORDERS")
+	if slices.Compare(expectedReplicaNames, replicaNames) != 0 {
+		t.Fatalf("Expected stream %s/%s replicas: %v, got: %v", globalAccountName, "ORDERS", expectedReplicaNames, replicaNames)
+	}
+
+	var foo struct{}
+	if err = ar.Load(&foo, TagCluster("C1"), TagServer("A")); !errors.Is(err, ErrNoMatches) {
+		t.Fatalf("Expected error '%s', but got: '%s'", ErrNoMatches, err)
+	}
+	if err = ar.Load(&foo, TagServerHealth()); !errors.Is(err, ErrMultipleMatches) {
+		t.Fatalf("Expected error '%s', but got: '%s'", ErrMultipleMatches, err)
+	}
+}
+
+func Test_IterateResourcesUsingTags(t *testing.T) {
+	const SEED = 123456
+	rng := rand.New(rand.NewSource(SEED))
+
+	dummyArtifact := struct {
+		x int
+		y []byte
+	}{
+		x: rng.Int(),
+	}
+	rng.Read(dummyArtifact.y)
+
+	archivePath := filepath.Join(t.TempDir(), "archive.zip")
+	aw, err := NewWriter(archivePath)
+	if err != nil {
+		t.Fatalf("Failed to create archive: %s", err)
+	}
+
+	clusterServerMap := map[string][]string{
+		"C1": {"A", "B", "C"},
+		"C2": {"X", "Y", "Z"},
+	}
+
+	expectedClusterNames := []string{
+		"C1",
+		"C2",
+	}
+	slices.SortFunc(expectedClusterNames, strings.Compare)
+
+	for clusterName, serverNames := range clusterServerMap {
+		for _, serverName := range serverNames {
+			err = aw.Add(
+				dummyArtifact,
+				TagCluster(clusterName),
+				TagServer(serverName),
+				TagServerHealth(),
+			)
+			if err != nil {
+				t.Fatalf("Failed to add artifact: %s", err)
+			}
+		}
+	}
+
+	err = aw.Close()
+	if err != nil {
+		t.Fatalf("Error closing writer: %s", err)
+	}
+
+	// Done writing, now verify
+
+	ar, err := NewReader(archivePath)
+	defer func(ar *Reader) {
+		err := ar.Close()
+		if err != nil {
+			t.Logf("Failed to close reader: %s", err)
+		}
+	}(ar)
+	if err != nil {
+		t.Fatalf("Failed to open archive: %s", err)
+	}
+
+	clusterNames := ar.GetClusterNames()
+	slices.SortFunc(clusterNames, strings.Compare)
+
+	if !slices.Equal(clusterNames, expectedClusterNames) {
+		t.Fatalf("Expected clusters: %v, actual: %v", expectedClusterNames, clusterNames)
+	}
+
+	if len(ar.GetClusterServerNames("NO_SUCH_CLUSTER")) != 0 {
+		t.Fatalf("Looking up non-existent cluster produced some results")
+	}
+
+	for clusterName, expectedServerNames := range clusterServerMap {
+		serverNames := ar.GetClusterServerNames(clusterName)
+		slices.SortFunc(expectedServerNames, strings.Compare)
+		slices.SortFunc(serverNames, strings.Compare)
+		if !slices.Equal(serverNames, expectedServerNames) {
+			t.Fatalf("Expected cluster %s servers: %v, actual: %v", clusterName, expectedServerNames, serverNames)
+		}
+	}
+}
+
+// TODO test writer overwrites existing file
+// TODO test creation in non-existing directory fails
+// TODO test adding twice a file with the same name (or tags)
+// TODO test with non-unique server name in different clusters

--- a/archive/reader.go
+++ b/archive/reader.go
@@ -1,0 +1,368 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+)
+
+// Reader encapsulates a reader for the actual underlying archive, and also provides indices for faster and
+// more convenient iteration and querying of the archive content
+type Reader struct {
+	archiveReader       *zip.ReadCloser
+	path                string
+	filesMap            map[string]*zip.File
+	manifestMap         map[string][]Tag
+	accountTags         []Tag
+	clusterTags         []Tag
+	serverTags          []Tag
+	streamTags          []Tag
+	accountNames        []string
+	clusterNames        []string
+	clustersServerNames map[string][]string
+	accountStreamNames  map[string][]string
+	streamServerNames   map[string][]string
+}
+
+func (r *Reader) rawFilesCount() int {
+	return len(r.archiveReader.File)
+}
+
+// Close closes the reader
+func (r *Reader) Close() error {
+	if r.archiveReader != nil {
+		err := r.archiveReader.Close()
+		r.archiveReader = nil
+		return err
+	}
+	return nil
+}
+
+// getFileReader create a reader for the given filename, if it exists in the archive.
+func (r *Reader) getFileReader(name string) (io.ReadCloser, uint64, error) {
+	f, exists := r.filesMap[name]
+	if !exists {
+		return nil, 0, os.ErrNotExist
+	}
+	reader, err := f.Open()
+	if err != nil {
+		return nil, 0, err
+	}
+	return reader, f.UncompressedSize64, nil
+}
+
+// loadFile decodes the provided filename into the given value
+func (r *Reader) loadFile(name string, v any) error {
+	f, _, err := r.getFileReader(name)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(f)
+	err = decoder.Decode(v)
+	if err != nil {
+		return fmt.Errorf("failed to decode: %w", err)
+	}
+	return nil
+}
+
+// ErrNoMatches is returned if no artifact matched the input combination of tags
+var ErrNoMatches = fmt.Errorf("no file matched the given query")
+
+// ErrMultipleMatches is returned if multiple artifact matched the input combination of tags
+var ErrMultipleMatches = fmt.Errorf("multiple files matched the given query")
+
+// Load queries the indices for a single artifact matching the given input tags.
+// If a single artifact is found, then it is deserialized into v
+// If multiple artifact or no artifacts match the input tag, then ErrMultipleMatches and ErrNoMatches are returned
+// respectively
+func (r *Reader) Load(v any, queryTags ...*Tag) error {
+	// TODO build and use inverted index
+	// This method scans the entire manifest every time. Ok for now, but may get noticeably slow for very
+	// large archives, or large number of checks.
+	// A simple inverted index would be the right approach. Eventually. For now this will do.
+
+	matchedFileNames := make([]string, 0, 1)
+
+	// Find manifest entry that matches all given query tags
+manifestSearchLoop:
+	for fileName, fileTags := range r.manifestMap {
+		// Turn file tags into a set
+		fileTagSet := make(map[Tag]struct{}, len(fileTags))
+		for _, fileTag := range fileTags {
+			fileTagSet[fileTag] = struct{}{}
+		}
+
+		// Check that each query tag is in this file tag set
+		for _, queryTag := range queryTags {
+			_, present := fileTagSet[*queryTag]
+			if !present {
+				continue manifestSearchLoop
+			}
+		}
+
+		// This file matches
+		matchedFileNames = append(matchedFileNames, fileName)
+
+		// Continue iterating and find all matching files
+		continue manifestSearchLoop
+	}
+
+	if len(matchedFileNames) < 1 {
+		return ErrNoMatches
+	} else if len(matchedFileNames) > 1 {
+		return ErrMultipleMatches
+	}
+
+	// A single file matched
+	matchedFileName := matchedFileNames[0]
+
+	// Unmarshall it into v
+	return r.loadFile(matchedFileName, v)
+}
+
+// NewReader creates a new reader for the file at the given archivePath.
+// Reader expect the file to comply to format and content created by a Writer in this same package.
+// During creation, Reader creates in-memory indices to speed up subsequent queries.
+func NewReader(archivePath string) (*Reader, error) {
+	// Create a zip reader
+	archiveReader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open archive: %w", err)
+	}
+
+	// Create map of filename -> file
+	filesMap := make(map[string]*zip.File, len(archiveReader.File))
+	for _, f := range archiveReader.File {
+		filesMap[f.Name] = f
+	}
+
+	// Find and open the manifest file
+	manifestFileName, err := createFilenameFromTags("json", []*Tag{internalTagManifest()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load manifest: %w", err)
+	}
+
+	manifestFile, exists := filesMap[manifestFileName]
+	if !exists {
+		return nil, fmt.Errorf("manifest file not found in archive")
+	}
+
+	manifestFileReader, err := manifestFile.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open manifest: %w", err)
+	}
+	defer manifestFileReader.Close()
+
+	// Load manifest, which is a normalized index:
+	// For each file, a list of tags is present
+	manifestMap := make(map[string][]Tag, len(filesMap))
+	err = json.NewDecoder(manifestFileReader).Decode(&manifestMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load manifest: %w", err)
+	}
+
+	// Check that each file in the manifest exists in the archive
+	for fileName := range manifestMap {
+		_, present := filesMap[fileName]
+		if !present {
+			return nil, fmt.Errorf("file %s is in manifest, but not present in archive", fileName)
+		}
+	}
+
+	// Check that each file in the archive is present in the manifest
+	manifestFilePath, err := createFilenameFromTags("json", []*Tag{internalTagManifest()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to compose expected manifest path: %w", err)
+	}
+	for filePath := range filesMap {
+		switch filePath {
+		case manifestFilePath:
+			// Manifest is not present in manifest
+		default:
+			if _, present := manifestMap[filePath]; !present {
+				fmt.Printf("Warning: archive file %s is not present in manifest\n", filePath)
+			}
+		}
+	}
+
+	// Map of cluster to set of server names
+	clustersServersMap := make(map[string]map[string]any)
+	accountsStreamsMap := make(map[string]map[string]map[string]any)
+
+	for _, tags := range manifestMap {
+		// Take note of certain tags, if present
+		var cluster, server, account, stream string
+		for _, tag := range tags {
+			switch tag.Name {
+			case clusterTagLabel:
+				cluster = tag.Value
+			case serverTagLabel:
+				server = tag.Value
+			case accountTagLabel:
+				account = tag.Value
+			case streamTagLabel:
+				stream = tag.Value
+			}
+		}
+
+		// If a cluster tag is set, create a record for it
+		if cluster != "" {
+			if _, knownCluster := clustersServersMap[cluster]; !knownCluster {
+				clustersServersMap[cluster] = make(map[string]any)
+			}
+			// File has cluster and server tags, save server in set for this cluster
+			if server != "" {
+				clustersServersMap[cluster][server] = nil // Map used as set, value doesn't matter
+			}
+		}
+
+		// If an account tag is set, create a record for it
+		if account != "" {
+			if _, knownAccount := accountsStreamsMap[account]; !knownAccount {
+				accountsStreamsMap[account] = make(map[string]map[string]any)
+			}
+			// If account and stream tags present, save stream in set for this account
+			if stream != "" {
+				if _, knownStream := accountsStreamsMap[account][stream]; !knownStream {
+					accountsStreamsMap[account][stream] = make(map[string]any)
+				}
+				// If account and stream and server tags present, save server in set for this stream
+				if server != "" {
+					accountsStreamsMap[account][stream][server] = nil // Map used as set, value doesn't matter
+				}
+			}
+		}
+	}
+
+	clusters, clusterServers := shrinkMapOfSets(clustersServersMap)
+	accounts, accountsStreams := shrinkMapOfSets(accountsStreamsMap)
+	streamsServers := make(map[string][]string, len(accounts))
+	for account, streamsMapServersSet := range accountsStreamsMap {
+		_, streamServers := shrinkMapOfSets(streamsMapServersSet)
+		for stream, serversList := range streamServers {
+			key := account + "/" + stream
+			streamsServers[key] = serversList
+		}
+	}
+
+	// Returns a deduplicated list of tags for the specific label present in the archive
+	// e.g. getUniqueTags(serverTagLabel) -> [Tag(server, s1), Tag(server, s2, Tag(server, s3)]
+	// TODO each call scans the manifest.
+	// Ok for now, but a single scan could build a list of unique tag values for each tag name
+	getUniqueTags := func(label TagLabel) []Tag {
+		var tagsSet = make(map[Tag]struct{}, len(manifestMap))
+		for _, tags := range manifestMap {
+			for _, tag := range tags {
+				if tag.Name == label {
+					// Found a tag for the given label, add it to the set
+					tagsSet[tag] = struct{}{}
+				}
+			}
+		}
+		// Create list of unique tags from the set
+		tagsList := make([]Tag, 0, len(tagsSet))
+		for tag := range tagsSet {
+			tagsList = append(tagsList, tag)
+		}
+		slices.SortFunc(tagsList, func(a, b Tag) int {
+			if a.Name != b.Name {
+				panic("Unexpected comparison between different tags")
+			}
+			return strings.Compare(a.Value, b.Value)
+		})
+		return tagsList
+	}
+
+	return &Reader{
+		path:                archivePath,
+		archiveReader:       archiveReader,
+		filesMap:            filesMap,
+		manifestMap:         manifestMap,
+		accountTags:         getUniqueTags(accountTagLabel),
+		clusterTags:         getUniqueTags(clusterTagLabel),
+		serverTags:          getUniqueTags(serverTagLabel),
+		streamTags:          getUniqueTags(streamTagLabel),
+		accountNames:        accounts,
+		clusterNames:        clusters,
+		clustersServerNames: clusterServers,
+		accountStreamNames:  accountsStreams,
+		streamServerNames:   streamsServers,
+	}, nil
+}
+
+// GetAccountNames list the unique names of accounts found in the archive
+// The list of names is sorted alphabetically
+func (r *Reader) GetAccountNames() []string {
+	return slices.Clone(r.accountNames)
+}
+
+// GetAccountStreamNames list the unique stream names found in the archive for the given account
+// The list of names is sorted alphabetically
+func (r *Reader) GetAccountStreamNames(accountName string) []string {
+	streams, present := r.accountStreamNames[accountName]
+	if present {
+		return slices.Clone(streams)
+	}
+	return make([]string, 0)
+}
+
+// GetClusterNames list the unique names of clusters found in the archive
+// The list of names is sorted alphabetically
+func (r *Reader) GetClusterNames() []string {
+	return slices.Clone(r.clusterNames)
+}
+
+// GetClusterServerNames list the unique server names found in the archive for the given cluster
+// The list of names is sorted alphabetically
+func (r *Reader) GetClusterServerNames(clusterName string) []string {
+	servers, present := r.clustersServerNames[clusterName]
+	if present {
+		return slices.Clone(servers)
+	}
+	return make([]string, 0)
+}
+
+// GetStreamServerNames list the unique server names found in the archive for the given stream in the given account
+// The list of names is sorted alphabetically
+func (r *Reader) GetStreamServerNames(accountName, streamName string) []string {
+	servers, present := r.streamServerNames[accountName+"/"+streamName]
+	if present {
+		return slices.Clone(servers)
+	}
+	return make([]string, 0)
+}
+
+// shrinkMapOfSets utility method, given a map[string] of sets (map[string]any), return:
+// The list of (unique) keys as string slice plus a shrunk map where sets are replaced with lists
+// The list of unique keys and each list in the map are sorted alphabetically.
+func shrinkMapOfSets[T any](m map[string]map[string]T) ([]string, map[string][]string) {
+	keysList := make([]string, 0, len(m))
+	newMap := make(map[string][]string, len(m))
+	for k, valuesMap := range m {
+		keysList = append(keysList, k)
+		newMap[k] = make([]string, 0, len(valuesMap))
+		for value := range valuesMap {
+			newMap[k] = append(newMap[k], value)
+		}
+		slices.Sort(newMap[k])
+	}
+	slices.Sort(keysList)
+	return keysList, newMap
+}

--- a/archive/tag.go
+++ b/archive/tag.go
@@ -1,0 +1,330 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"fmt"
+	"path"
+)
+
+type TagLabel string
+
+type Tag struct {
+	Name  TagLabel
+	Value string
+}
+
+const (
+	serverTagLabel      TagLabel = "server"
+	clusterTagLabel     TagLabel = "cluster"
+	accountTagLabel     TagLabel = "account"
+	streamTagLabel      TagLabel = "stream"
+	typeTagLabel        TagLabel = "artifact_type"
+	profileNameTagLabel TagLabel = "profile_name"
+	specialTagLabel     TagLabel = "special"
+)
+
+const (
+	// Server artifacts
+	healtzArtifactType   = "health"
+	varzArtifactType     = "variables"
+	connzArtifactType    = "connections"
+	routezArtifactType   = "routes"
+	gatewayzArtifactType = "gateways"
+	leafzArtifactType    = "leafs"
+	subzArtifactType     = "subs"
+	jszArtifactType      = "jetstream_info"
+	accountzArtifactType = "accounts"
+	// Account artifacts
+	accountConnectionsArtifactType = "account_connections"
+	accountLeafsArtifactType       = "account_leafs"
+	accountSubsArtifactType        = "account_subs"
+	accountJetStreamArtifactType   = "account_jetstream_info"
+	accountInfoArtifactType        = "account_info"
+	streamDetailsArtifactType      = "stream_info"
+	// Other artifacts
+	manifestArtifactName = "manifest"
+	profileArtifactType  = "profile"
+)
+
+const (
+	// Placeholder for cluster name for unclustered servers
+	noCluster = "unclustered"
+	// Archive root directory (so it doesn't explode in the containing directory)
+	rootDirectory = "capture"
+	// Directory where special artifacts are filed under
+	specialFilesDirectory = "misc"
+	// Used to join dimensions in a path, for example cluster name and server name
+	separator = "__"
+)
+
+// Special tags that get composed and combined in the filename
+var dimensionTagsNames = map[TagLabel]any{
+	accountTagLabel:     nil,
+	clusterTagLabel:     nil,
+	serverTagLabel:      nil,
+	streamTagLabel:      nil,
+	typeTagLabel:        nil,
+	profileNameTagLabel: nil,
+}
+
+func createFilenameFromTags(extension string, tags []*Tag) (string, error) {
+	if len(tags) < 1 {
+		return "", fmt.Errorf("at least one tag is required")
+	} else if len(tags) == 1 && tags[0].Name == specialTagLabel {
+		// Special-tagged go into a special subdirectory
+		return path.Join(
+			rootDirectory,
+			specialFilesDirectory,
+			tags[0].Value+"."+extension,
+		), nil
+	}
+
+	// "Dimension" tags:
+	// - Can have at most one value
+	// - They get combined to produce the file path
+	dimensionTagsMap := make(map[TagLabel]*Tag, len(tags))
+
+	// Capture non-dimension tags here (unused for now)
+	otherTags := make([]*Tag, 0, len(tags))
+
+	for _, tag := range tags {
+
+		// The 'special' tags should not be mixed with the rest
+		if tag.Name == specialTagLabel {
+			return "", fmt.Errorf("special tag (value: '%s') should not be combined with other tags", tag.Value)
+		}
+
+		// Save dimension tags and other tags
+		_, isDimensionTag := dimensionTagsNames[tag.Name]
+		_, isDuplicateDimensionTag := dimensionTagsMap[tag.Name]
+		if isDimensionTag && isDuplicateDimensionTag {
+			return "", fmt.Errorf("multiple values not allowed for tag '%s'", tag.Name)
+		} else if isDimensionTag {
+			dimensionTagsMap[tag.Name] = tag
+		} else {
+			otherTags = append(otherTags, tag)
+		}
+	}
+
+	if len(otherTags) > 0 {
+		// For the moment, the 'gather' command is the only user of this, and it is not using custom tags.
+		// If we ever open the archiving API beyond, we may need to address this.
+		return "", fmt.Errorf("unhandled custom tags")
+	}
+
+	accountTag, hasAccountTag := dimensionTagsMap[accountTagLabel], dimensionTagsMap[accountTagLabel] != nil
+	clusterTag, hasClusterTag := dimensionTagsMap[clusterTagLabel], dimensionTagsMap[clusterTagLabel] != nil
+	serverTag, hasServerTag := dimensionTagsMap[serverTagLabel], dimensionTagsMap[serverTagLabel] != nil
+	streamTag, hasStreamTag := dimensionTagsMap[streamTagLabel], dimensionTagsMap[streamTagLabel] != nil
+	typeTag, hasTypeTag := dimensionTagsMap[typeTagLabel], dimensionTagsMap[typeTagLabel] != nil
+	profileNameTag, hasProfileNameTag := dimensionTagsMap[profileNameTagLabel], dimensionTagsMap[profileNameTagLabel] != nil
+
+	// All artifacts must have a type, source server and source cluster (or "un-clustered")
+	for requiredTagName, hasRequiredTag := range map[string]bool{
+		"artifact type":  hasTypeTag,
+		"source cluster": hasClusterTag,
+		"source server":  hasServerTag,
+	} {
+		if !hasRequiredTag {
+			return "", fmt.Errorf("missing required tag: %s", requiredTagName)
+		}
+	}
+
+	if hasStreamTag {
+		// Stream artifact must have account and cluster tag
+		if !hasClusterTag || !hasAccountTag {
+			return "", fmt.Errorf("stream artifact is missing cluster or account tags")
+		}
+		return path.Join(
+			rootDirectory,
+			"accounts",
+			accountTag.Value,
+			"streams",
+			streamTag.Value,
+			"replicas",
+			clusterTag.Value+separator+serverTag.Value,
+			typeTag.Value+"."+extension,
+		), nil
+
+	} else if hasAccountTag {
+		// Account artifact (but not a stream)
+		if !hasClusterTag {
+			return "", fmt.Errorf("account artifact is missing cluster tag")
+		}
+		return path.Join(
+			rootDirectory,
+			"accounts",
+			accountTag.Value,
+			"servers",
+			clusterTag.Value+separator+serverTag.Value,
+			typeTag.Value+"."+extension,
+		), nil
+
+	} else if hasServerTag {
+		// Server artifact
+		clusterName := noCluster
+		if hasClusterTag {
+			clusterName = clusterTag.Value
+		}
+
+		// Handle certain types differently
+		switch typeTag.Value {
+		case profileArtifactType:
+			if !hasProfileNameTag {
+				return "", fmt.Errorf("profile artifact is missing profile name")
+			}
+			return path.Join(
+				rootDirectory,
+				"profiles",
+				clusterName,
+				serverTag.Value+separator+profileNameTag.Value+"."+extension,
+			), nil
+
+		default:
+			return path.Join(
+				rootDirectory,
+				"clusters",
+				clusterName,
+				serverTag.Value,
+				typeTag.Value+"."+extension,
+			), nil
+		}
+
+	} else {
+		// May add more cases later, for now bomb if none of the above applies
+		return "", fmt.Errorf("unhandled tags combination: %+v", dimensionTagsMap)
+	}
+}
+
+func TagArtifactType(artifactType string) *Tag {
+	return &Tag{
+		Name:  typeTagLabel,
+		Value: artifactType,
+	}
+}
+
+func TagServerHealth() *Tag {
+	return TagArtifactType(healtzArtifactType)
+}
+func TagServerVars() *Tag {
+	return TagArtifactType(varzArtifactType)
+}
+
+func TagServerConnections() *Tag {
+	return TagArtifactType(connzArtifactType)
+}
+
+func TagServerRoutes() *Tag {
+	return TagArtifactType(routezArtifactType)
+}
+
+func TagServerGateways() *Tag {
+	return TagArtifactType(gatewayzArtifactType)
+}
+
+func TagServerLeafs() *Tag {
+	return TagArtifactType(leafzArtifactType)
+}
+
+func TagServerSubs() *Tag {
+	return TagArtifactType(subzArtifactType)
+}
+
+func TagServerJetStream() *Tag {
+	return TagArtifactType(jszArtifactType)
+}
+
+func TagServerAccounts() *Tag {
+	return TagArtifactType(accountzArtifactType)
+}
+
+func TagAccountConnections() *Tag {
+	return TagArtifactType(accountConnectionsArtifactType)
+}
+
+func TagAccountLeafs() *Tag {
+	return TagArtifactType(accountLeafsArtifactType)
+}
+
+func TagAccountSubs() *Tag {
+	return TagArtifactType(accountSubsArtifactType)
+}
+
+func TagAccountJetStream() *Tag {
+	return TagArtifactType(accountJetStreamArtifactType)
+}
+
+func TagAccountInfo() *Tag {
+	return TagArtifactType(accountInfoArtifactType)
+}
+
+func TagStreamInfo() *Tag { return TagArtifactType(streamDetailsArtifactType) }
+
+func internalTagManifest() *Tag {
+	return TagSpecial(manifestArtifactName)
+}
+
+func TagServer(serverName string) *Tag {
+	return &Tag{
+		Name:  serverTagLabel,
+		Value: serverName,
+	}
+}
+
+func TagCluster(clusterName string) *Tag {
+	return &Tag{
+		Name:  clusterTagLabel,
+		Value: clusterName,
+	}
+}
+
+func TagNoCluster() *Tag {
+	return &Tag{
+		Name:  clusterTagLabel,
+		Value: noCluster,
+	}
+}
+
+func TagAccount(accountName string) *Tag {
+	return &Tag{
+		Name:  accountTagLabel,
+		Value: accountName,
+	}
+}
+
+func TagStream(streamName string) *Tag {
+	return &Tag{
+		Name:  streamTagLabel,
+		Value: streamName,
+	}
+}
+
+func TagServerProfile() *Tag {
+	return TagArtifactType(profileArtifactType)
+}
+
+func TagProfileName(profileType string) *Tag {
+	return &Tag{
+		Name:  profileNameTagLabel,
+		Value: profileType,
+	}
+}
+
+func TagSpecial(special string) *Tag {
+	return &Tag{
+		Name:  specialTagLabel,
+		Value: special,
+	}
+}

--- a/archive/tag_test.go
+++ b/archive/tag_test.go
@@ -1,0 +1,154 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"testing"
+)
+
+func Test_CreateFilenameFromTags(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		tags      []*Tag
+		extension string
+		want      string
+		wantErr   bool
+	}{
+		{
+			"server health",
+			[]*Tag{TagCluster("C1"), TagServer("S1"), TagServerHealth()},
+			"json",
+			"capture/clusters/C1/S1/health.json",
+			false,
+		},
+		{
+			"server info",
+			[]*Tag{TagCluster("C1"), TagServer("S1"), TagServerVars()},
+			"json",
+			"capture/clusters/C1/S1/variables.json",
+			false,
+		},
+		{
+			"server profile",
+			[]*Tag{TagCluster("C1"), TagServer("S1"), TagServerProfile(), TagProfileName("foo")},
+			"prof",
+			"capture/profiles/C1/S1__foo.prof",
+			false,
+		},
+		{
+			"server profile with missing name",
+			[]*Tag{TagCluster("C1"), TagServer("S1"), TagServerProfile()},
+			"_",
+			"",
+			true,
+		},
+		{
+			"cluster info",
+			[]*Tag{TagCluster("C1"), TagServer("S1"), TagArtifactType("cluster_info")},
+			"json",
+			"capture/clusters/C1/S1/cluster_info.json",
+			false,
+		},
+		{
+			"account details un-clustered",
+			[]*Tag{TagAccount("A1"), TagNoCluster(), TagServer("S1"), TagAccountInfo()},
+			"json",
+			"capture/accounts/A1/servers/unclustered__S1/account_info.json",
+			false,
+		},
+		{
+			"account details",
+			[]*Tag{TagAccount("A1"), TagCluster("C1"), TagServer("S1"), TagAccountInfo()},
+			"json",
+			"capture/accounts/A1/servers/C1__S1/account_info.json",
+			false,
+		},
+		{
+			"account connections",
+			[]*Tag{TagAccount("A1"), TagNoCluster(), TagServer("S1"), TagAccountConnections()},
+			"json",
+			"capture/accounts/A1/servers/unclustered__S1/account_connections.json",
+			false,
+		},
+		{
+			"account connections without source server",
+			[]*Tag{TagAccount("A1"), TagAccountConnections()},
+			"_",
+			"",
+			true,
+		},
+		{
+			"stream info",
+			[]*Tag{TagAccount("A1"), TagStream("Foo"), TagCluster("C1"), TagServer("S1"), TagArtifactType("stream_info")},
+			"json",
+			"capture/accounts/A1/streams/Foo/replicas/C1__S1/stream_info.json",
+			false,
+		},
+		{
+			"stream info without type",
+			[]*Tag{TagAccount("A1"), TagStream("Foo"), TagCluster("C1"), TagServer("S1")},
+			"_",
+			"",
+			true,
+		},
+		{
+			"stream info without source server",
+			[]*Tag{TagAccount("A1"), TagStream("Foo"), TagCluster("C1"), TagArtifactType("stream_info")},
+			"_",
+			"",
+			true,
+		},
+		{
+			"stream info without account server",
+			[]*Tag{TagServer("S1"), TagStream("Foo"), TagNoCluster(), TagArtifactType("stream_info")},
+			"_",
+			"",
+			true,
+		},
+		{
+			"manifest",
+			[]*Tag{internalTagManifest()},
+			"json",
+			"capture/misc/manifest.json",
+			false,
+		},
+		{
+			"manifest with other tag",
+			[]*Tag{internalTagManifest(), TagServer("foo")},
+			"_",
+			"",
+			true,
+		},
+		{
+			"no tags",
+			[]*Tag{},
+			"_",
+			"",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := createFilenameFromTags(tt.extension, tt.tags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createFilenameFromTags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("createFilenameFromTags() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/archive/writer.go
+++ b/archive/writer.go
@@ -1,0 +1,148 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"archive/zip"
+)
+
+// Writer encapsulates a zip writer for the underlying archive file, but also tracks metadata used by the Reader to
+// construct indices
+type Writer struct {
+	path        string
+	fileWriter  *os.File
+	zipWriter   *zip.Writer
+	manifestMap map[string][]*Tag
+}
+
+// Close closes the writer
+func (w *Writer) Close() error {
+	// Add manifest file to archive before closing it
+	if w.zipWriter != nil && w.fileWriter != nil {
+		err := w.Add(w.manifestMap, internalTagManifest())
+		if err != nil {
+			return fmt.Errorf("failed to add manifest: %w", err)
+		}
+	}
+
+	// Close and null the zip writer
+	if w.zipWriter != nil {
+		err := w.zipWriter.Close()
+		w.zipWriter = nil
+		if err != nil {
+			return fmt.Errorf("failed to close archive zip writer: %w", err)
+		}
+	}
+
+	// Close and null the file writer
+	if w.fileWriter != nil {
+		err := w.fileWriter.Close()
+		w.fileWriter = nil
+		if err != nil {
+			return fmt.Errorf("failed to close archive file writer: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// addArtifact low-level API that adds bytes without adding to the index, used for special files
+func (w *Writer) addArtifact(name string, content *bytes.Reader) error {
+	f, err := w.zipWriter.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(f, content)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Add serializes the given artifact to JSON and adds it to the archive, it creates a file name based on the provided
+// tags and ensures uniqueness. The artifact is also added to the manifest for indexing, enabling tag-based querying
+// in via Reader
+func (w *Writer) Add(artifact any, tags ...*Tag) error {
+	// Encode the artifact as (pretty-formatted) JSON
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetIndent("", "  ")
+	err := encoder.Encode(artifact)
+	if err != nil {
+		return fmt.Errorf("failed to encode: %w", err)
+	}
+
+	return w.AddRaw(bytes.NewReader(buf.Bytes()), "json", tags...)
+}
+
+// AddRaw adds the given artifact to the archive similarly to Add.
+// The artifact is assumed to be already serialized and is copied as-is byte for byte.
+func (w *Writer) AddRaw(reader *bytes.Reader, extension string, tags ...*Tag) error {
+	if w.zipWriter == nil {
+		return fmt.Errorf("attempting to write into a closed writer")
+	}
+
+	// Create filename based on tags
+	name, err := createFilenameFromTags(extension, tags)
+	if err != nil {
+		return fmt.Errorf("failed to create artifact name: %w", err)
+	}
+
+	// Ensure file is unique
+	_, exists := w.manifestMap[name]
+	if exists {
+		return fmt.Errorf("artifact %s with identical tags is already present", name)
+	}
+
+	// Open a zip writer
+	f, err := w.zipWriter.Create(name)
+	if err != nil {
+		return fmt.Errorf("failed to create file in archive: %w", err)
+	}
+
+	_, err = io.Copy(f, reader)
+	if err != nil {
+		return fmt.Errorf("failed to copy content: %w", err)
+	}
+
+	// Add file and its tags to the manifest
+	w.manifestMap[name] = tags
+
+	return nil
+}
+
+// NewWriter creates a new writer for the file at the given archivePath.
+// Writer creates a ZIP file whose content has additional structure and metadata.
+// If archivePath is an existing file, it will be overwritten.
+func NewWriter(archivePath string) (*Writer, error) {
+	fileWriter, err := os.Create(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create archive: %w", err)
+	}
+
+	zipWriter := zip.NewWriter(fileWriter)
+
+	return &Writer{
+		path:        archivePath,
+		fileWriter:  fileWriter,
+		zipWriter:   zipWriter,
+		manifestMap: make(map[string][]*Tag),
+	}, nil
+}

--- a/cli/audit_analyze_command.go
+++ b/cli/audit_analyze_command.go
@@ -1,0 +1,1124 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/choria-io/fisk"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/natscli/archive"
+)
+
+type auditAnalyzeCmd struct {
+	archivePath          string
+	veryVerbose          bool
+	exampleIssuesLimit   uint
+	exampleIssues        []string
+	omittedExampleIssues int
+	checks               []struct {
+		checkName string
+		checkFunc func(reader *archive.Reader) (auditCheckOutcome, error)
+	}
+}
+
+type auditCheckOutcome int
+
+func (s auditCheckOutcome) badge() string {
+	switch s {
+	case Pass:
+		return "PASS"
+	case Fail:
+		return "FAIL"
+	case SomeIssues:
+		return "WARN"
+	case Skipped:
+		return "SKIP"
+	default:
+		panic(s)
+	}
+}
+
+const (
+	Skipped auditCheckOutcome = iota
+	Pass
+	Fail
+	SomeIssues
+)
+
+func configureAuditAnalyzeCommand(srv *fisk.CmdClause) {
+	c := &auditAnalyzeCmd{}
+	c.checks = []struct {
+		checkName string
+		checkFunc func(reader *archive.Reader) (auditCheckOutcome, error)
+	}{
+		{
+			"Server health",
+			c.checkServerHealth,
+		},
+		{
+			"Uniform server version",
+			c.checkServerVersions,
+		},
+		{
+			"Slow consumers",
+			c.checkSlowConsumers,
+		},
+		{
+			"Cluster memory usage",
+			c.checkClusterMemoryUsageOutliers,
+		},
+		{
+			"Lagging stream replicas",
+			c.checkLaggingStreamReplicas,
+		},
+		{
+			"CPU usage",
+			c.checkCpuUsage,
+		},
+		{
+			"High subject cardinality streams",
+			c.checkHighSubjectCardinalityStreams,
+		},
+		{
+			"High number of HA assets",
+			c.checkHighHAAssetCardinality,
+		},
+		{
+			"Reserved resources limit",
+			c.checkResourceLimits,
+		},
+		{
+			"Account limits",
+			c.checkAccountLimits,
+		},
+		{
+			"Stream limits",
+			c.checkStreamLimits,
+		},
+		{
+			"Meta cluster offline replicas",
+			c.checkMetaClusterOfflineReplicas,
+		},
+		{
+			"Meta cluster leader",
+			c.checkMetaClusterLeader,
+		},
+		{
+			"Configured gateways",
+			c.checkConfiguredGateways,
+		},
+	}
+
+	analyze := srv.Command("analyze", "perform checks against an archive created by the 'gather' subcommand").Action(c.analyze)
+	analyze.Arg("archive", "path to input archive to analyze").Required().ExistingFileVar(&c.archivePath)
+	analyze.Flag("limit", "How many example issues to display for each failed check (Set to 0 to show all)").Default("5").UintVar(&c.exampleIssuesLimit)
+	// Hidden flags
+	analyze.Flag("very-verbose", "Enable debug console messages during analysis").Hidden().BoolVar(&c.veryVerbose)
+}
+
+func (cmd *auditAnalyzeCmd) analyze(_ *fisk.ParseContext) error {
+	// Open archive
+	ar, err := archive.NewReader(cmd.archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := ar.Close()
+		if err != nil {
+			fmt.Printf("Failed to close archive reader: %s\n", err)
+		}
+	}()
+
+	// Prepare table of check and their outcome
+	type checkSummary struct {
+		name    string
+		outcome auditCheckOutcome
+	}
+	summaryTable := make([]checkSummary, len(cmd.checks))
+	for i, check := range cmd.checks {
+		// Initialize all to skipped
+		summaryTable[i] = checkSummary{
+			name:    check.checkName,
+			outcome: Skipped,
+		}
+	}
+	// Always print summary on exit
+	defer func() {
+		fmt.Printf("\nSummary:\n")
+		for _, s := range summaryTable {
+			fmt.Printf("%s: %s\n", s.outcome.badge(), s.name)
+		}
+	}()
+
+	// Run all configured checks
+	for i, check := range cmd.checks {
+		cmd.logDebug("Running check: %s", check.checkName)
+		cmd.resetExampleIssues()
+		outcome, err := check.checkFunc(ar)
+		if err != nil {
+			return fmt.Errorf("check '%s' error: %w", check.checkName, err)
+		}
+		if len(cmd.exampleIssues) > 0 {
+			for _, example := range cmd.exampleIssues {
+				// NOTE: Do not use printf here or percentage signs in the string will be (wrongly) interpreted.
+				// Must print string as-is with println or similar.
+				fmt.Println("   - " + example)
+			}
+			if cmd.omittedExampleIssues > 0 {
+				fmt.Printf("   - ...%d more...\n", cmd.omittedExampleIssues)
+			}
+		}
+		summaryTable[i].outcome = outcome
+	}
+
+	return nil
+}
+
+// checkServerVersions verify all known servers are running the same software version
+func (cmd *auditAnalyzeCmd) checkServerVersions(r *archive.Reader) (auditCheckOutcome, error) {
+	versionsToServersMap := make(map[string][]string)
+
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var serverVarz server.Varz
+
+			err := r.Load(&serverVarz, clusterTag, serverTag, archive.TagServerVars())
+			if errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'VARZ' is missing for server %s", serverName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load variables for server %s: %w", serverTag.Value, err)
+			}
+
+			version := serverVarz.Version
+
+			_, exists := versionsToServersMap[version]
+			if !exists {
+				// First time encountering this version, create map entry
+				versionsToServersMap[version] = []string{}
+				// Add one example server for each version
+				cmd.addExampleIssue("%s - %s", serverName, version)
+			}
+			// Add this server to the list running this version
+			versionsToServersMap[version] = append(versionsToServersMap[version], serverName)
+		}
+	}
+
+	if len(versionsToServersMap) == 0 {
+		cmd.logWarning("No servers version information found")
+		return Skipped, nil
+	} else if len(versionsToServersMap) > 1 {
+		cmd.logIssue("Servers are running %d different versions", len(versionsToServersMap))
+		return SomeIssues, nil
+	}
+
+	// Map contains exactly one element
+	cmd.resetExampleIssues()
+	var version string
+	for v := range versionsToServersMap {
+		version = v
+		break
+	}
+
+	cmd.logInfo("All servers are running version %s", version)
+	return Pass, nil
+}
+
+// checkServerHealth verify all known servers are reporting healthy
+func (cmd *auditAnalyzeCmd) checkServerHealth(r *archive.Reader) (auditCheckOutcome, error) {
+	notHealthy, healthy := 0, 0
+
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var health server.HealthStatus
+
+			err := r.Load(&health, clusterTag, serverTag, archive.TagServerHealth())
+			if errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'HEALTHZ' is missing for server %s", serverName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load health for server %s: %w", serverName, err)
+			}
+
+			if health.Status != "ok" {
+				cmd.addExampleIssue("%s: %d - %s", serverName, health.StatusCode, health.Status)
+				notHealthy += 1
+			} else {
+				healthy += 1
+			}
+		}
+	}
+
+	if notHealthy > 0 {
+		cmd.logIssue("%d/%d servers are not healthy", notHealthy, healthy+notHealthy)
+		return SomeIssues, nil
+	}
+
+	cmd.logInfo("%d/%d servers are healthy", healthy, healthy)
+	return Pass, nil
+}
+
+// checkSlowConsumers alert for any server that is reporting slow consumers
+func (cmd *auditAnalyzeCmd) checkSlowConsumers(r *archive.Reader) (auditCheckOutcome, error) {
+
+	totalSlowConsumers := int64(0)
+
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var serverVarz server.Varz
+			err := r.Load(&serverVarz, clusterTag, serverTag, archive.TagServerVars())
+			if err != nil {
+				return Skipped, fmt.Errorf("failed to load Varz for server %s: %w", serverName, err)
+			}
+
+			if slowConsumers := serverVarz.SlowConsumers; slowConsumers > 0 {
+				cmd.addExampleIssue("%s/%s: %d slow consumers", clusterName, serverName, slowConsumers)
+				totalSlowConsumers += slowConsumers
+			}
+		}
+	}
+
+	if totalSlowConsumers > 0 {
+		cmd.logIssue("Total slow consumers: %d", totalSlowConsumers)
+		return SomeIssues, nil
+	}
+
+	cmd.logInfo("No slow consumers detected")
+	return Pass, nil
+}
+
+// checkClusterMemoryUsageOutliers calculates per-cluster memory usage and warns if any server in the cluster is using
+// significantly more
+func (cmd *auditAnalyzeCmd) checkClusterMemoryUsageOutliers(r *archive.Reader) (auditCheckOutcome, error) {
+	const (
+		outlierThreshold = 1.5 // Warn if one node is using over >1.5X the cluster average
+	)
+
+	typeTag := archive.TagServerVars()
+	clusterNames := r.GetClusterNames()
+
+	clustersWithIssuesMap := make(map[string]any, len(clusterNames))
+
+	for _, clusterName := range clusterNames {
+		clusterTag := archive.TagCluster(clusterName)
+
+		serverNames := r.GetClusterServerNames(clusterName)
+		clusterMemoryUsageMap := make(map[string]float64, len(serverNames))
+		clusterMemoryUsageTotal := float64(0)
+		numServers := 0 // cannot use len(serverNames) as some artifacts may be missing
+
+		for _, serverName := range serverNames {
+			serverTag := archive.TagServer(serverName)
+
+			var serverVarz server.Varz
+			err := r.Load(&serverVarz, clusterTag, serverTag, typeTag)
+			if errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'VARZ' is missing for server %s in cluster %s", serverName, clusterName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load VARZ for server %s in cluster %s: %w", serverName, clusterName, err)
+			}
+
+			numServers += 1
+			clusterMemoryUsageMap[serverTag.Value] = float64(serverVarz.Mem)
+			clusterMemoryUsageTotal += float64(serverVarz.Mem)
+		}
+
+		clusterMemoryUsageMean := clusterMemoryUsageTotal / float64(numServers)
+		threshold := clusterMemoryUsageMean * outlierThreshold
+
+		for serverName, serverMemoryUsage := range clusterMemoryUsageMap {
+			if serverMemoryUsage > threshold {
+				cmd.addExampleIssue(
+					"Cluster %s avg: %s, server %s: %s",
+					clusterName,
+					fiBytes(uint64(clusterMemoryUsageMean)),
+					serverName,
+					fiBytes(uint64(serverMemoryUsage)),
+				)
+				clustersWithIssuesMap[clusterName] = nil
+			}
+		}
+	}
+
+	if len(clustersWithIssuesMap) > 0 {
+		cmd.logIssue(
+			"Servers with memory usage above %.1fX the cluster average: %d in %d clusters",
+			outlierThreshold,
+			cmd.examplesIssuesCount(),
+			len(clustersWithIssuesMap),
+		)
+		return SomeIssues, nil
+	}
+	return Pass, nil
+}
+
+// checkLaggingStreamReplicas for each stream check if some replicas is too far behind the newest replica, using lastSeq
+func (cmd *auditAnalyzeCmd) checkLaggingStreamReplicas(r *archive.Reader) (auditCheckOutcome, error) {
+	const (
+		lastSequenceLagThreshold = 0.1 // Warn if 10% or more behind highest known lastSeq
+	)
+
+	typeTag := archive.TagStreamInfo()
+	accountNames := r.GetAccountNames()
+
+	if len(accountNames) == 0 {
+		cmd.logInfo("No accounts found in archive")
+	}
+
+	accountsWithStreams := make(map[string]any)
+	streamsInspected := make(map[string]any)
+	laggingReplicas := 0
+
+	for _, accountName := range accountNames {
+		accountTag := archive.TagAccount(accountName)
+		streamNames := r.GetAccountStreamNames(accountName)
+
+		if len(streamNames) == 0 {
+			cmd.logDebug("No streams found in account: %s", accountName)
+		}
+
+		for _, streamName := range streamNames {
+
+			// Track accounts with at least one streams
+			accountsWithStreams[accountName] = nil
+
+			streamTag := archive.TagStream(streamName)
+			serverNames := r.GetStreamServerNames(accountName, streamName)
+
+			cmd.logDebug(
+				"Inspecting account '%s' stream '%s', found %d servers: %v",
+				accountName,
+				streamName,
+				len(serverNames),
+				serverNames,
+			)
+
+			// Create map server->streamDetails
+			replicasStreamDetails := make(map[string]*server.StreamDetail, len(serverNames))
+			streamIsEmpty := true
+
+			for _, serverName := range serverNames {
+				serverTag := archive.TagServer(serverName)
+				streamDetails := &server.StreamDetail{}
+				err := r.Load(streamDetails, accountTag, streamTag, serverTag, typeTag)
+				if errors.Is(err, archive.ErrNoMatches) {
+					cmd.logWarning(
+						"Artifact not found: %s for stream %s in account %s by server %s",
+						typeTag.Value,
+						streamName,
+						accountName,
+						serverName,
+					)
+					continue
+				} else if err != nil {
+					return Skipped, fmt.Errorf("failed to lookup stream artifact: %w", err)
+				}
+
+				if streamDetails.State.LastSeq > 0 {
+					streamIsEmpty = false
+				}
+
+				replicasStreamDetails[serverName] = streamDetails
+				// Track streams with least one artifact
+				streamsInspected[accountName+"/"+streamName] = nil
+			}
+
+			// Check that all replicas are not too far behind the replica with the highest message & byte count
+			if !streamIsEmpty {
+				// Find the highest lastSeq
+				highestLastSeq, highestLastSeqServer := uint64(0), ""
+				for serverName, streamDetail := range replicasStreamDetails {
+					lastSeq := streamDetail.State.LastSeq
+					if lastSeq > highestLastSeq {
+						highestLastSeq = lastSeq
+						highestLastSeqServer = serverName
+					}
+				}
+				cmd.logDebug(
+					"Stream %s / %s highest last sequence: %d @ %s",
+					accountName,
+					streamName,
+					highestLastSeq,
+					highestLastSeqServer,
+				)
+
+				// Check if some server's sequence is below warning threshold
+				maxDelta := uint64(float64(highestLastSeq) * lastSequenceLagThreshold)
+				threshold := uint64(0)
+				if maxDelta <= highestLastSeq {
+					threshold = highestLastSeq - maxDelta
+				}
+				for serverName, streamDetail := range replicasStreamDetails {
+					lastSeq := streamDetail.State.LastSeq
+					if lastSeq < threshold {
+						cmd.addExampleIssue(
+							"%s/%s server %s lastSequence: %d is behind highest lastSequence: %d on server: %s",
+							accountName,
+							streamName,
+							serverName,
+							lastSeq,
+							highestLastSeq,
+							highestLastSeqServer,
+						)
+						laggingReplicas += 1
+					}
+				}
+			}
+		}
+	}
+
+	cmd.logInfo("Inspected %d streams across %d accounts", len(streamsInspected), len(accountsWithStreams))
+
+	if laggingReplicas > 0 {
+		cmd.logIssue("Found %d replicas lagging behind", laggingReplicas)
+		return SomeIssues, nil
+	}
+	return Pass, nil
+}
+
+// checkCpuUsage verify that CPU usage is below a certain threshold for all known servers
+func (cmd *auditAnalyzeCmd) checkCpuUsage(r *archive.Reader) (auditCheckOutcome, error) {
+	const (
+		cpuThreshold = 0.9 // Warn using >90% CPU
+	)
+
+	severVarsTag := archive.TagServerVars()
+
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+			var serverVarz server.Varz
+			if err := r.Load(&serverVarz, serverTag, clusterTag, severVarsTag); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'VARZ' is missing for server %s", serverName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load VARZ for server %s: %w", serverName, err)
+			}
+
+			// Example: 350% usage with 4 cores => 87.5% averaged
+			averageCpuUtilization := serverVarz.CPU / float64(serverVarz.Cores)
+
+			if averageCpuUtilization > cpuThreshold {
+				cmd.addExampleIssue("%s - %s: %.1f%%", clusterName, serverName, averageCpuUtilization)
+			}
+		}
+	}
+
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d servers with high CPU usage", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// checkHighSubjectCardinalityStreams verify that the number of unique subjects is below some magic number for each known stream
+func (cmd *auditAnalyzeCmd) checkHighSubjectCardinalityStreams(r *archive.Reader) (auditCheckOutcome, error) {
+	const (
+		numSubjectsThreshold = 1_000_000 // Warn if a stream has >1M unique subjects
+	)
+
+	streamDetailsTag := archive.TagStreamInfo()
+
+	for _, accountName := range r.GetAccountNames() {
+		accountTag := archive.TagAccount(accountName)
+
+		for _, streamName := range r.GetAccountStreamNames(accountName) {
+			streamTag := archive.TagStream(streamName)
+
+			serverNames := r.GetStreamServerNames(accountName, streamName)
+			for _, serverName := range serverNames {
+				serverTag := archive.TagServer(serverName)
+
+				var streamDetails server.StreamDetail
+				if err := r.Load(&streamDetails, serverTag, accountTag, streamTag, streamDetailsTag); errors.Is(err, archive.ErrNoMatches) {
+					cmd.logWarning("Artifact 'STREAM_DETAILS' is missing for stream %s in account %s", streamName, accountName)
+					continue
+				} else if err != nil {
+					return Skipped, fmt.Errorf("failed to load STREAM_DETAILS for stream %s in account %s: %w", streamName, accountName, err)
+				}
+
+				if streamDetails.State.NumSubjects > numSubjectsThreshold {
+					cmd.addExampleIssue("%s/%s: %d subjects", accountName, streamName, streamDetails.State.NumSubjects)
+					continue // no need to check other servers for this stream
+				}
+			}
+		}
+	}
+
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d streams with high subjects cardinality", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// checkHighHAAssetCardinality verify that the number of HA assets is below some magic number for each known server
+func (cmd *auditAnalyzeCmd) checkHighHAAssetCardinality(r *archive.Reader) (auditCheckOutcome, error) {
+	const (
+		haAssetsThreshold = 1000 // Warn if a server has more than 1000 HA assets
+	)
+
+	jsTag := archive.TagServerJetStream()
+
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var serverJSInfo server.JSInfo
+			if err := r.Load(&serverJSInfo, clusterTag, serverTag, jsTag); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'JSZ' is missing for server %s cluster %s", serverName, clusterName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load JSZ for server %s: %w", serverName, err)
+			}
+
+			if serverJSInfo.HAAssets > haAssetsThreshold {
+				cmd.addExampleIssue("%s: %d HA assets", serverName, serverJSInfo.HAAssets)
+			}
+		}
+	}
+
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d servers with high a large amount of HA assets", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// checkResourceLimits verify that the resource usage is not approaching the maximum reserved (memory and store) for
+// each known server
+func (cmd *auditAnalyzeCmd) checkResourceLimits(r *archive.Reader) (auditCheckOutcome, error) {
+	const (
+		usageThreshold = 0.90 // Warn if usage is 90% of reserved
+	)
+
+	jsTag := archive.TagServerJetStream()
+
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var serverJSInfo server.JSInfo
+			if err := r.Load(&serverJSInfo, clusterTag, serverTag, jsTag); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'JSZ' is missing for server %s cluster %s", serverName, clusterName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load JSZ for server %s: %w", serverName, err)
+			}
+
+			if serverJSInfo.ReservedMemory > 0 {
+				threshold := uint64(float64(serverJSInfo.ReservedMemory) * usageThreshold)
+				if serverJSInfo.Memory > threshold {
+					cmd.addExampleIssue("%s memory usage: %s of %s", serverName, fiBytes(serverJSInfo.Memory), fiBytes(serverJSInfo.ReservedMemory))
+				}
+			}
+
+			if serverJSInfo.ReservedStore > 0 {
+				threshold := uint64(float64(serverJSInfo.ReservedStore) * usageThreshold)
+				if serverJSInfo.Store > threshold {
+					cmd.addExampleIssue("%s store usage: %s of %s", serverName, fiBytes(serverJSInfo.Store), fiBytes(serverJSInfo.ReservedStore))
+				}
+			}
+		}
+	}
+
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d instances of server near reserved usage limit", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// checkAccountLimits verify that the number of connections & subscriptions is not approaching the limit for
+// each server in each known account
+func (cmd *auditAnalyzeCmd) checkAccountLimits(r *archive.Reader) (auditCheckOutcome, error) {
+	const (
+		connectionsThreshold   = 0.9 // 90% of limit
+		subscriptionsThreshold = 0.9 // 90% of limit
+	)
+
+	// Check value against limit threshold, create example if exceeded
+	checkLimit := func(limitName, serverName, accountName string, value, limit int64, percentThreshold float64) {
+		if limit <= 0 {
+			// Limit not set
+			return
+		}
+		threshold := int64(float64(limit) * percentThreshold)
+		if value > threshold {
+			cmd.addExampleIssue(
+				"account %s (on %s) using %.1f%% of %s limit (%d/%d)",
+				accountName,
+				serverName,
+				float64(value)*100/float64(limit),
+				limitName,
+				value,
+				limit,
+			)
+		}
+	}
+
+	accountsTag := archive.TagServerAccounts()
+	accountDetailsTag := archive.TagAccountInfo()
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var accountz server.Accountz
+			if err := r.Load(&accountz, clusterTag, serverTag, accountsTag); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'ACCOUNTZ' is missing for server %s cluster %s", serverName, clusterName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load ACCOUNTZ for server %s: %w", serverName, err)
+			}
+
+			for _, accountName := range accountz.Accounts {
+				accountTag := archive.TagAccount(accountName)
+
+				var accountInfo server.AccountInfo
+				if err := r.Load(&accountInfo, serverTag, accountTag, accountDetailsTag); errors.Is(err, archive.ErrNoMatches) {
+					cmd.logWarning("Account details is missing for account %s, server %s", accountName, serverName)
+					continue
+				} else if err != nil {
+					return Skipped, fmt.Errorf("failed to load Account details from server %s for account %s, error: %w", serverTag.Value, accountName, err)
+				}
+
+				if accountInfo.Claim == nil {
+					// Can't check limits without a claim
+					continue
+				}
+
+				checkLimit(
+					"client connections",
+					serverTag.Value,
+					accountName,
+					int64(accountInfo.ClientCnt),
+					accountInfo.Claim.Limits.Conn,
+					connectionsThreshold,
+				)
+
+				checkLimit(
+					"client connections (account)",
+					serverTag.Value,
+					accountName,
+					int64(accountInfo.ClientCnt),
+					accountInfo.Claim.Limits.AccountLimits.Conn,
+					connectionsThreshold,
+				)
+
+				checkLimit(
+					"leaf connections",
+					serverTag.Value,
+					accountName,
+					int64(accountInfo.LeafCnt),
+					accountInfo.Claim.Limits.LeafNodeConn,
+					connectionsThreshold,
+				)
+
+				checkLimit(
+					"leaf connections (account)",
+					serverTag.Value,
+					accountName,
+					int64(accountInfo.LeafCnt),
+					accountInfo.Claim.Limits.AccountLimits.LeafNodeConn,
+					connectionsThreshold,
+				)
+
+				checkLimit(
+					"subscriptions",
+					serverTag.Value,
+					accountName,
+					int64(accountInfo.SubCnt),
+					accountInfo.Claim.Limits.Subs,
+					subscriptionsThreshold,
+				)
+			}
+		}
+	}
+
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d instances of accounts approaching limit", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// checkAccountLimits verify that the number of messages/bytes/consumers is not approaching the limit for
+// each known stream
+func (cmd *auditAnalyzeCmd) checkStreamLimits(r *archive.Reader) (auditCheckOutcome, error) {
+	const (
+		messagesThreshold  = 0.9 // Alert if >90% of limit
+		bytesThreshold     = 0.9 // Alert if >90% of limit
+		consumersThreshold = 0.9 // Alert if >90% of limit
+	)
+
+	// Check value against limit threshold, create example if exceeded
+	checkLimit := func(limitName, accountName, streamName, serverName string, value, limit int64, percentThreshold float64) {
+		if limit <= 0 {
+			// Limit not set
+			return
+		}
+		threshold := int64(float64(limit) * percentThreshold)
+		if value > threshold {
+			cmd.addExampleIssue(
+				"stream %s (in %s on %s) using %.1f%% of %s limit (%d/%d)",
+				streamName,
+				accountName,
+				serverName,
+				float64(value)*100/float64(limit),
+				limitName,
+				value,
+				limit,
+			)
+		}
+	}
+
+	streamDetailsTag := archive.TagStreamInfo()
+
+	for _, accountName := range r.GetAccountNames() {
+		accountTag := archive.TagAccount(accountName)
+
+		for _, streamName := range r.GetAccountStreamNames(accountName) {
+			streamTag := archive.TagStream(streamName)
+
+			serverNames := r.GetStreamServerNames(accountName, streamName)
+			for _, serverName := range serverNames {
+				serverTag := archive.TagServer(serverName)
+
+				var streamDetails server.StreamDetail
+				if err := r.Load(&streamDetails, serverTag, accountTag, streamTag, streamDetailsTag); errors.Is(err, archive.ErrNoMatches) {
+					cmd.logWarning("Artifact 'STREAM_DETAILS' is missing for stream %s in account %s", streamName, accountName)
+					continue
+				} else if err != nil {
+					return Skipped, fmt.Errorf("failed to load STREAM_DETAILS for stream %s in account %s: %w", streamName, accountName, err)
+				}
+
+				checkLimit(
+					"messages",
+					accountName,
+					streamName,
+					serverName,
+					int64(streamDetails.State.Msgs),
+					streamDetails.Config.MaxMsgs,
+					messagesThreshold,
+				)
+
+				checkLimit(
+					"bytes",
+					accountName,
+					streamName,
+					serverName,
+					int64(streamDetails.State.Bytes),
+					streamDetails.Config.MaxBytes,
+					bytesThreshold,
+				)
+
+				checkLimit(
+					"consumers",
+					accountName,
+					streamName,
+					serverName,
+					int64(streamDetails.State.Consumers),
+					int64(streamDetails.Config.MaxConsumers),
+					consumersThreshold,
+				)
+			}
+		}
+	}
+
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d instances of streams approaching limit", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// checkMetaClusterOfflineReplicas verify that all meta-cluster replicas are online for each known cluster
+func (cmd *auditAnalyzeCmd) checkMetaClusterOfflineReplicas(r *archive.Reader) (auditCheckOutcome, error) {
+	serverVarsTag := archive.TagServerVars()
+	jsTag := archive.TagServerJetStream()
+
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var jetStreamInfo server.JSInfo
+			if err := r.Load(&jetStreamInfo, clusterTag, serverTag, jsTag); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'JSZ' is missing for server %s cluster %s", serverName, clusterName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load JSZ for server %s: %w", serverName, err)
+			}
+
+			if jetStreamInfo.Disabled {
+				continue
+			}
+
+			var serverVarz server.Varz
+			if err := r.Load(&serverVarz, clusterTag, serverTag, serverVarsTag); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'VARZ' is missing for server %s cluster %s", serverName, clusterName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load VARZ for server %s: %w", serverName, err)
+			}
+
+			if serverVarz.JetStream.Meta == nil {
+				cmd.logWarning("%s / %s does not have meta group info", clusterName, serverName)
+				continue
+			}
+
+			for _, peerInfo := range serverVarz.JetStream.Meta.Replicas {
+				if peerInfo.Offline {
+					cmd.addExampleIssue(
+						"%s - %s reports meta peer %s as offline",
+						clusterName,
+						serverName,
+						peerInfo.Name,
+					)
+				}
+			}
+
+		}
+	}
+
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d instance of replicas disagreeing on meta-cluster leader", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// checkMetaClusterLeader verify that all server agree on the same meta group leader in each known cluster
+func (cmd *auditAnalyzeCmd) checkMetaClusterLeader(r *archive.Reader) (auditCheckOutcome, error) {
+	serverVarsTag := archive.TagServerVars()
+	jsTag := archive.TagServerJetStream()
+
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+		leaderFollowers := make(map[string][]string)
+
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var jetStreamInfo server.JSInfo
+			if err := r.Load(&jetStreamInfo, clusterTag, serverTag, jsTag); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'JSZ' is missing for server %s cluster %s", serverName, clusterName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load JSZ for server %s: %w", serverName, err)
+			}
+
+			if jetStreamInfo.Disabled {
+				continue
+			}
+
+			var serverVarz server.Varz
+			if err := r.Load(&serverVarz, clusterTag, serverTag, serverVarsTag); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'VARZ' is missing for server %s cluster %s", serverName, clusterName)
+				continue
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load VARZ for server %s: %w", serverName, err)
+			}
+
+			if serverVarz.JetStream.Meta == nil {
+				cmd.logWarning("%s / %s does not have meta group info", clusterName, serverName)
+				continue
+			}
+
+			leader := serverVarz.JetStream.Meta.Leader
+			if leader == "" {
+				leader = "NO_LEADER"
+			}
+
+			_, present := leaderFollowers[leader]
+			if !present {
+				leaderFollowers[leader] = make([]string, 0)
+			}
+			leaderFollowers[leader] = append(leaderFollowers[leader], serverName)
+		}
+
+		if len(leaderFollowers) > 1 {
+			cmd.addExampleIssue("Members of %s disagree on meta leader (%v)", clusterName, leaderFollowers)
+		}
+	}
+
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d instance of replicas disagreeing on meta-cluster leader", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// checkConfiguredGateways verify that configured gateways match within all servers of each cluster
+func (cmd *auditAnalyzeCmd) checkConfiguredGateways(r *archive.Reader) (auditCheckOutcome, error) {
+	for _, clusterName := range r.GetClusterNames() {
+		clusterTag := archive.TagCluster(clusterName)
+
+		// For each cluster, build a map where they key is a server name in the cluster
+		// And the value is a list of configured remote target clusters
+		configuredOutboundGateways := make(map[string][]string)
+		configuredInboundGateways := make(map[string][]string)
+		for _, serverName := range r.GetClusterServerNames(clusterName) {
+			serverTag := archive.TagServer(serverName)
+
+			var gateways server.Gatewayz
+			if err := r.Load(&gateways, clusterTag, serverTag, archive.TagServerGateways()); errors.Is(err, archive.ErrNoMatches) {
+				cmd.logWarning("Artifact 'GATEWAYZ' is missing for server %s cluster %s", serverName, clusterName)
+			} else if err != nil {
+				return Skipped, fmt.Errorf("failed to load GATEWAYZ for server %s: %w", serverName, err)
+			}
+
+			// Create list of configured outbound gateways for this server
+			serverConfiguredOutboundGateways := make([]string, 0, len(gateways.OutboundGateways))
+			for targetClusterName, outboundGateway := range gateways.OutboundGateways {
+				if outboundGateway.IsConfigured {
+					serverConfiguredOutboundGateways = append(serverConfiguredOutboundGateways, targetClusterName)
+				}
+			}
+
+			// Create list of configured inbound gateways for this server
+			serverConfiguredInboundGateways := make([]string, 0, len(gateways.OutboundGateways))
+			for sourceClusterName, inboundGateways := range gateways.InboundGateways {
+				for _, inboundGateway := range inboundGateways {
+					if inboundGateway.IsConfigured {
+						serverConfiguredInboundGateways = append(serverConfiguredInboundGateways, sourceClusterName)
+						break
+					}
+				}
+			}
+
+			// Sort the lists for easier comparison later
+			sort.Strings(serverConfiguredOutboundGateways)
+			sort.Strings(serverConfiguredInboundGateways)
+			// Store for later comparison against other servers in the cluster
+			configuredOutboundGateways[serverName] = serverConfiguredOutboundGateways
+			configuredInboundGateways[serverName] = serverConfiguredInboundGateways
+		}
+
+		gatewayTypes := []struct {
+			gatewayType        string
+			configuredGateways map[string][]string
+		}{
+			{"inbound", configuredInboundGateways},
+			{"outbound", configuredOutboundGateways},
+		}
+
+		for _, t := range gatewayTypes {
+			// Check each server configured gateways against another server in the same cluster
+			var previousServerName string
+			var previousTargetClusterNames []string
+			for serverName, targetClusterNames := range t.configuredGateways {
+				if previousTargetClusterNames != nil {
+					cmd.logDebug(
+						"Cluster %s - Comparing configured %s gateways of %s (%d) to %s (%d)",
+						clusterName,
+						t.gatewayType,
+						serverName,
+						len(targetClusterNames),
+						previousServerName,
+						len(previousTargetClusterNames),
+					)
+					if !reflect.DeepEqual(targetClusterNames, previousTargetClusterNames) {
+						cmd.addExampleIssue(
+							"Cluster %s, %s gateways server %s: %v != server %s: %v",
+							clusterName,
+							t.gatewayType,
+							serverName,
+							targetClusterNames,
+							previousServerName,
+							previousTargetClusterNames,
+						)
+					}
+				}
+				previousServerName = serverName
+				previousTargetClusterNames = targetClusterNames
+			}
+		}
+	}
+	if cmd.examplesIssuesCount() > 0 {
+		cmd.logIssue("Found %d instance of gateways configurations mismatch", cmd.examplesIssuesCount())
+		return SomeIssues, nil
+	}
+
+	return Pass, nil
+}
+
+// logIssue for issues that need attention that need to be addressed
+func (cmd *auditAnalyzeCmd) logIssue(format string, a ...any) {
+	fmt.Printf("(!) "+format+"\n", a...)
+}
+
+// logInfo for neutral and positive messages
+func (cmd *auditAnalyzeCmd) logInfo(format string, a ...any) {
+	fmt.Printf(format+"\n", a...)
+}
+
+// logWarning for issues running the check itself, but not serious enough to terminate with an error
+func (cmd *auditAnalyzeCmd) logWarning(format string, a ...any) {
+	fmt.Printf("Warning: "+format+"\n", a...)
+}
+
+// logDebug for very fine grained progress, disabled by default
+func (cmd *auditAnalyzeCmd) logDebug(format string, a ...any) {
+	if cmd.veryVerbose {
+		fmt.Printf("(DEBUG) "+format+"\n", a...)
+	}
+}
+
+func (cmd *auditAnalyzeCmd) resetExampleIssues() {
+	cmd.exampleIssues = make([]string, 0)
+	cmd.omittedExampleIssues = 0
+}
+
+func (cmd *auditAnalyzeCmd) examplesIssuesCount() int {
+	return len(cmd.exampleIssues) + cmd.omittedExampleIssues
+}
+
+func (cmd *auditAnalyzeCmd) addExampleIssue(format string, a ...any) {
+	if cmd.exampleIssuesLimit == 0 || len(cmd.exampleIssues) < int(cmd.exampleIssuesLimit) {
+		cmd.exampleIssues = append(cmd.exampleIssues, fmt.Sprintf(format, a...))
+	} else {
+		cmd.omittedExampleIssues += 1
+	}
+}

--- a/cli/audit_command.go
+++ b/cli/audit_command.go
@@ -1,0 +1,38 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"time"
+)
+
+func configureAuditCommand(app commandHost) {
+	srv := app.Command("audit", "Audit a NATS deployment").Hidden()
+
+	configureAuditGatherCommand(srv)
+	configureAuditAnalyzeCommand(srv)
+}
+
+func init() {
+	registerCommand("audit", 19, configureAuditCommand)
+}
+
+type auditMetadata struct {
+	Timestamp              time.Time `json:"capture_timestamp"`
+	ConnectedServerName    string    `json:"connected_server_name"`
+	ConnectedServerVersion string    `json:"connected_server_version"`
+	ConnectURL             string    `json:"connect_url"`
+	UserName               string    `json:"user_name"`
+	CLIVersion             string    `json:"cli_version"`
+}

--- a/cli/audit_gather_command.go
+++ b/cli/audit_gather_command.go
@@ -1,0 +1,718 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"github.com/choria-io/fisk"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/natscli/archive"
+)
+
+type auditGatherCmd struct {
+	archiveFilePath string
+	progress        bool
+	include         struct {
+		serverEndpoints  bool
+		serverProfiles   bool
+		accountEndpoints bool
+		streams          bool
+		consumers        bool
+	}
+	captureLogWriter       io.Writer
+	serverEndpointConfigs  []auditEndpointCaptureConfig
+	accountEndpointConfigs []auditEndpointCaptureConfig
+	serverProfileNames     []string
+}
+
+// auditEndpointCaptureConfig configuration for capturing and tagging server and account endpoints
+type auditEndpointCaptureConfig struct {
+	apiSuffix     string
+	responseValue any
+	typeTag       *archive.Tag
+}
+
+// serverAPIResponseNoData is a modified version of server.ServerAPIResponse that inhibits deserialization of the
+// `data` field by using `json.RawMessage`. This is necessary because deserializing into a generic object (i.e. map)
+// can cause loss of precision for large numbers.
+type serverAPIResponseNoData struct {
+	Server *server.ServerInfo `json:"server"`
+	Data   json.RawMessage    `json:"data,omitempty"`
+	Error  *server.ApiError   `json:"error,omitempty"`
+}
+
+func configureAuditGatherCommand(srv *fisk.CmdClause) {
+	c := &auditGatherCmd{
+		serverEndpointConfigs: []auditEndpointCaptureConfig{
+			{
+				"VARZ",
+				server.Varz{},
+				archive.TagServerVars(),
+			},
+			{
+				"CONNZ",
+				server.Connz{},
+				archive.TagServerConnections(),
+			},
+			{
+				"ROUTEZ",
+				server.Routez{},
+				archive.TagServerRoutes(),
+			},
+			{
+				"GATEWAYZ",
+				server.Gatewayz{},
+				archive.TagServerGateways(),
+			},
+			{
+				"LEAFZ",
+				server.Leafz{},
+				archive.TagServerLeafs(),
+			},
+			{
+				"SUBSZ",
+				server.Subsz{},
+				archive.TagServerSubs(),
+			},
+			{
+				"JSZ",
+				server.JSInfo{},
+				archive.TagServerJetStream(),
+			},
+			{
+				"ACCOUNTZ",
+				server.Accountz{},
+				archive.TagServerAccounts(),
+			},
+			{
+				"HEALTHZ",
+				server.HealthStatus{},
+				archive.TagServerHealth(),
+			},
+		},
+		accountEndpointConfigs: []auditEndpointCaptureConfig{
+			{
+				"CONNZ",
+				server.Connz{},
+				archive.TagAccountConnections(),
+			},
+			{
+				"LEAFZ",
+				server.Leafz{},
+				archive.TagAccountLeafs(),
+			},
+			{
+				"SUBSZ",
+				server.Subsz{},
+				archive.TagAccountSubs(),
+			},
+			{
+				"INFO",
+				server.AccountInfo{},
+				archive.TagAccountInfo(),
+			},
+			{
+				"JSZ",
+				server.JetStreamStats{},
+				archive.TagAccountJetStream(),
+			},
+		},
+		serverProfileNames: []string{
+			"goroutine",
+			"heap",
+			"allocs",
+		},
+	}
+
+	gather := srv.Command("gather", "capture a variety of data from a deployment into an archive file").Action(c.gather)
+	gather.Flag("output", "output file path of generated archive").Short('o').StringVar(&c.archiveFilePath)
+	gather.Flag("progress", "Display progress messages during gathering").Default("true").BoolVar(&c.progress)
+	gather.Flag("server-endpoints", "Capture monitoring endpoints for each server").Default("true").BoolVar(&c.include.serverEndpoints)
+	gather.Flag("server-profiles", "Capture profiles for each server").Default("true").BoolVar(&c.include.serverProfiles)
+	gather.Flag("account-endpoints", "Capture monitoring endpoints for each account").Default("true").BoolVar(&c.include.accountEndpoints)
+	gather.Flag("streams", "Capture state of each stream").Default("true").BoolVar(&c.include.streams)
+	gather.Flag("consumers", "Capture state of each stream consumers").Default("true").BoolVar(&c.include.consumers)
+}
+
+const auditServerProfilesFileExtension = "prof"
+
+func (c *auditGatherCmd) gather(_ *fisk.ParseContext) error {
+
+	nc, err := newNatsConn("", natsOpts()...)
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	// If no output path is specified, create one
+	if c.archiveFilePath == "" {
+		c.archiveFilePath = filepath.Join(os.TempDir(), "archive.zip")
+	}
+
+	// Gathering prints messages to stdout, but they are also written into this buffer.
+	// A copy of the output is included in the archive itself.
+	var captureLogBuffer bytes.Buffer
+	c.captureLogWriter = &captureLogBuffer
+
+	// Create an archive writer
+	aw, err := archive.NewWriter(c.archiveFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create archive: %w", err)
+	}
+	defer func() {
+		// Add the output of this command (so far) to the archive as additional log artifact
+		if c.captureLogWriter != nil {
+			err = aw.AddRaw(bytes.NewReader(captureLogBuffer.Bytes()), "log", archive.TagSpecial("audit_gather_log"))
+			if err != nil {
+				fmt.Printf("Failed to add capture log: %s\n", err)
+			}
+			c.captureLogWriter = nil
+		}
+
+		err := aw.Close()
+		if err != nil {
+			fmt.Printf("Failed to close archive: %s\n", err)
+		}
+		fmt.Printf("Archive created at: %s\n", c.archiveFilePath)
+	}()
+
+	// Discover servers, create map with servers info
+	serverInfoMap, err := c.discoverServers(nc)
+	if err != nil {
+		return fmt.Errorf("failed to discover servers: %w", err)
+	}
+
+	// Discover accounts, create map with count of server for each account
+	accountIdsToServersCountMap, systemAccount, err := c.discoverAccounts(nc, serverInfoMap)
+	if err != nil {
+		return fmt.Errorf("failed to discover accounts: %w", err)
+	}
+
+	// Capture server endpoints
+	if c.include.serverEndpoints {
+		err := c.captureServerEndpoints(nc, serverInfoMap, aw)
+		if err != nil {
+			return fmt.Errorf("failed to capture server endpoints")
+		}
+	} else {
+		c.logProgress("Skipping servers endpoints data gathering")
+	}
+
+	// Capture server profiles
+	if c.include.serverProfiles {
+		err := c.captureServerProfiles(nc, serverInfoMap, aw)
+		if err != nil {
+			return fmt.Errorf("failed to capture server profiles: %w", err)
+		}
+	} else {
+		c.logProgress("Skipping server profiles gathering")
+	}
+
+	// Capture account endpoints
+	if c.include.accountEndpoints {
+		err := c.captureAccountEndpoints(nc, serverInfoMap, accountIdsToServersCountMap, aw)
+		if err != nil {
+			return fmt.Errorf("failed to capture account endpoints: %w", err)
+		}
+	} else {
+		c.logProgress("Skipping accounts endpoints data gathering")
+	}
+
+	// Discover and capture streams in each account
+	if c.include.streams {
+		c.logProgress("Gathering streams data...")
+		for accountId, numServers := range accountIdsToServersCountMap {
+			// Skip system account, JetStream is probably not enabled
+			if accountId == systemAccount {
+				continue
+			}
+			err := c.captureAccountStreams(nc, serverInfoMap, accountId, numServers, aw)
+			if err != nil {
+				c.logWarning("Failed to capture streams for account %s", accountId)
+			}
+		}
+	} else {
+		c.logProgress("Skipping streams data gathering")
+	}
+
+	// Capture metadata
+	err = c.captureMetadata(nc, aw)
+	if err != nil {
+		return fmt.Errorf("failed to capture metadata: %w", err)
+	}
+
+	return nil
+}
+
+// Discover servers by broadcasting a PING and then collecting responses
+func (c *auditGatherCmd) discoverServers(nc *nats.Conn) (map[string]*server.ServerInfo, error) {
+	var serverInfoMap = make(map[string]*server.ServerInfo)
+	c.logProgress("Broadcasting PING to discover servers... (this may take a few seconds)")
+	err := doReqAsync(nil, "$SYS.REQ.SERVER.PING", 0, nc, func(b []byte) {
+		var apiResponse server.ServerAPIResponse
+		if err := json.Unmarshal(b, &apiResponse); err != nil {
+			c.logWarning("Failed to deserialize PING response: %s", err)
+			return
+		}
+
+		serverId, serverName := apiResponse.Server.ID, apiResponse.Server.Name
+
+		_, exists := serverInfoMap[apiResponse.Server.ID]
+		if exists {
+			c.logWarning("Duplicate server %s (%s) response to PING, ignoring", serverId, serverName)
+			return
+		}
+
+		serverInfoMap[serverId] = apiResponse.Server
+		c.logProgress("Discovered server '%s' (%s)", serverName, serverId)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to gather server responses: %w", err)
+	}
+	c.logProgress("Discovered %d servers", len(serverInfoMap))
+	return serverInfoMap, nil
+}
+
+// Discover accounts by broadcasting a PING and then collecting responses
+func (c *auditGatherCmd) discoverAccounts(nc *nats.Conn, serverInfoMap map[string]*server.ServerInfo) (map[string]int, string, error) {
+	// Broadcast PING.ACCOUNTZ to discover (active) accounts
+	// N.B. Inactive accounts (no connections) cannot be discovered this way
+	c.logProgress("Broadcasting PING to discover accounts... ")
+	var accountIdsToServersCountMap = make(map[string]int)
+	var systemAccount = ""
+	err := doReqAsync(nil, "$SYS.REQ.SERVER.PING.ACCOUNTZ", len(serverInfoMap), nc, func(b []byte) {
+		var apiResponse serverAPIResponseNoData
+		err := json.Unmarshal(b, &apiResponse)
+		if err != nil {
+			c.logWarning("Failed to deserialize accounts response, ignoring")
+			return
+		}
+
+		serverId, serverName := apiResponse.Server.ID, apiResponse.Server.Name
+
+		// Ignore responses from servers not discovered earlier.
+		// We are discarding useful data, but limiting additional collection to a fixed set of nodes
+		// simplifies querying and analysis. Could always re-run gather if a new server just joined.
+		if _, serverKnown := serverInfoMap[serverId]; !serverKnown {
+			c.logWarning("Ignoring accounts response from unknown server: %s", serverName)
+			return
+		}
+
+		var accountsResponse server.Accountz
+		err = json.Unmarshal(apiResponse.Data, &accountsResponse)
+		if err != nil {
+			c.logWarning("Failed to deserialize accounts response body: %s", err)
+			return
+		}
+
+		c.logProgress("Discovered %d accounts on server %s", len(accountsResponse.Accounts), serverName)
+
+		// Track how many servers known any given account
+		for _, accountId := range accountsResponse.Accounts {
+			_, accountKnown := accountIdsToServersCountMap[accountId]
+			if !accountKnown {
+				accountIdsToServersCountMap[accountId] = 0
+			}
+			accountIdsToServersCountMap[accountId] += 1
+		}
+
+		// Track system account (normally, only one for the entire ensemble)
+		if accountsResponse.SystemAccount == "" {
+			c.logWarning("Server %s system account is not set", serverName)
+		} else if systemAccount == "" {
+			systemAccount = accountsResponse.SystemAccount
+			c.logProgress("Discovered system account name: %s", systemAccount)
+		} else if systemAccount != accountsResponse.SystemAccount {
+			// This should not happen under normal circumstances!
+			c.logWarning("Multiple system accounts detected (%s, %s)", systemAccount, accountsResponse.SystemAccount)
+		}
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to discover accounts: %w", err)
+	}
+	c.logProgress("Discovered %d accounts over %d servers", len(accountIdsToServersCountMap), len(serverInfoMap))
+	return accountIdsToServersCountMap, systemAccount, nil
+}
+
+// Capture configured endpoints for each known server
+func (c *auditGatherCmd) captureServerEndpoints(nc *nats.Conn, serverInfoMap map[string]*server.ServerInfo, aw *archive.Writer) error {
+	c.logProgress("Querying %d endpoints on %d known servers...", len(c.serverEndpointConfigs), len(serverInfoMap))
+	capturedCount := 0
+	for serverId, serverInfo := range serverInfoMap {
+		serverName := serverInfo.Name
+		for _, endpoint := range c.serverEndpointConfigs {
+
+			subject := fmt.Sprintf("$SYS.REQ.SERVER.%s.%s", serverId, endpoint.apiSuffix)
+
+			endpointResponse := reflect.New(reflect.TypeOf(endpoint.responseValue)).Interface()
+
+			responses, err := doReq(nil, subject, 1, nc)
+			if err != nil {
+				c.logWarning("Failed to request %s from server %s: %s", endpoint.apiSuffix, serverName, err)
+				continue
+			}
+
+			if len(responses) != 1 {
+				c.logWarning("Unexpected number of responses to %s from server %s: %d", endpoint.apiSuffix, serverName, len(responses))
+				continue
+			}
+
+			responseBytes := responses[0]
+
+			var apiResponse serverAPIResponseNoData
+			if err = json.Unmarshal(responseBytes, &apiResponse); err != nil {
+				c.logWarning("Failed to deserialize %s response from server %s: %s", endpoint.apiSuffix, serverName, err)
+				continue
+			}
+
+			err = json.Unmarshal(apiResponse.Data, endpointResponse)
+			if err != nil {
+				c.logWarning("Failed to deserialize %s response data from server %s: %s", endpoint.apiSuffix, serverName, err)
+				continue
+			}
+
+			tags := []*archive.Tag{
+				archive.TagServer(serverName), // Source server
+				endpoint.typeTag,              // Type of artifact
+			}
+
+			if serverInfo.Cluster != "" {
+				tags = append(tags, archive.TagCluster(serverInfo.Cluster))
+			} else {
+				tags = append(tags, archive.TagNoCluster())
+			}
+
+			err = aw.Add(endpointResponse, tags...)
+			if err != nil {
+				return fmt.Errorf("failed to add endpoint %s response to archive: %w", subject, err)
+			}
+
+			capturedCount += 1
+		}
+	}
+	c.logProgress("Captured %d endpoint responses from %d servers", capturedCount, len(serverInfoMap))
+	return nil
+}
+
+// Capture configured profiles for each known server
+func (c *auditGatherCmd) captureServerProfiles(nc *nats.Conn, serverInfoMap map[string]*server.ServerInfo, aw *archive.Writer) error {
+	c.logProgress("Capturing %d profiles on %d known servers...", len(c.serverProfileNames), len(serverInfoMap))
+	capturedCount := 0
+	for serverId, serverInfo := range serverInfoMap {
+		serverName := serverInfo.Name
+		clusterTag := archive.TagNoCluster()
+		if serverInfo.Cluster != "" {
+			clusterTag = archive.TagCluster(serverInfo.Cluster)
+		}
+
+		for _, profileName := range c.serverProfileNames {
+
+			subject := fmt.Sprintf("$SYS.REQ.SERVER.%s.PROFILEZ", serverId)
+			payload := server.ProfilezOptions{
+				Name:  profileName,
+				Debug: 0,
+			}
+
+			responses, err := doReq(payload, subject, 1, nc)
+			if err != nil {
+				c.logWarning("Failed to request %s profile from server %s: %s", profileName, serverName, err)
+				continue
+			}
+
+			if len(responses) != 1 {
+				c.logWarning("Unexpected number of responses to %s profile from server %s: %d", profileName, serverName, len(responses))
+				continue
+			}
+
+			responseBytes := responses[0]
+
+			var apiResponse struct {
+				Server *server.ServerInfo     `json:"server"`
+				Data   *server.ProfilezStatus `json:"data,omitempty"`
+				Error  *server.ApiError       `json:"error,omitempty"`
+			}
+			if err = json.Unmarshal(responseBytes, &apiResponse); err != nil {
+				c.logWarning("Failed to deserialize %s profile response from server %s: %s", profileName, serverName, err)
+				continue
+			}
+			if apiResponse.Error != nil {
+				c.logWarning("Failed to retrieve %s profile from server %s: %s", profileName, serverName, apiResponse.Error.Description)
+				continue
+			}
+
+			profileStatus := apiResponse.Data
+			if profileStatus.Error != "" {
+				c.logWarning("Failed to retrieve %s profile from server %s: %s", profileName, serverName, profileStatus.Error)
+				continue
+			}
+
+			tags := []*archive.Tag{
+				archive.TagServer(serverName),
+				archive.TagServerProfile(),
+				archive.TagProfileName(profileName),
+				clusterTag,
+			}
+
+			profileDataBytes := apiResponse.Data.Profile
+
+			err = aw.AddRaw(bytes.NewReader(profileDataBytes), auditServerProfilesFileExtension, tags...)
+			if err != nil {
+				return fmt.Errorf("failed to add %s profile from to archive: %w", profileName, err)
+			}
+
+			capturedCount += 1
+		}
+	}
+	c.logProgress("Captured %d server profiles from %d servers", capturedCount, len(serverInfoMap))
+	return nil
+}
+
+// Capture configured endpoints for each known account
+func (c *auditGatherCmd) captureAccountEndpoints(nc *nats.Conn, serverInfoMap map[string]*server.ServerInfo, accountIdsToServersCountMap map[string]int, aw *archive.Writer) error {
+	type Responder struct {
+		ClusterName string
+		ServerName  string
+	}
+	capturedCount := 0
+	c.logProgress("Querying %d endpoints for %d known accounts...", len(c.accountEndpointConfigs), len(accountIdsToServersCountMap))
+	for accountId, serversCount := range accountIdsToServersCountMap {
+		for _, endpoint := range c.accountEndpointConfigs {
+			subject := fmt.Sprintf("$SYS.REQ.ACCOUNT.%s.%s", accountId, endpoint.apiSuffix)
+			endpointResponses := make(map[Responder]any, serversCount)
+
+			err := doReqAsync(nil, subject, serversCount, nc, func(b []byte) {
+				var apiResponse serverAPIResponseNoData
+				err := json.Unmarshal(b, &apiResponse)
+				if err != nil {
+					c.logWarning("Failed to deserialize %s response for account %s: %s", endpoint.apiSuffix, accountId, err)
+					return
+				}
+
+				serverId := apiResponse.Server.ID
+
+				// Ignore responses from servers not discovered earlier.
+				// We are discarding useful data, but limiting additional collection to a fixed set of nodes
+				// simplifies querying and analysis. Could always re-run gather if a new server just joined.
+				if _, serverKnown := serverInfoMap[serverId]; !serverKnown {
+					c.logWarning("Ignoring account %s response from unknown server: %s", endpoint.apiSuffix, serverId)
+					return
+				}
+
+				endpointResponse := reflect.New(reflect.TypeOf(endpoint.responseValue)).Interface()
+				err = json.Unmarshal(apiResponse.Data, endpointResponse)
+				if err != nil {
+					c.logWarning("Failed to deserialize %s response for account %s: %s", endpoint.apiSuffix, accountId, err)
+					return
+				}
+
+				responder := Responder{
+					ClusterName: apiResponse.Server.Cluster,
+					ServerName:  apiResponse.Server.Name,
+				}
+
+				if _, isDuplicateResponse := endpointResponses[responder]; isDuplicateResponse {
+					c.logWarning("Ignoring duplicate account %s response from server %s", endpoint.apiSuffix, responder.ServerName)
+					return
+				}
+
+				endpointResponses[responder] = endpointResponse
+			})
+			if err != nil {
+				c.logWarning("Failed to request %s for account %s: %s", endpoint.apiSuffix, accountId, err)
+				continue
+			}
+
+			// Store all responses for this account endpoint
+			for responder, endpointResponse := range endpointResponses {
+				clusterTag := archive.TagNoCluster()
+				if responder.ClusterName != "" {
+					clusterTag = archive.TagCluster(responder.ClusterName)
+				}
+
+				tags := []*archive.Tag{
+					archive.TagAccount(accountId),
+					archive.TagServer(responder.ServerName),
+					clusterTag,
+					endpoint.typeTag,
+				}
+
+				err = aw.Add(endpointResponse, tags...)
+				if err != nil {
+					return fmt.Errorf("failed to add response to %s to archive: %w", subject, err)
+				}
+
+				capturedCount += 1
+			}
+		}
+	}
+	c.logProgress("Captured %d endpoint responses from %d accounts", capturedCount, len(accountIdsToServersCountMap))
+	return nil
+}
+
+// Discover streams in given account, and capture info for each one
+func (c *auditGatherCmd) captureAccountStreams(nc *nats.Conn, serverInfoMap map[string]*server.ServerInfo, accountId string, numServers int, aw *archive.Writer) error {
+
+	jszOptions := server.JSzOptions{
+		Account:    accountId,
+		Streams:    true,
+		Consumer:   c.include.consumers, // Capture consumers, unless configured to skip
+		Config:     true,
+		RaftGroups: true,
+	}
+
+	jsInfoResponses := make(map[string]*server.JSInfo, numServers)
+	err := doReqAsync(jszOptions, "$SYS.REQ.SERVER.PING.JSZ", numServers, nc, func(b []byte) {
+		var apiResponse serverAPIResponseNoData
+		err := json.Unmarshal(b, &apiResponse)
+		if err != nil {
+			c.logWarning("Failed to deserialize JS info response for account %s: %s", accountId, err)
+			return
+		}
+
+		serverId, serverName := apiResponse.Server.ID, apiResponse.Server.Name
+
+		// Ignore responses from servers not discovered earlier.
+		// We are discarding useful data, but limiting additional collection to a fixed set of nodes
+		// simplifies querying and analysis. Could always re-run gather if a new server just joined.
+		if _, serverKnown := serverInfoMap[serverId]; !serverKnown {
+			c.logWarning("Ignoring JS info response from unknown server: %s", serverName)
+			return
+		}
+
+		if _, isDuplicateResponse := jsInfoResponses[serverName]; isDuplicateResponse {
+			c.logWarning("Ignoring duplicate JS info response for account %s from server %s", accountId, serverName)
+			return
+		}
+
+		jsInfoResponse := &server.JSInfo{}
+		err = json.Unmarshal(apiResponse.Data, jsInfoResponse)
+		if err != nil {
+			c.logWarning("Failed to deserialize JS info response data for account %s: %s", accountId, err)
+			return
+		}
+
+		if len(jsInfoResponse.AccountDetails) == 0 {
+			// No account details in response, don't bother saving this
+			//c.logWarning("🐛 Skip JSZ response from %s, no accounts details", serverName)
+			return
+		} else if len(jsInfoResponse.AccountDetails) > 1 {
+			// Server will respond with multiple accounts if the one specified in the request is not found
+			// https://github.com/nats-io/nats-server/pull/5229
+			//c.logWarning("🐛 Skip JSZ response from %s, account not found", serverName)
+			return
+		}
+
+		jsInfoResponses[serverName] = jsInfoResponse
+	})
+	if err != nil {
+		return fmt.Errorf("failed to retrieve account %s streams: %w", accountId, err)
+	}
+
+	streamNamesSet := make(map[string]any)
+
+	// Capture stream info from each known replica
+	for serverName, jsInfo := range jsInfoResponses {
+		// Cases where len(jsInfo.AccountDetails) != 1 are filtered above
+		accountDetail := jsInfo.AccountDetails[0]
+
+		for _, streamInfo := range accountDetail.Streams {
+			streamName := streamInfo.Name
+
+			_, streamKnown := streamNamesSet[streamName]
+			if !streamKnown {
+				c.logProgress("Discovered stream %s in account %s", streamName, accountId)
+			}
+
+			clusterTag := archive.TagNoCluster()
+			if streamInfo.Cluster != nil {
+				clusterTag = archive.TagCluster(streamInfo.Cluster.Name)
+			}
+
+			tags := []*archive.Tag{
+				archive.TagAccount(accountId),
+				archive.TagServer(serverName),
+				clusterTag,
+				archive.TagStream(streamName),
+				archive.TagStreamInfo(),
+			}
+
+			err = aw.Add(streamInfo, tags...)
+			if err != nil {
+				return fmt.Errorf("failed to add stream %s info to archive: %w", streamName, err)
+			}
+
+			streamNamesSet[streamName] = nil
+		}
+	}
+
+	c.logProgress("Discovered %d streams in account %s", len(streamNamesSet), accountId)
+	return nil
+}
+
+// Capture runtime information about the capture
+func (c *auditGatherCmd) captureMetadata(nc *nats.Conn, aw *archive.Writer) error {
+	{
+		username := "?"
+		currentUser, err := user.Current()
+		if err != nil {
+			c.logWarning("Failed to capture username: %s", err)
+		} else {
+			username = fmt.Sprintf("%s (%s)", currentUser.Username, currentUser.Name)
+		}
+
+		metadata := &auditMetadata{
+			Timestamp:              time.Now(),
+			ConnectedServerName:    nc.ConnectedServerName(),
+			ConnectedServerVersion: nc.ConnectedServerVersion(),
+			ConnectURL:             nc.ConnectedUrl(),
+			UserName:               username,
+			CLIVersion:             Version,
+		}
+
+		err = aw.Add(&metadata, archive.TagSpecial("audit_gather_metadata"))
+		if err != nil {
+			return fmt.Errorf("failed to save metadata: %w", err)
+		}
+	}
+	return nil
+}
+
+// logProgress prints updates to the gathering process. It can be turned off to make capture less verbose.
+// Updates are also tee'd to the capture log
+func (c *auditGatherCmd) logProgress(format string, args ...any) {
+	if c.progress {
+		fmt.Printf(format+"\n", args...)
+	}
+	if c.captureLogWriter != nil {
+		_, _ = fmt.Fprintf(c.captureLogWriter, format+"\n", args...)
+	}
+}
+
+// logWarning prints non-fatal errors during the gathering process. Messages are also tee'd to the capture log
+func (c *auditGatherCmd) logWarning(format string, args ...any) {
+	fmt.Printf("(!) "+format+"\n", args...)
+	if c.captureLogWriter != nil {
+		_, _ = fmt.Fprintf(c.captureLogWriter, format+"\n", args...)
+	}
+}


### PR DESCRIPTION
Add new `audit` command, not fully baked, but useful to gather some initial feedback from users.

2 subcommands:
 - `gather` pulls a number of artifacts from a cluster into a zip-file useful for debugging
 - `analyze` runs a set of checks against a `gather` archive, highlighting potential problems (unhealthy servers, mismatching server versions, resources hitting capacity limits, ...)
 - 