### PR TITLE
Cross platform testing & fix runNatsCli timeout

### DIFF
--- a/cli/auth_nkey_command.go
+++ b/cli/auth_nkey_command.go
@@ -287,6 +287,7 @@ func (c *authNKCommand) sealAction(_ *fisk.ParseContext) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	_, err = f.Write(encryptedData)
 	if err != nil {
@@ -342,6 +343,7 @@ func (c *authNKCommand) unsealAction(_ *fisk.ParseContext) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	_, err = f.Write(decryptedData)
 	if err != nil {

--- a/cli/auth_xkey_test.go
+++ b/cli/auth_xkey_test.go
@@ -15,12 +15,11 @@ package cli
 
 import (
 	"crypto/rand"
+	"github.com/nats-io/nkeys"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/nats-io/nkeys"
 )
 
 func TestSealUnseal(t *testing.T) {

--- a/cli/auth_xkey_test.go
+++ b/cli/auth_xkey_test.go
@@ -15,11 +15,12 @@ package cli
 
 import (
 	"crypto/rand"
-	"github.com/nats-io/nkeys"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/nats-io/nkeys"
 )
 
 func TestSealUnseal(t *testing.T) {

--- a/nats/tests/auth_command_test.go
+++ b/nats/tests/auth_command_test.go
@@ -133,7 +133,7 @@ func TestMapping(t *testing.T) {
 					t.Fatalf("Error writing to file: %s", err)
 				}
 
-				output := runNatsCli(t, fmt.Sprintf("auth account mappings add %s --operator=%s --config=%s", accountName, operatorName, fp))
+				output := runNatsCli(t, fmt.Sprintf("auth account mappings add %s --operator=%s --config='%s'", accountName, operatorName, fp))
 
 				for name, pattern := range fields {
 					if !pattern.Match(output) {

--- a/nats/tests/nats_nix_test.go
+++ b/nats/tests/nats_nix_test.go
@@ -38,7 +38,7 @@ func runCommand(cmd string, input string, args ...string) ([]byte, error) {
 	select {
 	case <-ctx.Done():
 		if execution.Process != nil {
-			_ = syscall.Kill(execution.Process.Pid, syscall.SIGKILL)
+			_ = syscall.Kill(-execution.Process.Pid, syscall.SIGKILL)
 		}
 		return nil, fmt.Errorf("nats utility timed out")
 	case err := <-errCh:

--- a/nats/tests/nats_nix_test.go
+++ b/nats/tests/nats_nix_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func runCommand(cmd string, input string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	execution := exec.Command(cmd, args...)
+
+	execution.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	if input != "" {
+		execution.Stdin = strings.NewReader(input)
+	}
+
+	outCh := make(chan []byte)
+	errCh := make(chan error)
+	go func() {
+		out, err := execution.CombinedOutput()
+		if err != nil {
+			errCh <- err
+		} else {
+			outCh <- out
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		if execution.Process != nil {
+			_ = syscall.Kill(execution.Process.Pid, syscall.SIGKILL)
+		}
+		return nil, fmt.Errorf("nats utility timed out")
+	case err := <-errCh:
+		return nil, fmt.Errorf("nats utility failed: %v\n%v", err, string(<-outCh))
+	case out := <-outCh:
+		return out, nil
+	}
+}

--- a/nats/tests/nats_test.go
+++ b/nats/tests/nats_test.go
@@ -62,12 +62,15 @@ func runNatsCliWithInput(t *testing.T, input string, args ...string) (output []b
 	t.Helper()
 
 	var cmd []string
+	var err error
 	if os.Getenv("CI") == "true" {
-		cmd, _ = shellquote.Split(fmt.Sprintf("../nats %s", strings.Join(args, " ")))
+		cmd, err = shellquote.Split(fmt.Sprintf("../nats %s", strings.Join(args, " ")))
 	} else {
-		cmd, _ = shellquote.Split(fmt.Sprintf("run ../main.go %s", strings.Join(args, " ")))
+		cmd, err = shellquote.Split(fmt.Sprintf("run ../main.go %s", strings.Join(args, " ")))
 	}
-
+	if err != nil {
+		t.Fatalf("spliting command argument string failed: %v", err)
+	}
 	out, err := runCommand("go", input, cmd...)
 	if err != nil {
 		t.Fatalf("%v", err)

--- a/nats/tests/nats_windows_test.go
+++ b/nats/tests/nats_windows_test.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCommand(cmd string, input string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	execution := exec.Command(cmd, args...)
+
+	if input != "" {
+		execution.Stdin = strings.NewReader(input)
+	}
+
+	outCh := make(chan []byte)
+	errCh := make(chan error)
+	go func() {
+		out, err := execution.CombinedOutput()
+		if err != nil {
+			errCh <- err
+		} else {
+			outCh <- out
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("nats utility timed out")
+	case err := <-errCh:
+		return nil, fmt.Errorf("nats utility failed: %v\n%v", err, string(<-outCh))
+	case out := <-outCh:
+		return out, nil
+	}
+}


### PR DESCRIPTION
The tests relied on `bash -c` to take in the commands from strings, as created by `fmt.Sprintf` statements throughout the code. This isn't available on Windows, the equivalent `cmd /c` does not support `""` or `''` quotes for arguments which would break a few of the tests. 

`exec.Command()` expects to take a slice and when provided with a slice of arguments the spaces do not matter - nor is there a need for `bash -c` or `cmd /c`. 

This PR provides the following:
* Converts all command arguments from strings to slices
* Fixes the timeout, it was not working as bash was spawning go and go the program. 
* Provides an implementation for *nix variants and Windows.

I have tested it on Windows, Linux and Mac. 

Note: For Windows you need `wc` from [coreutils](https://gnuwin32.sourceforge.net/packages/coreutils.htm) in your PATH. The other platforms should have it by default.

Question: In the Command there is the following `$(ls ../*.go | grep -v _test.go)`. Is there a historical purpose of this? The test files have been removed from the folder and there is only one go file now.