### PR TITLE
Fix progress bar display issue

### DIFF
--- a/cli/bench_command.go
+++ b/cli/bench_command.go
@@ -1716,8 +1716,26 @@ func (c *benchCmd) runCorePublisher(bm *bench.Benchmark, errChan chan error, nc 
 	log.Printf("Starting publisher, publishing %s messages", f(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		barTotal := numMsg
+		if barTotal == 0 {
+			barTotal = 1
+		}
+
+		progress = uiprogress.AddBar(barTotal).AppendCompleted().PrependElapsed()
 		progress.Width = progressWidth()
+
+		if numMsg == 0 {
+			progress.PrependFunc(func(b *uiprogress.Bar) string {
+				return "Finished  "
+			})
+			progress.Incr()
+		}
+	}
+
+	if numMsg == 0 {
+		donewg.Done()
+		errChan <- nil
+		return
 	}
 
 	var msg []byte


### PR DESCRIPTION
There is an issue with a Uiprogress runtime error during "nats bench" when the number of publishers exceeds the number of messages. This results in some publishers being assigned 0 messages, which is set as the total for the progress bar. However, Uiprogress does not accept zero as a valid total and throws a runtime error.

To prevent this error, the progress bar can be shown as already completed when there are no messages to publish.

Issue: https://github.com/nats-io/natscli/issues/1134