### PR TITLE
Add object edit command

### DIFF
--- a/cli/object_command.go
+++ b/cli/object_command.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/jedib0t/go-pretty/v6/progress"
 	"io"
 	"os"
 	"path/filepath"
@@ -25,15 +24,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nats-io/nats.go/jetstream"
-	iu "github.com/nats-io/natscli/internal/util"
-
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/choria-io/fisk"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
+	"github.com/jedib0t/go-pretty/v6/progress"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	iu "github.com/nats-io/natscli/internal/util"
 )
 
 type objCommand struct {


### PR DESCRIPTION
Closes #1262 .
Edit for kv is already provided by another contribution. Inspired by that, here is the edit command for object store buckets.
Also there's a bonus commit here to sort the imports (they are sorted in other files, this one was probably missing).