### PR TITLE
Enable domains and api prefixes in server check

### DIFF
--- a/cli/server_check_command.go
+++ b/cli/server_check_command.go
@@ -326,7 +326,7 @@ func (c *SrvCheckCmd) checkConsumer(_ *fisk.ParseContext) error {
 	if opts().Trace {
 		logger = api.NewDefaultLogger(api.TraceLevel)
 	}
-	err := monitor.ConsumerHealthCheck(opts().Config.ServerURL(), natsOpts(), check, *checkOpts, logger)
+	err := monitor.ConsumerHealthCheck(opts().Config.ServerURL(), natsOpts(), jsmOpts(), check, *checkOpts, logger)
 	if err != nil {
 		return fmt.Errorf("health check failed: %v", err)
 	}
@@ -372,7 +372,7 @@ func (c *SrvCheckCmd) checkJS(_ *fisk.ParseContext) error {
 	check := &monitor.Result{Name: "JetStream", Check: "jetstream", OutFile: checkRenderOutFile, NameSpace: opts().PrometheusNamespace, RenderFormat: checkRenderFormat, Trace: opts().Trace}
 	defer check.GenericExit()
 
-	return monitor.CheckJetStreamAccount(opts().Config.ServerURL(), natsOpts(), check, monitor.CheckJetStreamAccountOptions{
+	return monitor.CheckJetStreamAccount(opts().Config.ServerURL(), natsOpts(), jsmOpts(), check, monitor.CheckJetStreamAccountOptions{
 		MemoryWarning:       c.jsMemWarn,
 		MemoryCritical:      c.jsMemCritical,
 		FileWarning:         c.jsStoreWarn,
@@ -444,7 +444,7 @@ func (c *SrvCheckCmd) checkStream(_ *fisk.ParseContext) error {
 	if opts().Trace {
 		logger = api.NewDefaultLogger(api.TraceLevel)
 	}
-	err := monitor.CheckStreamHealth(opts().Config.ServerURL(), natsOpts(), check, *checkOpts, logger)
+	err := monitor.CheckStreamHealth(opts().Config.ServerURL(), natsOpts(), jsmOpts(), check, *checkOpts, logger)
 	check.CriticalIfErr(err, "Healthcheck failed: %s", err)
 
 	return nil
@@ -454,7 +454,7 @@ func (c *SrvCheckCmd) checkMsg(_ *fisk.ParseContext) error {
 	check := &monitor.Result{Name: "Stream Message", Check: "message", OutFile: checkRenderOutFile, NameSpace: opts().PrometheusNamespace, RenderFormat: checkRenderFormat, Trace: opts().Trace}
 	defer check.GenericExit()
 
-	return monitor.CheckStreamMessage(opts().Config.ServerURL(), natsOpts(), check, monitor.CheckStreamMessageOptions{
+	return monitor.CheckStreamMessage(opts().Config.ServerURL(), natsOpts(), jsmOpts(), check, monitor.CheckStreamMessageOptions{
 		StreamName:      c.sourcesStream,
 		Subject:         c.msgSubject,
 		AgeWarning:      c.msgAgeWarn.Seconds(),

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.6.6
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.17.11
-	github.com/nats-io/jsm.go v0.1.1-0.20250207154114-3173c77580a6
+	github.com/nats-io/jsm.go v0.1.1-0.20250213110753-19c36a3b25c7
 	github.com/nats-io/jwt/v2 v2.7.3
 	github.com/nats-io/nats-server/v2 v2.11.0-dev.0.20250212011304-b848ef11daa4
 	github.com/nats-io/nats.go v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nats-io/jsm.go v0.1.1-0.20250207154114-3173c77580a6 h1:ffBn2DalSseF2YmuEs+Ko6pnx+b+f338qenGwBNlBzo=
 github.com/nats-io/jsm.go v0.1.1-0.20250207154114-3173c77580a6/go.mod h1:8dMjkX/FvrOkAcQH4nGyv49V+v6yLEge9uf1Kql5HQs=
+github.com/nats-io/jsm.go v0.1.1-0.20250213083755-12d02538f5c4 h1:XB6wphdG+Ey4jzV5pk75PcQKE6Q08nyN4dLGywGucqo=
+github.com/nats-io/jsm.go v0.1.1-0.20250213083755-12d02538f5c4/go.mod h1:8dMjkX/FvrOkAcQH4nGyv49V+v6yLEge9uf1Kql5HQs=
+github.com/nats-io/jsm.go v0.1.1-0.20250213110753-19c36a3b25c7 h1:b/C5HLAv6mjK4jmP3G/oUqU43LC+4/ociB+ohdx3dhk=
+github.com/nats-io/jsm.go v0.1.1-0.20250213110753-19c36a3b25c7/go.mod h1:8dMjkX/FvrOkAcQH4nGyv49V+v6yLEge9uf1Kql5HQs=
 github.com/nats-io/jwt/v2 v2.7.3 h1:6bNPK+FXgBeAqdj4cYQ0F8ViHRbi7woQLq4W29nUAzE=
 github.com/nats-io/jwt/v2 v2.7.3/go.mod h1:GvkcbHhKquj3pkioy5put1wvPxs78UlZ7D/pY+BgZk4=
 github.com/nats-io/nats-server/v2 v2.11.0-dev.0.20250212011304-b848ef11daa4 h1:CfOv4PMRmMnROf3Lb+TiOZ1mODupeR3EOYkCrh2guSI=


### PR DESCRIPTION
Previously we handled jsm options correctly but in the move out of CLI we forgot to handle those at all meaning trace, domains, api prefix all stopped being supported.

This restores all that.