### PR TITLE
Fix account report connections

### DIFF
--- a/cli/account_command.go
+++ b/cli/account_command.go
@@ -208,12 +208,18 @@ func (c *actCmd) restoreAction(kp *fisk.ParseContext) error {
 }
 
 func (c *actCmd) reportConnectionsAction(pc *fisk.ParseContext) error {
+	nc, _, err := prepareHelper("", natsOpts()...)
+	if err != nil {
+		return err
+	}
+
 	cmd := SrvReportCmd{
 		topk:                    c.topk,
 		sort:                    c.sort,
 		subject:                 c.subject,
 		reverse:                 c.reverse,
 		skipDiscoverClusterSize: true,
+		nc:                      nc,
 	}
 
 	return cmd.reportConnections(pc)


### PR DESCRIPTION
#1322 broke the `nats account report connections` command. This should fix the regression.