### PR TITLE
Fix whitespace check to include newlines

### DIFF
--- a/internal/audit/cluster_checks.go
+++ b/internal/audit/cluster_checks.go
@@ -221,7 +221,7 @@ func makeCheckClusterHighHAAssets(haAssetsThreshold int) checkFunc {
 func checkClusterNamesForWhitespace(reader *archive.Reader, examples *ExamplesCollection) (Outcome, error) {
 
 	for _, clusterName := range reader.GetClusterNames() {
-		if strings.Contains(clusterName, " ") {
+		if strings.ContainsAny(clusterName, " \n") {
 			examples.add("Cluster: %s", clusterName)
 		}
 	}
@@ -253,7 +253,7 @@ func checkLeafnodeServerNamesForWhitespace(r *archive.Reader, examples *Examples
 
 			for _, leaf := range serverLeafz.Leafs {
 				// check if leafnode name contains whitespace
-				if strings.Contains(leaf.Name, " ") {
+				if strings.ContainsAny(leaf.Name, " \n") {
 					leafnodesWithWhitespace[leaf.Name] = struct{}{}
 				}
 			}

--- a/internal/audit/server_checks.go
+++ b/internal/audit/server_checks.go
@@ -249,7 +249,7 @@ func checkJetStreamDomainsForWhitespace(r *archive.Reader, examples *ExamplesCol
 			}
 
 			// check if jetstream domain contains whitespace
-			if strings.Contains(serverJsz.Config.Domain, " ") {
+			if strings.ContainsAny(serverJsz.Config.Domain, " \n") {
 				examples.add("Cluster %s Server %s Domain %s", clusterName, serverName, serverJsz.Config.Domain)
 			}
 		}


### PR DESCRIPTION
#1096 only checks for ` `, while other characters (e.g., `\n` in the server name can still break the cluster.

Signed-off-by: reubenninan <reuben@nats.io>
