### PR TITLE
(maint) Update kv and object commands to use new jetstream api

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -36,6 +36,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/nats-io/natscli/options"
 
 	iu "github.com/nats-io/natscli/internal/util"
@@ -376,7 +377,7 @@ func newNatsConn(servers string, copts ...nats.Option) (*nats.Conn, error) {
 	return newNatsConnUnlocked(servers, copts...)
 }
 
-func prepareJSHelper() (*nats.Conn, nats.JetStreamContext, error) {
+func prepareJSHelper() (*nats.Conn, jetstream.JetStream, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -394,12 +395,13 @@ func prepareJSHelper() (*nats.Conn, nats.JetStreamContext, error) {
 		return opts.Conn, opts.JSc, nil
 	}
 
-	opts.JSc, err = opts.Conn.JetStream(jsOpts()...)
+	opts.JSc, err = jetstream.New(opts.Conn)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return opts.Conn, opts.JSc, nil
+
 }
 
 func prepareHelper(servers string, copts ...nats.Option) (*nats.Conn, *jsm.Manager, error) {

--- a/options/options.go
+++ b/options/options.go
@@ -14,10 +14,12 @@
 package options
 
 import (
+	"time"
+
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/nats.go"
-	"time"
+	"github.com/nats-io/nats.go/jetstream"
 )
 
 var DefaultOptions *Options
@@ -63,7 +65,7 @@ type Options struct {
 	// Mgr sets a prepared jsm Manager to use for JetStream access
 	Mgr *jsm.Manager
 	// JSc is a prepared NATS JetStream context to use for KV and Object access
-	JSc nats.JetStreamContext
+	JSc jetstream.JetStream
 	// Disables registering of CLI cheats
 	NoCheats bool
 	// PrometheusNamespace is the namespace to use for prometheus format output in server check


### PR DESCRIPTION
Here we update both the kv and object commands to no longer use the deprecated nats.JetstreamContext and instead use jetstream.Jetstream.

We also fix some minor usability issues, like make the `revision` flag required for the `update` action, improve the error message when attempting to revert a key value in a bucket with history=1, and perform the revert with an `update` action instead of a `put`.