### PR TITLE
Add flags to the `sub` command

### DIFF
--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -559,7 +559,7 @@ func (c *subCmd) printMsg(msg *nats.Msg, reply *nats.Msg, ctr uint, startTime ti
 		} else if c.jetStream {
 			fmt.Printf("[#%d] Received JetStream message: stream: %s seq %d / subject: %s / time: %v\n", ctr, info.Stream(), info.StreamSequence(), msg.Subject, info.TimeStamp().Format(time.RFC3339))
 		} else {
-			fmt.Printf("[#%d] Received JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, info.Stream(), info.Consumer(), msg.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
+			fmt.Printf("[#%d]%s Received JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, timeStamp, info.Stream(), info.Consumer(), msg.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
 		}
 
 		if c.subjectsOnly {
@@ -572,7 +572,7 @@ func (c *subCmd) printMsg(msg *nats.Msg, reply *nats.Msg, ctr uint, startTime ti
 			if info == nil {
 				fmt.Printf("[#%d]%s Matched reply on %q\n", ctr, timeStamp, reply.Subject)
 			} else if c.jetStream {
-				fmt.Printf("[#%d]%s Matched reply JetStream message: stream: %s seq %d / subject: %s / time: %v\n", ctr, timeStamp, info.Stream(), info.StreamSequence(), reply.Subject, info.TimeStamp().Format(time.RFC3339))
+				fmt.Printf("[#%d] Matched reply JetStream message: stream: %s seq %d / subject: %s / time: %v\n", ctr, info.Stream(), info.StreamSequence(), reply.Subject, info.TimeStamp().Format(time.RFC3339))
 			} else {
 				fmt.Printf("[#%d]%s Matched reply JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, timeStamp, info.Stream(), info.Consumer(), reply.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
 			}

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -557,13 +557,9 @@ func (c *subCmd) printMsg(msg *nats.Msg, reply *nats.Msg, ctr uint, startTime ti
 				fmt.Printf("[#%d]%s Received on %q\n", ctr, timeStamp, msg.Subject)
 			}
 		} else if c.jetStream {
-			if c.deltaTimeStamps {
-				fmt.Printf("[#%d]%s Received JetStream message: stream: %s seq %d / subject: %s / time: %v\n", ctr, timeStamp, info.Stream(), info.StreamSequence(), msg.Subject, info.TimeStamp().Format(time.RFC3339))
-			} else {
-				fmt.Printf("[#%d] Received JetStream message: stream: %s seq %d / subject: %s / time: %v\n", ctr, info.Stream(), info.StreamSequence(), msg.Subject, info.TimeStamp().Format(time.RFC3339))
-			}
+			fmt.Printf("[#%d] Received JetStream message: stream: %s seq %d / subject: %s / time: %v\n", ctr, info.Stream(), info.StreamSequence(), msg.Subject, info.TimeStamp().Format(time.RFC3339))
 		} else {
-			fmt.Printf("[#%d]%s Received JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, timeStamp, info.Stream(), info.Consumer(), msg.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
+			fmt.Printf("[#%d] Received JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, info.Stream(), info.Consumer(), msg.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
 		}
 
 		if c.subjectsOnly {

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -57,8 +57,8 @@ type subCmd struct {
 	jetStream             bool
 	ignoreSubjects        []string
 	wait                  time.Duration
-	ts                    bool
-	dt                    bool
+	timeStamps            bool
+	deltaTimeStamps       bool
 	sOnly                 bool
 }
 
@@ -78,6 +78,7 @@ func configureSubCommand(app commandHost) {
 	act.Flag("count", "Quit after receiving this many messages").UintVar(&c.limit)
 	act.Flag("dump", "Dump received messages to files, 1 file per message. Specify - for null terminated STDOUT for use with xargs -0").PlaceHolder("DIRECTORY").StringVar(&c.dump)
 	act.Flag("headers-only", "Do not render any data, shows only headers").UnNegatableBoolVar(&c.headersOnly)
+	act.Flag("subjects-only", "Prints only the messages' subjects").UnNegatableBoolVar(&c.sOnly)
 	act.Flag("start-sequence", "Starts at a specific Stream sequence (requires JetStream)").PlaceHolder("SEQUENCE").Uint64Var(&c.sseq)
 	act.Flag("all", "Delivers all messages found in the Stream (requires JetStream").UnNegatableBoolVar(&c.deliverAll)
 	act.Flag("new", "Delivers only future messages (requires JetStream)").UnNegatableBoolVar(&c.deliverNew)
@@ -89,9 +90,8 @@ func configureSubCommand(app commandHost) {
 	act.Flag("wait", "Unsubscribe after this amount of time without any traffic").DurationVar(&c.wait)
 	act.Flag("report-subjects", "Subscribes to a subject pattern and builds a de-duplicated report of active subjects receiving data").UnNegatableBoolVar(&c.reportSubjects)
 	act.Flag("report-top", "Number of subjects to show when doing 'report-subjects'. Default is 10.").Default("10").IntVar(&c.reportSubjectsCount)
-	act.Flag("timestamp", "Show timestamps in output").Short('t').UnNegatableBoolVar(&c.ts)
-	act.Flag("delta-time", "Show delta time in output").Short('d').UnNegatableBoolVar(&c.dt)
-	act.Flag("subjects-only", "Prints only the messages' subjects").UnNegatableBoolVar(&c.sOnly)
+	act.Flag("timestamp", "Show timestamps in output").Short('t').UnNegatableBoolVar(&c.timeStamps)
+	act.Flag("delta-time", "Show time since start in output").Short('d').UnNegatableBoolVar(&c.deltaTimeStamps)
 }
 
 func init() {
@@ -189,7 +189,7 @@ func (c *subCmd) subscribe(p *fisk.ParseContext) error {
 	if c.reportSubjects && c.reportSubjectsCount == 0 {
 		return fmt.Errorf("subject count must be at least one")
 	}
-	if c.ts && c.dt {
+	if c.timeStamps && c.deltaTimeStamps {
 		return fmt.Errorf("timestamp and delta-time flags are mutually exclusive")
 	}
 
@@ -511,9 +511,9 @@ func (c *subCmd) printMsg(msg *nats.Msg, reply *nats.Msg, ctr uint, startTime ti
 	}
 
 	var timeStamp string
-	if c.ts {
+	if c.timeStamps {
 		timeStamp = fmt.Sprintf(" @ %s", time.Now().Format(time.StampMicro))
-	} else if c.dt {
+	} else if c.deltaTimeStamps {
 		timeStamp = fmt.Sprintf(" @ %s", time.Since(startTime).String())
 	}
 
@@ -563,6 +563,8 @@ func (c *subCmd) printMsg(msg *nats.Msg, reply *nats.Msg, ctr uint, startTime ti
 		}
 
 		if !c.sOnly {
+			return
+		} else {
 			prettyPrintMsg(msg, c.headersOnly, c.translate)
 
 			if reply != nil {

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -559,7 +559,7 @@ func (c *subCmd) printMsg(msg *nats.Msg, reply *nats.Msg, ctr uint, startTime ti
 		} else if c.jetStream {
 			fmt.Printf("[#%d] Received JetStream message: stream: %s seq %d / subject: %s / time: %v\n", ctr, info.Stream(), info.StreamSequence(), msg.Subject, info.TimeStamp().Format(time.RFC3339))
 		} else {
-			fmt.Printf("[#%d]%s Received JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, timeStamp, info.Stream(), info.Consumer(), msg.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
+			fmt.Printf("[#%d] Received JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, info.Stream(), info.Consumer(), msg.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
 		}
 
 		if c.subjectsOnly {
@@ -574,7 +574,7 @@ func (c *subCmd) printMsg(msg *nats.Msg, reply *nats.Msg, ctr uint, startTime ti
 			} else if c.jetStream {
 				fmt.Printf("[#%d] Matched reply JetStream message: stream: %s seq %d / subject: %s / time: %v\n", ctr, info.Stream(), info.StreamSequence(), reply.Subject, info.TimeStamp().Format(time.RFC3339))
 			} else {
-				fmt.Printf("[#%d]%s Matched reply JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, timeStamp, info.Stream(), info.Consumer(), reply.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
+				fmt.Printf("[#%d] Matched reply JetStream message: consumer: %s > %s / subject: %s / delivered: %d / consumer seq: %d / stream seq: %d\n", ctr, info.Stream(), info.Consumer(), reply.Subject, info.Delivered(), info.ConsumerSequence(), info.StreamSequence())
 			}
 
 			prettyPrintMsg(reply, c.headersOnly, c.translate)


### PR DESCRIPTION
Adds the following flags to `nats sub`:

- `--subjects-only` only prints the subject for each message received
- `--timestamp` adds a time stamp of when the message is received
- `--delta-time` adds a time since the start of the command of when the message is received