### PR TITLE
(#1140) Add stream-check and consumer-check subcommands

### DIFF
--- a/cli/server_command.go
+++ b/cli/server_command.go
@@ -31,6 +31,8 @@ func configureServerCommand(app commandHost) {
 	configureServerRequestCommand(srv)
 	configureServerRunCommand(srv)
 	configureServerWatchCommand(srv)
+	configureStreamCheckCommand(srv)
+	configureConsumerCheckCommand(srv)
 }
 
 func init() {

--- a/cli/server_consumer_check.go
+++ b/cli/server_consumer_check.go
@@ -1,0 +1,323 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/choria-io/fisk"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/natscli/internal/sysclient"
+)
+
+type (
+	ConsumerDetail struct {
+		ServerID             string
+		StreamName           string
+		ConsumerName         string
+		Account              string
+		AccountID            string
+		RaftGroup            string
+		State                server.StreamState
+		Cluster              *server.ClusterInfo
+		StreamCluster        *server.ClusterInfo
+		DeliveredStreamSeq   uint64
+		DeliveredConsumerSeq uint64
+		AckFloorStreamSeq    uint64
+		AckFloorConsumerSeq  uint64
+		NumAckPending        int
+		NumRedelivered       int
+		NumWaiting           int
+		NumPending           uint64
+		HealthStatus         string
+	}
+
+	ConsumerCheckCmd struct {
+		raftGroup      string
+		streamName     string
+		consumerName   string
+		unsyncedFilter bool
+		health         bool
+		expected       int
+		stdin          bool
+		readTimeout    int
+	}
+)
+
+func configureConsumerCheckCommand(app commandHost) {
+	cc := &ConsumerCheckCmd{}
+	consumerCheck := app.Command("consumer-check", "Check and display consumer information").Action(cc.consumerCheck).Hidden()
+	consumerCheck.Flag("stream", "Filter results by stream").StringVar(&cc.streamName)
+	consumerCheck.Flag("consumer", "Filter results by consumer").StringVar(&cc.consumerName)
+	consumerCheck.Flag("raft-group", "Filter results by raft group").StringVar(&cc.raftGroup)
+	consumerCheck.Flag("health", "Check health from consumers").UnNegatableBoolVar(&cc.health)
+	consumerCheck.Flag("expected", "Expected number of servers").IntVar(&cc.expected)
+	consumerCheck.Flag("unsynced", "Filter results by streams that are out of sync").UnNegatableBoolVar(&cc.unsyncedFilter)
+	consumerCheck.Flag("stdin", "Process the contents from STDIN").UnNegatableBoolVar(&cc.stdin)
+	consumerCheck.Flag("read-timeout", "Read timeout in seconds").Default("5").IntVar(&cc.readTimeout)
+}
+
+func (c *ConsumerCheckCmd) consumerCheck(_ *fisk.ParseContext) error {
+	var err error
+	start := time.Now()
+
+	nc, _, err := prepareHelper(opts().Servers, natsOpts()...)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Connected in %.3fs\n", time.Since(start).Seconds())
+
+	sys := sysclient.New(nc)
+
+	if c.expected == 0 {
+		c.expected, err = currentActiveServers(nc)
+		if err != nil {
+			return fmt.Errorf("failed to get current active servers: %s", err)
+		}
+	}
+
+	start = time.Now()
+	servers, err := sys.FindServers(c.stdin, c.expected, opts().Timeout, time.Duration(c.readTimeout), true)
+	if err != nil {
+		return fmt.Errorf("failed to find servers: %s", err)
+	}
+	fmt.Printf("Response took %.3fs\n", time.Since(start).Seconds())
+	fmt.Printf("Servers: %d\n", len(servers))
+
+	streams := make(map[string]map[string]*streamDetail)
+	consumers := make(map[string]map[string]*ConsumerDetail)
+	// Collect all info from servers.
+	for _, resp := range servers {
+		server := resp.Server
+		jsz := resp.JSInfo
+		for _, acc := range jsz.AccountDetails {
+			for _, stream := range acc.Streams {
+				var mok bool
+				var ms map[string]*streamDetail
+				mkey := fmt.Sprintf("%s|%s", acc.Name, stream.RaftGroup)
+				if ms, mok = streams[mkey]; !mok {
+					ms = make(map[string]*streamDetail)
+					streams[mkey] = ms
+				}
+				ms[server.Name] = &streamDetail{
+					ServerID:   server.ID,
+					StreamName: stream.Name,
+					Account:    acc.Name,
+					AccountID:  acc.Id,
+					RaftGroup:  stream.RaftGroup,
+					State:      stream.State,
+					Cluster:    stream.Cluster,
+				}
+
+				for _, consumer := range stream.Consumer {
+					var raftGroup string
+					for _, cr := range stream.ConsumerRaftGroups {
+						if cr.Name == consumer.Name {
+							raftGroup = cr.RaftGroup
+							break
+						}
+					}
+
+					var ok bool
+					var m map[string]*ConsumerDetail
+					key := fmt.Sprintf("%s|%s", acc.Name, raftGroup)
+					if m, ok = consumers[key]; !ok {
+						m = make(map[string]*ConsumerDetail)
+						consumers[key] = m
+					}
+
+					m[server.Name] = &ConsumerDetail{
+						ServerID:             server.ID,
+						StreamName:           consumer.Stream,
+						ConsumerName:         consumer.Name,
+						Account:              acc.Name,
+						AccountID:            acc.Id,
+						RaftGroup:            raftGroup,
+						State:                stream.State,
+						DeliveredStreamSeq:   consumer.Delivered.Stream,
+						DeliveredConsumerSeq: consumer.Delivered.Consumer,
+						AckFloorStreamSeq:    consumer.AckFloor.Stream,
+						AckFloorConsumerSeq:  consumer.AckFloor.Consumer,
+						Cluster:              consumer.Cluster,
+						StreamCluster:        stream.Cluster,
+						NumAckPending:        consumer.NumAckPending,
+						NumRedelivered:       consumer.NumRedelivered,
+						NumWaiting:           consumer.NumWaiting,
+						NumPending:           consumer.NumPending,
+					}
+				}
+			}
+		}
+	}
+
+	keys := make([]string, 0)
+	for k := range consumers {
+		for kk := range consumers[k] {
+			key := fmt.Sprintf("%s/%s", k, kk)
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	fmt.Printf("Consumers: %d\n", len(keys))
+
+	table := newTableWriter("Consumers")
+	table.AddHeaders("Consumer", "Stream", "Raft", "Account", "Account ID", "Node", "Delivered (S,C)", "ACK Floor (S,C)", "Counters", "Status", "Leader", "Stream Cluster Leader", "Peers")
+
+	if c.health {
+		table.AddHeaders("Health")
+	}
+
+	for _, k := range keys {
+		var unsynced bool
+		av := strings.Split(k, "|")
+		accName := av[0]
+		v := strings.Split(av[1], "/")
+		raftGroup, serverName := v[0], v[1]
+
+		if c.raftGroup != "" && raftGroup == c.raftGroup {
+			continue
+		}
+
+		key := fmt.Sprintf("%s|%s", accName, raftGroup)
+		consumer := consumers[key]
+		replica := consumer[serverName]
+		var status string
+		statuses := make(map[string]bool)
+
+		if c.consumerName != "" && replica.ConsumerName != c.consumerName {
+			continue
+		}
+
+		if c.streamName != "" && replica.StreamName != c.streamName {
+			continue
+		}
+
+		if replica.State.LastSeq < replica.DeliveredStreamSeq {
+			statuses["UNSYNCED:DELIVERED_AHEAD_OF_STREAM_SEQ"] = true
+			unsynced = true
+		}
+
+		if replica.State.LastSeq < replica.AckFloorStreamSeq {
+			statuses["UNSYNCED:ACKFLOOR_AHEAD_OF_STREAM_SEQ"] = true
+			unsynced = true
+		}
+
+		// Make comparisons against other peers.
+		for _, peer := range consumer {
+			if peer.DeliveredStreamSeq != replica.DeliveredStreamSeq ||
+				peer.DeliveredConsumerSeq != replica.DeliveredConsumerSeq {
+				statuses["UNSYNCED:DELIVERED"] = true
+				unsynced = true
+			}
+			if peer.AckFloorStreamSeq != replica.AckFloorStreamSeq ||
+				peer.AckFloorConsumerSeq != replica.AckFloorConsumerSeq {
+				statuses["UNSYNCED:ACK_FLOOR"] = true
+				unsynced = true
+			}
+			if peer.Cluster == nil {
+				statuses["NO_CLUSTER"] = true
+				unsynced = true
+			} else {
+				if replica.Cluster == nil {
+					statuses["NO_CLUSTER_R"] = true
+					unsynced = true
+				}
+				if peer.Cluster.Leader != replica.Cluster.Leader {
+					statuses["MULTILEADER"] = true
+					unsynced = true
+				}
+			}
+		}
+		if replica.AckFloorStreamSeq == 0 || replica.AckFloorConsumerSeq == 0 ||
+			replica.DeliveredConsumerSeq == 0 || replica.DeliveredStreamSeq == 0 {
+			statuses["EMPTY"] = true
+		}
+		if len(statuses) > 0 {
+			for k := range statuses {
+				status = fmt.Sprintf("%s%s,", status, k)
+			}
+		} else {
+			status = "IN SYNC"
+		}
+
+		if serverName == replica.Cluster.Leader && replica.Cluster.Leader == replica.StreamCluster.Leader {
+			status += " / INTERSECT"
+		}
+
+		if c.unsyncedFilter && !unsynced {
+			continue
+		}
+		var alen int
+		if len(replica.Account) > 10 {
+			alen = 10
+		} else {
+			alen = len(replica.Account)
+		}
+
+		accountname := strings.Replace(replica.Account[:alen], " ", "_", -1)
+
+		// Mark it in case it is a leader.
+		var suffix string
+		if replica.Cluster == nil {
+			status = "NO_CLUSTER"
+			unsynced = true
+		} else if serverName == replica.Cluster.Leader {
+			suffix = "*"
+		} else if replica.Cluster.Leader == "" {
+			status = "LEADERLESS"
+			unsynced = true
+		}
+		node := fmt.Sprintf("%s%s", serverName, suffix)
+
+		progress := "0%"
+		if replica.State.LastSeq > 0 {
+			result := (float64(replica.DeliveredStreamSeq) / float64(replica.State.LastSeq)) * 100
+			progress = fmt.Sprintf("%-3.0f%%", result)
+		}
+
+		delivered := fmt.Sprintf("%d [%d, %d] %-3s | %d",
+			replica.DeliveredStreamSeq, replica.State.FirstSeq, replica.State.LastSeq, progress, replica.DeliveredConsumerSeq)
+		ackfloor := fmt.Sprintf("%d | %d", replica.AckFloorStreamSeq, replica.AckFloorConsumerSeq)
+		counters := fmt.Sprintf("(ap:%d, nr:%d, nw:%d, np:%d)", replica.NumAckPending, replica.NumRedelivered, replica.NumWaiting, replica.NumPending)
+
+		var replicasInfo string
+		for _, r := range replica.Cluster.Replicas {
+			info := fmt.Sprintf("%s(current=%-5v,offline=%v)", r.Name, r.Current, r.Offline)
+			replicasInfo = fmt.Sprintf("%-40s %s", info, replicasInfo)
+		}
+
+		// Include Healthz if option added.
+		var healthStatus string
+		if c.health {
+			hstatus, err := sys.Healthz(replica.ServerID, server.HealthzOptions{
+				Account:  replica.Account,
+				Stream:   replica.StreamName,
+				Consumer: replica.ConsumerName,
+			})
+			if err != nil {
+				healthStatus = err.Error()
+			} else {
+				healthStatus = fmt.Sprintf(":%s:%s", hstatus.Healthz.Status, hstatus.Healthz.Error)
+			}
+		}
+
+		table.AddRow(replica.ConsumerName, replica.StreamName, replica.RaftGroup, accountname, replica.AccountID, node, delivered, ackfloor, counters, status, replica.Cluster.Leader, replica.StreamCluster.Leader, replicasInfo, healthStatus)
+	}
+
+	fmt.Println(table.Render())
+	return nil
+}

--- a/cli/server_stream_check.go
+++ b/cli/server_stream_check.go
@@ -1,0 +1,231 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/choria-io/fisk"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/natscli/internal/sysclient"
+)
+
+type (
+	streamDetail struct {
+		StreamName   string
+		Account      string
+		AccountID    string
+		RaftGroup    string
+		State        server.StreamState
+		Cluster      *server.ClusterInfo
+		HealthStatus string
+		ServerID     string
+	}
+
+	StreamCheckCmd struct {
+		raftGroup      string
+		streamName     string
+		unsyncedFilter bool
+		health         bool
+		expected       int
+		stdin          bool
+		readTimeout    int
+	}
+)
+
+func configureStreamCheckCommand(app commandHost) {
+	sc := &StreamCheckCmd{}
+	streamCheck := app.Command("stream-check", "Check and display stream information").Action(sc.streamCheck).Hidden()
+	streamCheck.Flag("stream", "Filter results by stream").StringVar(&sc.streamName)
+	streamCheck.Flag("raft-group", "Filter results by raft group").StringVar(&sc.raftGroup)
+	streamCheck.Flag("health", "Check health from streams").UnNegatableBoolVar(&sc.health)
+	streamCheck.Flag("expected", "Expected number of servers").IntVar(&sc.expected)
+	streamCheck.Flag("unsynced", "Filter results by streams that are out of sync").UnNegatableBoolVar(&sc.unsyncedFilter)
+	streamCheck.Flag("stdin", "Process the contents from STDIN").UnNegatableBoolVar(&sc.stdin)
+	streamCheck.Flag("read-timeout", "Read timeout in seconds").Default("5").IntVar(&sc.readTimeout)
+}
+
+func (c *StreamCheckCmd) streamCheck(_ *fisk.ParseContext) error {
+	var err error
+	start := time.Now()
+
+	nc, _, err := prepareHelper(opts().Servers, natsOpts()...)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Connected in %.3fs\n", time.Since(start).Seconds())
+
+	sys := sysclient.New(nc)
+
+	if c.expected == 0 {
+		c.expected, err = currentActiveServers(nc)
+		if err != nil {
+			return fmt.Errorf("failed to get current active servers: %s", err)
+		}
+	}
+
+	start = time.Now()
+	servers, err := sys.FindServers(c.stdin, c.expected, opts().Timeout, time.Duration(c.readTimeout), false)
+	if err != nil {
+		return fmt.Errorf("failed to find servers: %s", err)
+	}
+	fmt.Printf("Response took %.3fs\n", time.Since(start).Seconds())
+	fmt.Printf("Servers: %d\n", len(servers))
+
+	// Collect all info from servers.
+	streams := make(map[string]map[string]*streamDetail)
+	for _, resp := range servers {
+		server := resp.Server
+		jsz := resp.JSInfo
+		for _, acc := range jsz.AccountDetails {
+			for _, stream := range acc.Streams {
+				var ok bool
+				var m map[string]*streamDetail
+				key := fmt.Sprintf("%s|%s", acc.Name, stream.RaftGroup)
+				if m, ok = streams[key]; !ok {
+					m = make(map[string]*streamDetail)
+					streams[key] = m
+				}
+				m[server.Name] = &streamDetail{
+					ServerID:   server.ID,
+					StreamName: stream.Name,
+					Account:    acc.Name,
+					AccountID:  acc.Id,
+					RaftGroup:  stream.RaftGroup,
+					State:      stream.State,
+					Cluster:    stream.Cluster,
+				}
+			}
+		}
+	}
+	keys := make([]string, 0)
+	for k := range streams {
+		for kk := range streams[k] {
+			keys = append(keys, fmt.Sprintf("%s/%s", k, kk))
+		}
+	}
+	sort.Strings(keys)
+
+	fmt.Printf("Streams: %d\n", len(keys))
+
+	table := newTableWriter("Streams")
+	table.AddHeaders("Stream Replica", "Raft", "Account", "Account ID", "Node", "Messages", "Bytes", "Subjects", "Deleted", "Consumers", "First", "Last", "Status", "Leader", "Peers")
+
+	if c.health {
+		table.AddHeaders("Health")
+	}
+
+	for _, k := range keys {
+		var unsynced bool
+		av := strings.Split(k, "|")
+		accName := av[0]
+		v := strings.Split(av[1], "/")
+		raftName, serverName := v[0], v[1]
+		if c.raftGroup != "" && raftName != c.raftGroup {
+			continue
+		}
+
+		key := fmt.Sprintf("%s|%s", accName, raftName)
+		stream := streams[key]
+		replica := stream[serverName]
+		status := "IN SYNC"
+
+		if c.streamName != "" && replica.StreamName != c.streamName {
+			continue
+		}
+
+		// Make comparisons against other peers.
+		for _, peer := range stream {
+			if peer.State.Msgs != replica.State.Msgs && peer.State.Bytes != replica.State.Bytes {
+				status = "UNSYNCED"
+				unsynced = true
+			}
+			if peer.State.FirstSeq != replica.State.FirstSeq {
+				status = "UNSYNCED"
+				unsynced = true
+			}
+			if peer.State.LastSeq != replica.State.LastSeq {
+				status = "UNSYNCED"
+				unsynced = true
+			}
+			// Cannot trust results unless coming from the stream leader.
+			// Need Stream INFO and collect multiple responses instead.
+			if peer.Cluster.Leader != replica.Cluster.Leader {
+				status = "MULTILEADER"
+				unsynced = true
+			}
+		}
+		if c.unsyncedFilter && !unsynced {
+			continue
+		}
+
+		if replica == nil {
+			status = "?"
+			unsynced = true
+			continue
+		}
+		var alen int
+		if len(replica.Account) > 10 {
+			alen = 10
+		} else {
+			alen = len(replica.Account)
+		}
+
+		account := strings.Replace(replica.Account[:alen], " ", "_", -1)
+
+		// Mark it in case it is a leader.
+		var suffix string
+		var isStreamLeader bool
+		if serverName == replica.Cluster.Leader {
+			isStreamLeader = true
+			suffix = "*"
+		} else if replica.Cluster.Leader == "" {
+			status = "LEADERLESS"
+			unsynced = true
+		}
+
+		var replicasInfo string // PEER
+		for _, r := range replica.Cluster.Replicas {
+			if isStreamLeader && r.Name == replica.Cluster.Leader {
+				status = "LEADER_IS_FOLLOWER"
+				unsynced = true
+			}
+			info := fmt.Sprintf("%s(current=%-5v,offline=%v)", r.Name, r.Current, r.Offline)
+			replicasInfo = fmt.Sprintf("%-40s %s", info, replicasInfo)
+		}
+
+		// Include Healthz if option added.
+		var healthStatus string
+		if c.health {
+			hstatus, err := sys.Healthz(replica.ServerID, server.HealthzOptions{
+				Account: replica.Account,
+				Stream:  replica.StreamName,
+			})
+			if err != nil {
+				healthStatus = err.Error()
+			} else {
+				healthStatus = fmt.Sprintf(":%s:%s", hstatus.Healthz.Status, hstatus.Healthz.Error)
+			}
+		}
+
+		table.AddRow(replica.StreamName, replica.RaftGroup, account, replica.AccountID, fmt.Sprintf("%s%s", serverName, suffix), replica.State.Msgs, replica.State.Bytes, replica.State.NumSubjects, replica.State.NumDeleted, replica.State.Consumers, replica.State.FirstSeq,
+			replica.State.LastSeq, status, replica.Cluster.Leader, replicasInfo, healthStatus)
+	}
+
+	fmt.Println(table.Render())
+	return nil
+}

--- a/internal/sysclient/healthstatus.go
+++ b/internal/sysclient/healthstatus.go
@@ -1,0 +1,83 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysclient
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/natscli/internal/util"
+)
+
+const (
+	StatusOK HealthStatus = iota
+	StatusUnavailable
+	StatusError
+)
+
+type (
+	HealthzResp struct {
+		Server  server.ServerInfo `json:"server"`
+		Healthz Healthz           `json:"data"`
+	}
+
+	Healthz struct {
+		Status HealthStatus `json:"status"`
+		Error  string       `json:"error,omitempty"`
+	}
+
+	HealthStatus int
+)
+
+func (hs *HealthStatus) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case util.JSONString("ok"):
+		*hs = StatusOK
+	case util.JSONString("na"), util.JSONString("unavailable"):
+		*hs = StatusUnavailable
+	case util.JSONString("error"):
+		*hs = StatusError
+	default:
+		return fmt.Errorf("cannot unmarshal %q", data)
+	}
+
+	return nil
+}
+
+func (hs HealthStatus) MarshalJSON() ([]byte, error) {
+	switch hs {
+	case StatusOK:
+		return json.Marshal("ok")
+	case StatusUnavailable:
+		return json.Marshal("na")
+	case StatusError:
+		return json.Marshal("error")
+	default:
+		return nil, fmt.Errorf("unknown health status: %v", hs)
+	}
+}
+
+func (hs HealthStatus) String() string {
+	switch hs {
+	case StatusOK:
+		return "ok"
+	case StatusUnavailable:
+		return "na"
+	case StatusError:
+		return "error"
+	default:
+		return "unknown health status"
+	}
+}

--- a/internal/sysclient/sysclient.go
+++ b/internal/sysclient/sysclient.go
@@ -1,0 +1,232 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysclient
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	srvJszSubj = "$SYS.REQ.SERVER.%s.JSZ"
+	// Healthz checks server health status.
+	srvHealthzSubj        = "$SYS.REQ.SERVER.%s.HEALTHZ"
+	DefaultRequestTimeout = 60 * time.Second
+)
+
+var (
+	ErrValidation      = errors.New("validation error")
+	ErrInvalidServerID = errors.New("server with given ID does not exist")
+)
+
+type (
+	// SysClient can be used to request monitoring data from the server.
+	// This is used by the stream-check and consumer-check commands
+	SysClient struct {
+		nc *nats.Conn
+	}
+
+	FetchOpts struct {
+		Timeout     time.Duration
+		ReadTimeout time.Duration
+		Expected    int
+	}
+
+	FetchOpt func(*FetchOpts) error
+
+	JSZResp struct {
+		Server server.ServerInfo `json:"server"`
+		JSInfo server.JSInfo     `json:"data"`
+	}
+)
+
+func New(nc *nats.Conn) SysClient {
+	return SysClient{
+		nc: nc,
+	}
+}
+
+func (s *SysClient) JszPing(opts server.JszEventOptions, fopts ...FetchOpt) ([]JSZResp, error) {
+	subj := fmt.Sprintf(srvJszSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.Fetch(subj, payload, fopts...)
+	if err != nil {
+		return nil, err
+	}
+	srvJsz := make([]JSZResp, 0, len(resp))
+	for _, msg := range resp {
+		var jszResp JSZResp
+		if err := json.Unmarshal(msg.Data, &jszResp); err != nil {
+			return nil, err
+		}
+		srvJsz = append(srvJsz, jszResp)
+	}
+	return srvJsz, nil
+}
+
+func (s *SysClient) Fetch(subject string, data []byte, opts ...FetchOpt) ([]*nats.Msg, error) {
+	if subject == "" {
+		return nil, fmt.Errorf("%w: expected subject 0", ErrValidation)
+	}
+
+	conn := s.nc
+	reqOpts := &FetchOpts{}
+	for _, opt := range opts {
+		if err := opt(reqOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	inbox := nats.NewInbox()
+	res := make([]*nats.Msg, 0)
+	msgsChan := make(chan *nats.Msg, 100)
+
+	readTimer := time.NewTimer(reqOpts.ReadTimeout)
+	sub, err := conn.Subscribe(inbox, func(msg *nats.Msg) {
+		readTimer.Reset(reqOpts.ReadTimeout)
+		msgsChan <- msg
+	})
+	defer sub.Unsubscribe()
+
+	if err := conn.PublishRequest(subject, inbox, data); err != nil {
+		return nil, err
+	}
+
+	for {
+		select {
+		case msg := <-msgsChan:
+			if msg.Header.Get("Status") == "503" {
+				return nil, fmt.Errorf("server request on subject %q failed: %w", subject, err)
+			}
+			res = append(res, msg)
+			if reqOpts.Expected != -1 && len(res) == reqOpts.Expected {
+				return res, nil
+			}
+		case <-readTimer.C:
+			return res, nil
+		case <-time.After(reqOpts.Timeout):
+			return res, nil
+		}
+	}
+}
+
+func (s *SysClient) Healthz(id string, opts server.HealthzOptions) (*HealthzResp, error) {
+	if id == "" {
+		return nil, fmt.Errorf("%w: server id cannot be empty", ErrValidation)
+	}
+	subj := fmt.Sprintf(srvHealthzSubj, id)
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.nc.Request(subj, payload, DefaultRequestTimeout)
+	if err != nil {
+		if errors.Is(err, nats.ErrNoResponders) {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidServerID, id)
+		}
+		return nil, err
+	}
+	var healthzResp HealthzResp
+	if err := json.Unmarshal(resp.Data, &healthzResp); err != nil {
+		return nil, err
+	}
+
+	return &healthzResp, nil
+}
+
+func (s *SysClient) FindServers(stdin bool, expected int, timeout time.Duration, readTimeout time.Duration, getConsumer bool) ([]JSZResp, error) {
+	var err error
+	servers := []JSZResp{}
+
+	if stdin {
+		reader := bufio.NewReader(os.Stdin)
+
+		for i := 0; i < expected; i++ {
+			data, err := reader.ReadString('\n')
+			if err != nil && err != io.EOF {
+				return servers, err
+			}
+			if len(data) > 0 {
+				var jszResp JSZResp
+				if err := json.Unmarshal([]byte(data), &jszResp); err != nil {
+					return servers, err
+				}
+				servers = append(servers, jszResp)
+			}
+		}
+	} else {
+		jszOptions := server.JSzOptions{
+			Streams:    true,
+			RaftGroups: true,
+		}
+
+		if getConsumer {
+			jszOptions.Consumer = true
+		}
+
+		fetchTimeout := fetchTimeout(timeout * time.Second)
+		fetchExpected := fetchExpected(expected)
+		fetchReadTimeout := fetchReadTimeout(readTimeout * time.Second)
+		servers, err = s.JszPing(server.JszEventOptions{
+			JSzOptions: jszOptions,
+		}, fetchTimeout, fetchReadTimeout, fetchExpected)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	return servers, nil
+}
+
+func fetchTimeout(timeout time.Duration) FetchOpt {
+	return func(opts *FetchOpts) error {
+		if timeout <= 0 {
+			return fmt.Errorf("%w: timeout has to be greater than 0", ErrValidation)
+		}
+		opts.Timeout = timeout
+		return nil
+	}
+}
+
+func fetchReadTimeout(timeout time.Duration) FetchOpt {
+	return func(opts *FetchOpts) error {
+		if timeout <= 0 {
+			return fmt.Errorf("%w: read timeout has to be greater than 0", ErrValidation)
+		}
+		opts.ReadTimeout = timeout
+		return nil
+	}
+}
+
+func fetchExpected(expected int) FetchOpt {
+	return func(opts *FetchOpts) error {
+		if expected <= 0 {
+			return fmt.Errorf("%w: expected request count has to be greater than 0", ErrValidation)
+		}
+		opts.Expected = expected
+		return nil
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -425,3 +425,8 @@ func ProgressWidth() int {
 		return w - 30
 	}
 }
+
+// JSONString returns a quoted string to be used as a JSON object
+func JSONString(s string) string {
+	return "\"" + s + "\""
+}


### PR DESCRIPTION
Here we add the `stream-check` and `consumer-check` subcommands to the `server` command.

These subcommands are hidden, and will use the system credentials to iterate all servers, streams and consumers and display debugging related information to the user in a table.