### PR TITLE
adds xkey seal/open functionality to commandline

### DIFF
--- a/cli/auth_nkey_command.go
+++ b/cli/auth_nkey_command.go
@@ -66,7 +66,7 @@ func configureAuthNkeyCommand(auth commandHost) {
 	nkSeal.Arg("key", "NKey to sign with").Required().ExistingFileVar(&c.keyFile)
 	nkSeal.Arg("receipent", "Public XKey of receipient").Required().StringVar(&c.counterpartKey)
 	nkSeal.Flag("output", "Write the encrypted data to a file").StringVar(&c.outFile)
-	nkSeal.Flag("b64", "Write base64 encoded data to stdout").Default("false").UnNegatableBoolVar(&c.b64out)
+	nkSeal.Flag("b64", "Write base64 encoded data [Default]").Default("true").BoolVar(&c.b64out)
 
 	nkOpen := nk.Command("open", "Decrypts file").Alias("decrypt").Alias("dec").Action(c.openAction)
 	nkOpen.Arg("file", "File to decrypt").Required().ExistingFileVar(&c.dataFile)
@@ -300,9 +300,10 @@ func (c *authNKCommand) sealAction(_ *fisk.ParseContext) error {
 			return err
 		}
 		if c.b64out {
-			fmt.Println(base64.StdEncoding.EncodeToString(encryptedData))
-			return nil
-		} else if c.outFile != "" {
+			encryptedData = []byte(base64.StdEncoding.EncodeToString(encryptedData))
+		}
+
+		if c.outFile != "" {
 			f, err := os.Create(c.outFile)
 			if err != nil {
 				return err

--- a/cli/auth_xkey_test.go
+++ b/cli/auth_xkey_test.go
@@ -15,12 +15,16 @@ package cli
 
 import (
 	"crypto/rand"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/nats-io/nkeys"
 )
 
 func TestSealOpen(t *testing.T) {
+	// Create two pairs of xkeys
 	ef := rand.Reader
 	p1, err := nkeys.CreateCurveKeysWithRand(ef)
 	if err != nil {
@@ -32,34 +36,90 @@ func TestSealOpen(t *testing.T) {
 		t.Error("Failed to create key")
 		t.FailNow()
 	}
+	p1_seed, _ := p1.Seed()
+	p2_seed, _ := p2.Seed()
 
-	msg := []byte("Hello World")
-
-	p2_pub, err := p2.PublicKey()
+	// Setup all the test files
+	p1_key, err := os.Create(filepath.Join(os.TempDir(), "p1_seed"))
 	if err != nil {
-		t.Error("Failed to get public key")
+		t.Error("Failed to create test key file")
 		t.FailNow()
 	}
-
-	enc_data, err := p1.Seal(msg, p2_pub)
-	if err != nil || enc_data == nil {
-		t.Error("Failed to seal data")
-		t.FailNow()
-	}
-
-	p1_pub, err := p1.PublicKey()
+	defer p1_key.Close()
+	defer os.RemoveAll(filepath.Join(os.TempDir(), "p1_seed"))
+	err = os.WriteFile(filepath.Join(os.TempDir(), "p1_seed"), p1_seed, 0644)
 	if err != nil {
-		t.Error("Failed to get public key")
-		t.FailNow()
-	}
-	dec_data, err := p2.Open(enc_data, p1_pub)
-	if err != nil {
-		t.Error("Failed to open data")
+		t.Error("Failed to write test key to file")
 		t.FailNow()
 	}
 
-	if string(dec_data) != "Hello World" {
-		t.Error("Decrypted data does not match original")
+	p2_key, err := os.Create(filepath.Join(os.TempDir(), "p2_seed"))
+	if err != nil {
+		t.Error("Failed to create test key file")
 		t.FailNow()
+	}
+	defer p2_key.Close()
+	defer os.RemoveAll(filepath.Join(os.TempDir(), "p2_seed"))
+	err = os.WriteFile(filepath.Join(os.TempDir(), "p2_seed"), p2_seed, 0644)
+	if err != nil {
+		t.Error("Failed to write test key to file")
+		t.FailNow()
+	}
+
+	message, err := os.Create(filepath.Join(os.TempDir(), "message.txt"))
+	if err != nil {
+		t.Error("Failed to create test key file")
+		t.FailNow()
+	}
+	defer message.Close()
+	defer os.RemoveAll(filepath.Join(os.TempDir(), "message.txt"))
+	err = os.WriteFile(filepath.Join(os.TempDir(), "message.txt"), []byte("test"), 0644)
+	if err != nil {
+		t.Error("Failed to write test key to file")
+		t.FailNow()
+	}
+
+	// Get both public keys
+	p1_pub, _ := p1.PublicKey()
+	p2_pub, _ := p2.PublicKey()
+
+	// Setup fisk for Seal Test
+	c := &authNKCommand{}
+	c.b64out = false
+	c.counterpartKey = p2_pub
+	c.dataFile = filepath.Join(os.TempDir(), "message.txt")
+	c.outFile = filepath.Join(os.TempDir(), "message.enc")
+	c.keyFile = filepath.Join(os.TempDir(), "p1_seed")
+
+	err = c.sealAction(nil)
+	if err != nil {
+		t.Error("Failed to seal message")
+		t.FailNow()
+	}
+
+	// Setup fisk for Seal Test
+	c = &authNKCommand{}
+	c.counterpartKey = p1_pub
+	c.dataFile = filepath.Join(os.TempDir(), "message.enc")
+	c.keyFile = filepath.Join(os.TempDir(), "p2_seed")
+
+	// Redirect stdout to capture decrypted output
+	stdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = c.openAction(nil)
+	if err != nil {
+		t.Error("Failed to open message")
+		t.FailNow()
+	}
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	os.Stdout = stdout
+
+	// Test if decrypted output is correct
+	if string(out) != "test\n" {
+		t.Fail()
 	}
 }

--- a/cli/auth_xkey_test.go
+++ b/cli/auth_xkey_test.go
@@ -97,7 +97,7 @@ func TestSealOpen(t *testing.T) {
 		t.FailNow()
 	}
 
-	// Setup fisk for Seal Test
+	// Setup fisk for Open Test
 	c = &authNKCommand{}
 	c.counterpartKey = p1_pub
 	c.dataFile = filepath.Join(os.TempDir(), "message.enc")

--- a/cli/auth_xkey_test.go
+++ b/cli/auth_xkey_test.go
@@ -1,3 +1,16 @@
+// Copyright 2023-2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli
 
 import (

--- a/cli/auth_xkey_test.go
+++ b/cli/auth_xkey_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/nats-io/nkeys"
+)
+
+func TestSealOpen(t *testing.T) {
+	ef := rand.Reader
+	p1, err := nkeys.CreateCurveKeysWithRand(ef)
+	if err != nil {
+		t.Error("Failed to create key")
+		t.FailNow()
+	}
+	p2, err := nkeys.CreateCurveKeysWithRand(ef)
+	if err != nil {
+		t.Error("Failed to create key")
+		t.FailNow()
+	}
+
+	msg := []byte("Hello World")
+
+	p2_pub, err := p2.PublicKey()
+	if err != nil {
+		t.Error("Failed to get public key")
+		t.FailNow()
+	}
+
+	enc_data, err := p1.Seal(msg, p2_pub)
+	if err != nil || enc_data == nil {
+		t.Error("Failed to seal data")
+		t.FailNow()
+	}
+
+	p1_pub, err := p1.PublicKey()
+	if err != nil {
+		t.Error("Failed to get public key")
+		t.FailNow()
+	}
+	dec_data, err := p2.Open(enc_data, p1_pub)
+	if err != nil {
+		t.Error("Failed to open data")
+		t.FailNow()
+	}
+
+	if string(dec_data) != "Hello World" {
+		t.Error("Decrypted data does not match original")
+		t.FailNow()
+	}
+}

--- a/cli/auth_xkey_test.go
+++ b/cli/auth_xkey_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/nats-io/nkeys"
 )
 
-func TestSealOpen(t *testing.T) {
+func TestSealUnseal(t *testing.T) {
 	tDir := t.TempDir()
 	// Create two pairs of xkeys
 	ef := rand.Reader
@@ -110,7 +110,7 @@ func TestSealOpen(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err = c.openAction(nil)
+	err = c.unsealAction(nil)
 	if err != nil {
 		t.Error("Failed to unseal message: " + err.Error())
 		t.FailNow()


### PR DESCRIPTION
Adds the helper command to NATS cli to allow encryptions/decryption via xkeys.

```
└─❯ cat message.txt
hello

└─❯ go run . auth nkey seal message.txt ./my.key XBZ6MJBDOTEIMIEHHFWY2TBGNGOVU7QRMGHDUSOZ5OPJ2EYWCRUB32W4 --output derp.enc

└─❯ cat derp.enc
xkv1����݋i8���fܮ L^T��^K�o�^Y��$U΄�]���^^�F���r-�G

└─❯ go run . auth nkey open derp.enc ./their.key XDBAJQRNSD6OD6A6X66UWNQTQDFJWGDFJBCVKQJSZ5NA2WM7CVYA7UUP
hello
```