### PR TITLE
Fix columns for mirrors under `Replication Report`

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -1477,7 +1477,7 @@ func (c *streamCmd) reportAction(_ *fisk.ParseContext) error {
 
 func (c *streamCmd) renderReplication(stats []streamStat) {
 	table := newTableWriter("Replication Report")
-	table.AddHeaders("Stream", "Kind", "API Prefix", "Source Stream", "Filters and Transforms", "Active", "Lag", "Error")
+	table.AddHeaders("Stream", "Kind", "API Prefix", "Source Stream", "Filters and Transforms", "Seen", "Lag", "Error")
 
 	for _, s := range stats {
 		if len(s.Sources) == 0 && s.Mirror == nil {
@@ -1496,9 +1496,9 @@ func (c *streamCmd) renderReplication(stats []streamStat) {
 			}
 
 			if c.reportRaw {
-				table.AddRow(s.Name, "Mirror", eApiPrefix, s.Mirror.Name, "", "", s.Mirror.Active, s.Mirror.Lag, apierr)
+				table.AddRow(s.Name, "Mirror", eApiPrefix, s.Mirror.Name, "", s.Mirror.Active, s.Mirror.Lag, apierr)
 			} else {
-				table.AddRow(s.Name, "Mirror", eApiPrefix, s.Mirror.Name, "", "", f(s.Mirror.Active), f(s.Mirror.Lag), apierr)
+				table.AddRow(s.Name, "Mirror", eApiPrefix, s.Mirror.Name, "", f(s.Mirror.Active), f(s.Mirror.Lag), apierr)
 			}
 		}
 


### PR DESCRIPTION
Previously there were too many columns for the headers, and `Active` was named incorrectly:
```
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                Replication Report                                                │
├──────────────────┬────────┬──────────────┬──────────────────┬────────────────────────┬────────┬───────┬───────┬──┤
│ Stream           │ Kind   │ API Prefix   │ Source Stream    │ Filters and Transforms │ Active │ Lag   │ Error │  │
├──────────────────┼────────┼──────────────┼──────────────────┼────────────────────────┼────────┼───────┼───────┼──┤
│ stream           │ Mirror │ $JS.home.API │ source           │                        │        │ 528ms │ 0     │  │
╰──────────────────┴────────┴──────────────┴──────────────────┴────────────────────────┴────────┴───────┴───────┴──╯
```
... when they should have been lined up like so, with `Seen` instead:
```
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                              Replication Report                                             │
├──────────────────┬────────┬──────────────┬──────────────────┬────────────────────────┬────────┬─────┬───────┤
│ Stream           │ Kind   │ API Prefix   │ Source Stream    │ Filters and Transforms │ Seen   │ Lag │ Error │
├──────────────────┼────────┼──────────────┼──────────────────┼────────────────────────┼────────┼─────┼───────┤
│ stream           │ Mirror │ $JS.home.API │ source           │                        │ 100ms  │ 0   │       │
╰──────────────────┴────────┴──────────────┴──────────────────┴────────────────────────┴────────┴─────┴───────╯
```

Signed-off-by: Neil Twigg <neil@nats.io>