### PR TITLE
Reverts the availability check for js

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -465,10 +465,6 @@ func prepareHelperUnlocked(servers string, copts ...nats.Option) (*nats.Conn, *j
 		return nil, nil, err
 	}
 
-	if !opts.Mgr.IsJetStreamEnabled() {
-		return nil, nil, nats.ErrJetStreamNotEnabled
-	}
-
 	return opts.Conn, opts.Mgr, err
 }
 


### PR DESCRIPTION
Since we use the prepare helper for account and system accounts, and those without jetstream, we really cant check this here