### PR TITLE
goreleaser: switch to v2 config & GH Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,9 +56,9 @@ jobs:
           repositories: "homebrew-nats-tools"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 project_name: natscli
+version: 2
 
 release:
   github:
@@ -9,7 +10,7 @@ release:
   prerelease: auto
 
 changelog:
-  skip: true
+  disable: true
 
 builds:
   - main: ./nats
@@ -54,7 +55,7 @@ checksum:
 
 brews:
   - name: nats
-    folder: Formula
+    directory: Formula
     repository:
       owner: nats-io
       name: homebrew-nats-tools


### PR DESCRIPTION
Handle deprecated configuration settings, updating per guidance in <https://goreleaser.com/deprecations/>.

Add an internal `version:` field in the GoReleaser YAML, for v2.

Switch the GitHub Action to @v6 which will use goreleaser v2, and make the version explicitly `"~> v2"`.  Before, it said "latest" but that was implicitly bound by the action to be v1, leading to a little head-scratching.