### PR TITLE
#181 support TLS Insecure connection - added flag --tlsinsecure

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -56,7 +56,7 @@ var (
 
 	// These are persisted by contexts, as properties thereof.
 	// So don't include NATS_CONTEXT in this list.
-	overrideEnvVars = []string{"NATS_URL", "NATS_USER", "NATS_PASSWORD", "NATS_CREDS", "NATS_NKEY", "NATS_CERT", "NATS_KEY", "NATS_CA", "NATS_TIMEOUT", "NATS_SOCKS_PROXY", "NATS_COLOR"}
+	overrideEnvVars = []string{"NATS_URL", "NATS_USER", "NATS_PASSWORD", "NATS_CREDS", "NATS_NKEY", "NATS_CERT", "NATS_KEY", "NATS_CA", "NATS_TIMEOUT", "NATS_SOCKS_PROXY", "NATS_COLOR", "NATS_TLSINSECURE"}
 )
 
 func registerCommand(name string, order int, c func(app commandHost)) {

--- a/cli/util.go
+++ b/cli/util.go
@@ -309,7 +309,15 @@ func natsOpts() []nats.Option {
 	}
 
 	if opts().TlsInsecure {
-		copts = append(copts, nats.Secure(&tls.Config{InsecureSkipVerify: true}))
+		insecureOption := func(o *nats.Options) error {
+			if o.TLSConfig == nil {
+				o.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+			} else {
+				o.TLSConfig.InsecureSkipVerify = true
+			}
+			return nil
+		}
+		copts = append(copts, insecureOption)	
 	}
 
 	return append(copts, []nats.Option{

--- a/cli/util.go
+++ b/cli/util.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -305,6 +306,10 @@ func natsOpts() []nats.Option {
 	connectionName := strings.TrimSpace(opts().ConnectionName)
 	if len(connectionName) == 0 {
 		connectionName = "NATS CLI Version " + Version
+	}
+
+	if opts().TlsInsecure {
+		copts = append(copts, nats.Secure(&tls.Config{InsecureSkipVerify: true}))
 	}
 
 	return append(copts, []nats.Option{

--- a/cli/util.go
+++ b/cli/util.go
@@ -310,6 +310,7 @@ func natsOpts() []nats.Option {
 
 	if opts().TlsInsecure {
 		insecureOption := func(o *nats.Options) error {
+			o.Secure = true
 			if o.TLSConfig == nil {
 				o.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 			} else {

--- a/nats/main.go
+++ b/nats/main.go
@@ -57,6 +57,7 @@ See 'nats cheat' for a quick cheatsheet of commands`
 	ncli.Flag("tlskey", "TLS private key").Envar("NATS_KEY").PlaceHolder("FILE").ExistingFileVar(&opts.TlsKey)
 	ncli.Flag("tlsca", "TLS certificate authority chain").Envar("NATS_CA").PlaceHolder("FILE").ExistingFileVar(&opts.TlsCA)
 	ncli.Flag("tlsfirst", "Perform TLS handshake before expecting the server greeting").BoolVar(&opts.TlsFirst)
+	ncli.Flag("tlsinsecure", "Disable TLS Certificate Verification").Envar("NATS_TLSINSECURE").BoolVar(&opts.TlsInsecure)
 	if runtime.GOOS == "windows" {
 		ncli.Flag("certstore", "Uses a Windows Certificate Store for TLS (user, machine)").PlaceHolder("TYPE").EnumVar(&opts.WinCertStoreType, "user", "windowscurrentuser", "machine", "windowslocalmachine")
 		ncli.Flag("certstore-match", "Which certificate to use in the store").PlaceHolder("QUERY").StringVar(&opts.WinCertStoreMatch)

--- a/options/options.go
+++ b/options/options.go
@@ -36,6 +36,8 @@ type Options struct {
 	TlsKey string
 	// TlsCA is the certificate authority to verify the connection with
 	TlsCA string
+	// TlsInsecure Disable TLS Certificate Verification
+	TlsInsecure bool
 	// Timeout is how long to wait for operations
 	Timeout time.Duration
 	// ConnectionName is the name to use for the underlying NATS connection


### PR DESCRIPTION
This PR adds a new flag for `--tlsinsecure` or env `NATS_TLSINSECURE`
Since the server side supports it, the cli should also support it.

fixes #181 

tested in a pod:

```
nats-box:/# ./nats obj ls 
nats: error: tls: failed to verify certificate: x509: certificate is valid for ::1, 127.0.0.1, not 10.1.1.1

nats-box:/# ./nats obj ls --tlsinsecure
╭────────────────────────────────────────────────────────────────────╮
│                        Object Store Buckets                        │
├─────────┬─────────────┬─────────────────────┬────────┬─────────────┤
│ Bucket  │ Description │ Created             │ Size   │ Last Update │
│ test    │             │ 2024-07-22 08:31:17 │ 12 KiB │ 57m3s       │
╰─────────┴─────────────┴─────────────────────┴────────┴─────────────╯

```