### PR TITLE
goreleaser: adapt to deprecated archives.format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,7 +44,8 @@ builds:
 archives:
   - name_template: "nats-{{.Version}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"
     wrap_in_directory: true
-    format: zip
+    formats:
+      - zip
     files:
       - README.md
       - LICENSE


### PR DESCRIPTION
Per <https://goreleaser.com/deprecations/#archivesformat> the `archives.format` entry has been deprecated since GoReleaser v2.6.  It's now on 2.9.

Our GH Actions semver constraint is `~> 2`, so this should be a safe change for everyone except those with stale local installs of GoReleaser.
