### PR TITLE
(#1393) Add downgrade safety report

### DIFF
--- a/cli/server_consumer_check.go
+++ b/cli/server_consumer_check.go
@@ -91,7 +91,7 @@ func (c *ConsumerCheckCmd) consumerCheck(_ *fisk.ParseContext) error {
 		fmt.Printf("Connected in %.3fs\n", time.Since(start).Seconds())
 	}
 
-	sys := sysclient.New(nc)
+	sys := sysclient.New(nc, opts().Trace)
 
 	if !c.stdin {
 		if c.expected == 0 {

--- a/cli/server_stream_check.go
+++ b/cli/server_stream_check.go
@@ -85,7 +85,7 @@ func (c *StreamCheckCmd) streamCheck(_ *fisk.ParseContext) error {
 		}
 	}
 
-	sys := sysclient.New(nc)
+	sys := sysclient.New(nc, opts().Trace)
 
 	start = time.Now()
 	servers, err := sys.FindServers(c.stdin, c.expected, opts().Timeout, time.Duration(c.readTimeout), false)

--- a/internal/sysclient/sysclient.go
+++ b/internal/sysclient/sysclient.go
@@ -15,12 +15,14 @@ package sysclient
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/nats-io/nats-server/v2/server"
@@ -43,7 +45,8 @@ type (
 	// SysClient can be used to request monitoring data from the server.
 	// This is used by the stream-check and consumer-check commands
 	SysClient struct {
-		nc *nats.Conn
+		nc    *nats.Conn
+		trace bool
 	}
 
 	FetchOpts struct {
@@ -60,12 +63,15 @@ type (
 	}
 )
 
-func New(nc *nats.Conn) SysClient {
+// New creates an instace of SyscClient
+func New(nc *nats.Conn, trace bool) SysClient {
 	return SysClient{
-		nc: nc,
+		nc:    nc,
+		trace: trace,
 	}
 }
 
+// JszPing sends a PING request to the JSZ endpoint and returns parsed responses.
 func (s *SysClient) JszPing(opts server.JszEventOptions, fopts ...FetchOpt) ([]JSZResp, error) {
 	subj := fmt.Sprintf(srvJszSubj, "PING")
 	payload, err := json.Marshal(opts)
@@ -87,48 +93,191 @@ func (s *SysClient) JszPing(opts server.JszEventOptions, fopts ...FetchOpt) ([]J
 	return srvJsz, nil
 }
 
+// FetchJszPaged pages through JSZ account data from all servers.
+// It calls the provided function for each page of AccountDetail results.
+func (s *SysClient) FetchJszPaged(baseOpts server.JszEventOptions, limit int, timeout time.Duration, active int, fn func([]*server.AccountDetail)) error {
+	offsets := map[string]int{}
+	fopts := []FetchOpt{fetchTimeout(timeout)}
+	if active > 0 {
+		fopts = append(fopts, fetchExpected(active))
+	}
+	baseOpts.Limit = limit
+
+	// Initial request
+	initialPages, err := s.JszPing(baseOpts, fopts...)
+	if err != nil {
+		return err
+	}
+
+	for _, page := range initialPages {
+		name := page.Server.Name
+		fn(page.JSInfo.AccountDetails)
+		if len(page.JSInfo.AccountDetails) == baseOpts.Limit {
+			offsets[name] = baseOpts.Offset + baseOpts.Limit
+		}
+	}
+
+	fopts = append(fopts, fetchExpected(1))
+
+	// iterate through all the servers that still have pages
+	for len(offsets) > 0 {
+		for name, offset := range offsets {
+			opts := baseOpts
+			opts.EventFilterOptions.Name = name
+			opts.Offset = offset
+
+			page, err := s.JszPing(opts, fopts...)
+			if err != nil {
+				return err
+			}
+			if len(page) == 0 {
+				delete(offsets, name)
+				continue
+			}
+
+			jsz := page[0]
+			fn(jsz.JSInfo.AccountDetails)
+
+			if len(jsz.JSInfo.AccountDetails) == baseOpts.Limit {
+				offsets[name] += baseOpts.Limit
+			} else {
+				delete(offsets, name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// CollectClusterAccounts gathers account-level JetStream metadata from the cluster.
+// It fetches paged JSZ responses and merges streams across pages for each account.
+func (s *SysClient) CollectClusterAccounts(timeout time.Duration, active int) ([]*server.AccountDetail, error) {
+	accountMap := map[string]*server.AccountDetail{}
+	opts := server.JszEventOptions{
+		JSzOptions: server.JSzOptions{
+			Accounts: true,
+			Streams:  true,
+			Consumer: true,
+			Config:   true,
+		},
+	}
+
+	err := s.FetchJszPaged(opts, 1024, timeout, active, func(pages []*server.AccountDetail) {
+		for _, acct := range pages {
+			if existing, found := accountMap[acct.Name]; found {
+				existing.Streams = mergeStreams(existing.Streams, acct.Streams)
+			} else {
+				copy := *acct
+				accountMap[acct.Name] = &copy
+			}
+		}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var accounts []*server.AccountDetail
+	for _, acct := range accountMap {
+		accounts = append(accounts, acct)
+	}
+
+	sort.Slice(accounts, func(i, j int) bool { return accounts[i].Name < accounts[j].Name })
+	for _, acct := range accounts {
+		sort.Slice(acct.Streams, func(i, j int) bool { return acct.Streams[i].Name < acct.Streams[j].Name })
+	}
+
+	return accounts, nil
+}
+
+// Fetch publishes a request to the given subject and collects replies.
+// If FetchOpts.Expected > 0, it blocks until that number of replies is received or the timeout elapses.
+// If FetchOpts.Expected == 0, it collects as many replies as possible until the discovery interval elapses with no new data.
 func (s *SysClient) Fetch(subject string, data []byte, opts ...FetchOpt) ([]*nats.Msg, error) {
 	if subject == "" {
 		return nil, fmt.Errorf("%w: expected subject 0", ErrValidation)
 	}
 
-	conn := s.nc
-	reqOpts := &FetchOpts{}
+	reqOpts := defaultFetchOpts()
 	for _, opt := range opts {
 		if err := opt(reqOpts); err != nil {
 			return nil, err
 		}
 	}
 
-	inbox := nats.NewInbox()
-	res := make([]*nats.Msg, 0)
-	msgsChan := make(chan *nats.Msg, 100)
+	ctx, cancel := context.WithTimeout(context.Background(), reqOpts.Timeout)
+	defer cancel()
 
-	readTimer := time.NewTimer(reqOpts.ReadTimeout)
-	sub, err := conn.Subscribe(inbox, func(msg *nats.Msg) {
-		readTimer.Reset(reqOpts.ReadTimeout)
+	inbox := nats.NewInbox()
+	msgsChan := make(chan *nats.Msg, 256)
+	res := make([]*nats.Msg, 0, 32)
+
+	sub, err := s.nc.Subscribe(inbox, func(msg *nats.Msg) {
+		if s.trace {
+			log.Printf("<<< %q", msg.Data)
+		}
 		msgsChan <- msg
 	})
+	if err != nil {
+		return nil, err
+	}
 	defer sub.Unsubscribe()
 
-	if err := conn.PublishRequest(subject, inbox, data); err != nil {
+	if s.trace {
+		log.Printf(">>> %s: %s", subject, string(data))
+	}
+	if err := s.nc.PublishRequest(subject, inbox, data); err != nil {
 		return nil, err
 	}
 
+	if reqOpts.Expected == 0 {
+		return s.fetchUntilTimeout(ctx, msgsChan, res, reqOpts)
+	}
+	return s.fetchUntilExpected(ctx, msgsChan, res, reqOpts)
+}
+
+func (s *SysClient) fetchUntilTimeout(ctx context.Context, msgsChan <-chan *nats.Msg, res []*nats.Msg, reqOpts *FetchOpts) ([]*nats.Msg, error) {
+	defaultInterval := 2 * time.Second
+	discoveryInterval := max(min(defaultInterval, reqOpts.Timeout/2), 10*time.Millisecond)
+
+	timer := time.NewTimer(discoveryInterval)
+	defer timer.Stop()
+
 	for {
 		select {
+		case <-ctx.Done():
+			return res, fmt.Errorf("server request timed out")
+		case <-timer.C:
+			return res, nil
 		case msg := <-msgsChan:
 			if msg.Header.Get("Status") == "503" {
-				return nil, fmt.Errorf("server request on subject %q failed: %w", subject, err)
+				return nil, fmt.Errorf("server request on subject %q failed: %w", msg.Subject, ErrInvalidServerID)
 			}
 			res = append(res, msg)
-			if reqOpts.Expected != -1 && len(res) == reqOpts.Expected {
+			timer.Reset(discoveryInterval)
+		}
+	}
+}
+
+func (s *SysClient) fetchUntilExpected(ctx context.Context, msgsChan <-chan *nats.Msg, res []*nats.Msg, reqOpts *FetchOpts) ([]*nats.Msg, error) {
+	timer := time.NewTimer(reqOpts.ReadTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return res, fmt.Errorf("server request timed out")
+		case <-timer.C:
+			return res, fmt.Errorf("server request timed out (received %d of %d expected)", len(res), reqOpts.Expected)
+		case msg := <-msgsChan:
+			if msg.Header.Get("Status") == "503" {
+				return nil, fmt.Errorf("server request on subject %q failed: %w", msg.Subject, ErrInvalidServerID)
+			}
+			res = append(res, msg)
+			if len(res) >= reqOpts.Expected {
 				return res, nil
 			}
-		case <-readTimer.C:
-			return res, nil
-		case <-time.After(reqOpts.Timeout):
-			return res, nil
+			timer.Reset(reqOpts.ReadTimeout)
 		}
 	}
 }
@@ -203,6 +352,28 @@ func (s *SysClient) FindServers(stdin bool, expected int, timeout time.Duration,
 	}
 
 	return servers, nil
+}
+
+func mergeStreams(a, b []server.StreamDetail) []server.StreamDetail {
+	seen := map[string]any{}
+	var result []server.StreamDetail
+
+	for _, s := range append(a, b...) {
+		if _, found := seen[s.Name]; found {
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		result = append(result, s)
+	}
+	return result
+}
+
+func defaultFetchOpts() *FetchOpts {
+	return &FetchOpts{
+		Timeout:     5 * time.Second,
+		ReadTimeout: 2 * time.Second,
+		Expected:    0,
+	}
 }
 
 func fetchTimeout(timeout time.Duration) FetchOpt {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -639,3 +639,13 @@ func ParseStringAsBytes(s string) (int64, error) {
 
 	return num, nil
 }
+
+// ParseApiLevel takes an api level string and converts it to an unsigned int for comparison.
+// An empty level will be converted into 0
+func ParseApiLevel(lvl string) uint {
+	if lvl == "" {
+		return 0
+	}
+	i, _ := strconv.Atoi(lvl)
+	return uint(i)
+}


### PR DESCRIPTION
This commit introduces a new CLI command: `report downgrade`.

Running `nats report downgrade <api-level>` checks the required API levels for streams and consumers, and reports which assets would fail to start if the server were downgraded to the specified API level.

By default, only consumers that are directly incompatible are shown. To include consumers that inherit incompatibility from their streams, use the `--all` flag.

Output is shown in a table format by default. `--json` is also included.