### PR TITLE
Release using stable go

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Install deps
         shell: bash --noprofile --norc -x -eo pipefail {0}


### PR DESCRIPTION
This ensures we use latest go and not latest-1