### PR TITLE
Add token authentication support to context options

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -494,6 +494,10 @@ func loadContext(softFail bool) error {
 		ctxOpts = append(ctxOpts, natscontext.WithTLSHandshakeFirst())
 	}
 
+	if opts.Token != "" {
+		ctxOpts = append(ctxOpts, natscontext.WithToken(opts.Token))
+	}
+
 	if opts.Username != "" && opts.Password == "" {
 		ctxOpts = append(ctxOpts, natscontext.WithToken(opts.Username))
 	} else {

--- a/nats/main.go
+++ b/nats/main.go
@@ -51,6 +51,7 @@ See 'nats cheat' for a quick cheatsheet of commands`
 	ncli.Flag("server", "NATS server urls").Short('s').Envar("NATS_URL").PlaceHolder("URL").StringVar(&opts.Servers)
 	ncli.Flag("user", "Username or Token").Envar("NATS_USER").PlaceHolder("USER").StringVar(&opts.Username)
 	ncli.Flag("password", "Password").Envar("NATS_PASSWORD").PlaceHolder("PASSWORD").StringVar(&opts.Password)
+	ncli.Flag("token", "Token").Envar("NATS_TOKEN").PlaceHolder("TOKEN").StringVar(&opts.Token)
 	ncli.Flag("connection-name", "Nickname to use for the underlying NATS Connection").Default("NATS CLI Version " + getVersion()).PlaceHolder("NAME").StringVar(&opts.ConnectionName)
 	ncli.Flag("creds", "User credentials").Envar("NATS_CREDS").PlaceHolder("FILE").StringVar(&opts.Creds)
 	ncli.Flag("nkey", "User NKEY").Envar("NATS_NKEY").PlaceHolder("FILE").StringVar(&opts.Nkey)

--- a/options/options.go
+++ b/options/options.go
@@ -46,6 +46,8 @@ type Options struct {
 	Username string
 	// Password is the password to connect with
 	Password string
+	// Token is the token to connect with
+	Token string
 	// Nkey is the file holding a nkey to connect with
 	Nkey string
 	// JsApiPrefix is the JetStream API prefix


### PR DESCRIPTION
# Add Token Authentication Support to Context Options

## Description
This PR adds support for token-based authentication in the NATS CLI context options. It introduces a dedicated `Token` field to the `Options` struct, providing a clearer and more semantically correct way to handle token-based authentication compared to using the `Password` field.

## Changes
- Added `Token` field to the `Options` struct
- Updated `loadContext` to support token-based authentication alongside existing username/password authentication
- Maintained backward compatibility with existing password-based authentication

## Why
Currently, token-based authentication requires using the `Password` field, which is semantically incorrect and can lead to confusion. This change provides a dedicated field for token authentication, making the code's intent clearer.

## Testing
- [ ] Verified token authentication works with the new `Token` field
- [ ] Confirmed backward compatibility with existing password-based authentication
- [ ] Tested scenarios where both `Token` and `Password` fields are present

## Related Issues
N/A

## Notes
This change is backward compatible and does not break existing functionality. Users can continue using the `Password` field for password-based authentication while using the new `Token` field for token-based authentication.