### PR TITLE
(#1393) Add --api-level flag to stream find and consumer find commands

### DIFF
--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -125,6 +125,7 @@ type consumerCmd struct {
 	groupName          string
 	fPinned            bool
 	placementPreferred string
+	apiLevel           int
 }
 
 func configureConsumerCommand(app commandHost) {
@@ -227,6 +228,7 @@ func configureConsumerCommand(app commandHost) {
 	consFind.Flag("pinned", "Finds Pinned Client priority group consumers that are fully pinned").UnNegatableBoolVar(&c.fPinned)
 	consFind.Flag("invert", "Invert the check - before becomes after, with becomes without").BoolVar(&c.fInvert)
 	consFind.Flag("expression", "Match consumers using an expression language").StringVar(&c.fExpression)
+	consFind.Flag("api-level", "Match consumers that support at least the given api level").IntVar(&c.apiLevel)
 
 	consInfo := cons.Command("info", "Consumer information").Alias("nfo").Action(c.infoAction)
 	consInfo.Arg("stream", "Stream name").StringVar(&c.stream)
@@ -432,6 +434,9 @@ func (c *consumerCmd) findAction(_ *fisk.ParseContext) error {
 	}
 	if c.fPinned {
 		opts = append(opts, jsm.ConsumerQueryIsPinned())
+	}
+	if c.apiLevel > 0 {
+		opts = append(opts, jsm.ConsumerQueryApiLevelMin(c.apiLevel))
 	}
 
 	found, err := stream.QueryConsumers(opts...)

--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -163,6 +163,7 @@ type streamCmd struct {
 	allowMsgTTL               bool
 	subjectDeleteMarkerTTLSet bool
 	subjectDeleteMarkerTTL    time.Duration
+	apiLevel                  int
 }
 
 type streamStat struct {
@@ -314,6 +315,7 @@ Finding streams with certain subjects configured:
 	strFind.Flag("names", "Show just the stream names").Short('n').UnNegatableBoolVar(&c.listNames)
 	strFind.Flag("invert", "Invert the check - before becomes after, with becomes without").BoolVar(&c.fInvert)
 	strFind.Flag("expression", "Match streams using an expression language").StringVar(&c.fExpression)
+	strFind.Flag("api-level", "Match streams that support at least the given api level").IntVar(&c.apiLevel)
 
 	strInfo := str.Command("info", "Stream information").Alias("nfo").Alias("i").Action(c.infoAction)
 	strInfo.Arg("stream", "Stream to retrieve information for").StringVar(&c.stream)
@@ -846,6 +848,9 @@ func (c *streamCmd) findAction(_ *fisk.ParseContext) (err error) {
 	}
 	if c.fLeader != "" {
 		opts = append(opts, jsm.StreamQueryLeaderServer(c.fLeader))
+	}
+	if c.apiLevel > 0 {
+		opts = append(opts, jsm.StreamQueryApiLevelMin(c.apiLevel))
 	}
 
 	found, err := c.mgr.QueryStreams(opts...)


### PR DESCRIPTION
api-level will cause find to return the streams or consumers where the minimum required api level matches the given value.

If stream S1 requires api-level 1, --api-level=1 will return it and --api-level=2 will not. The same applies for consumers.