### PR TITLE
Report the storage type used in a `object info` command

### DIFF
--- a/cli/object_command.go
+++ b/cli/object_command.go
@@ -301,6 +301,7 @@ func (c *objCommand) showBucketInfo(store nats.ObjectStore) error {
 			cols.AddRow("Maximum Bucket Size", humanize.IBytes(uint64(nfo.Config.MaxBytes)))
 		}
 	}
+	cols.AddRow("Storage", status.Storage())
 	cols.AddRow("Backing Store Kind", status.BackingStore())
 	if status.BackingStore() == "JetStream" {
 		cols.AddRow("JetStream Stream", nfo.Config.Name)


### PR DESCRIPTION
Using the nats cli, it was hard to tell whether or not a bucket was using a File storage or a Memory storage.

This commit introduces a row that displays the StorageType as reported from the ObjectBucketStatus structure