### PR TITLE
Add man page and zsh completion

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,8 +66,17 @@ brews:
     skip_upload: auto
     test: |
       system "#{bin}/nats --version"
+    custom_block: |
+      resource "zsh_completion" do
+        url "https://get-nats.io/zsh.complete.nats"
+        sha256 "2b0832b26b1644ff01a293dc1b91320fc24f818ad8e89dd416f9c83f23b4df59"
+      end
     install: |
       bin.install "nats"
+      (man1/"nats.1").write Utils.safe_popen_read(bin/"nats", "--help-man")
+      resource("zsh_completion").stage do
+        zsh_completion.install "zsh.complete.nats" => "_nats"
+      end
 
 nfpms:
   - file_name_template: 'nats-{{.Version}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,17 +66,10 @@ brews:
     skip_upload: auto
     test: |
       system "#{bin}/nats --version"
-    custom_block: |
-      resource "zsh_completion" do
-        url "https://get-nats.io/zsh.complete.nats"
-        sha256 "2b0832b26b1644ff01a293dc1b91320fc24f818ad8e89dd416f9c83f23b4df59"
-      end
     install: |
       bin.install "nats"
       (man1/"nats.1").write Utils.safe_popen_read(bin/"nats", "--help-man")
-      resource("zsh_completion").stage do
-        zsh_completion.install "zsh.complete.nats" => "_nats"
-      end
+      generate_completions_from_executable(bin/"nats", shells: [:bash, :zsh], shell_parameter_format: "--completion-script-")
 
 nfpms:
   - file_name_template: 'nats-{{.Version}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,6 @@ brews:
       system "#{bin}/nats --version"
     install: |
       bin.install "nats"
-      (man1/"nats.1").write Utils.safe_popen_read(bin/"nats", "--help-man")
       generate_completions_from_executable(bin/"nats", shells: [:bash, :zsh], shell_parameter_format: "--completion-script-")
 
 nfpms:


### PR DESCRIPTION
Please, update the [fisk](github.com/choria-io/fisk) dependency version after https://github.com/choria-io/fisk/pull/54 merge.

[36f3fec](https://github.com/nats-io/natscli/commit/36f3fec3581a114f93fad3adb2f12b768d80f699) uses [zsh.complete.nats](https://github.com/ConnectEverything/client-tools/blob/main/zsh.complete.nats), but I consider that `generate_completions_from_executable` is more suitable for maintenance.