### PR TITLE
switch BoolVars that default to false to UnNegatableBoolVar

### DIFF
--- a/cli/auth_account_command.go
+++ b/cli/auth_account_command.go
@@ -118,12 +118,12 @@ func configureAuthAccountCommand(auth commandHost) {
 	acct := auth.Command("account", "Manage NATS Accounts").Alias("a").Alias("acct").Alias("act")
 
 	addCreateFlags := func(f *fisk.CmdClause, edit bool) {
-		f.Flag("bearer", "Allows bearer tokens").Default("false").IsSetByUser(&c.bearerAllowedIsSet).BoolVar(&c.bearerAllowed)
+		f.Flag("bearer", "Allows bearer tokens").Default("false").IsSetByUser(&c.bearerAllowedIsSet).UnNegatableBoolVar(&c.bearerAllowed)
 		f.Flag("connections", "Maximum allowed connections").Default("-1").IsSetByUser(&c.maxConnsIsSet).Int64Var(&c.maxConns)
 		f.Flag("expiry", "How long this account should be valid for as a duration").PlaceHolder("DURATION").DurationVar(&c.expiry)
 		f.Flag("exports", "Maximum allowed exports").Default("-1").IsSetByUser(&c.maxExportsIsSet).Int64Var(&c.maxExports)
 		f.Flag("imports", "Maximum allowed imports").Default("-1").IsSetByUser(&c.maxImportsIsSet).Int64Var(&c.maxImports)
-		f.Flag("jetstream", "Enables JetStream").Default("false").IsSetByUser(&c.jetStreamIsSet).BoolVar(&c.jetStream)
+		f.Flag("jetstream", "Enables JetStream").Default("false").IsSetByUser(&c.jetStreamIsSet).UnNegatableBoolVar(&c.jetStream)
 		f.Flag("js-consumers", "Sets the maximum Consumers the account can have").Default("-1").IsSetByUser(&c.maxConsumersIsSet).Int64Var(&c.maxConsumers)
 		f.Flag("js-disk", "Sets a Disk Storage quota").PlaceHolder("BYTES").StringVar(&c.storeMaxString)
 		f.Flag("js-disk-stream", "Sets the maximum size a Disk Storage stream may be").PlaceHolder("BYTES").Default("-1").StringVar(&c.storeMaxStreamString)
@@ -267,7 +267,7 @@ func configureAuthAccountCommand(auth commandHost) {
 	skadd.Flag("description", "Description for the signing key").StringVar(&c.description)
 	skadd.Flag("subscriptions", "Maximum allowed subscriptions").Default("-1").Int64Var(&c.maxSubs)
 	skadd.Flag("payload", "Maximum allowed payload").PlaceHolder("BYTES").StringVar(&c.maxPayloadString)
-	skadd.Flag("bearer", "Allows bearer tokens").Default("false").BoolVar(&c.bearerAllowed)
+	skadd.Flag("bearer", "Allows bearer tokens").Default("false").UnNegatableBoolVar(&c.bearerAllowed)
 	skadd.Flag("locale", "Locale for the client").StringVar(&c.locale)
 	skadd.Flag("connection", "Set the allowed connections (nats, ws, wsleaf, mqtt)").EnumsVar(&c.connTypes, "nats", "ws", "leaf", "wsleaf", "mqtt")
 	skadd.Flag("pub-allow", "Sets subjects where publishing is allowed").StringsVar(&c.pubAllow)

--- a/cli/bench_command.go
+++ b/cli/bench_command.go
@@ -124,7 +124,7 @@ func configureBenchCommand(app commandHost) {
 		f.Flag("consumer", "Specify the durable consumer name to use").Default(benchDefaultDurableConsumerName).StringVar(&c.consumerName)
 		f.Flag("batch", "Sets the max number of messages that can be buffered in the client").Default("500").IntVar(&c.batchSize)
 		f.Flag("acks", "Acknowledgement mode for the consumer").Default(benchAckModeExplicit).EnumVar(&c.ackMode, benchAckModeExplicit, benchAckModeNone, benchAckModeAll)
-		f.Flag("doubleack", "Synchronously acknowledge messages, waiting for a reply from the server").Default("false").BoolVar(&c.doubleAck)
+		f.Flag("doubleack", "Synchronously acknowledge messages, waiting for a reply from the server").Default("false").UnNegatableBoolVar(&c.doubleAck)
 		f.Flag("filter", "Filter Stream by subjects").PlaceHolder("SUBJECTS").StringsVar(&c.filterSubjects)
 	}
 
@@ -219,14 +219,14 @@ func configureBenchCommand(app commandHost) {
 	oldJSPush.Flag("consumer", "Specify the durable consumer name to use").Default(benchDefaultDurableConsumerName).StringVar(&c.consumerName)
 	oldJSPush.Flag("maxacks", "Sets the max ack pending value, adjusts for the number of clients").Default("500").IntVar(&c.batchSize)
 	oldJSPush.Flag("ack", "Uses explicit message acknowledgement or not for the consumer").Default("true").BoolVar(&c.ack)
-	oldJSPush.Flag("doubleack", "Synchronously acknowledge messages, waiting for a reply from the server").Default("false").BoolVar(&c.doubleAck)
+	oldJSPush.Flag("doubleack", "Synchronously acknowledge messages, waiting for a reply from the server").Default("false").UnNegatableBoolVar(&c.doubleAck)
 
 	oldJSPull := oldJSCommand.Command("pull", "Consume JetStream messages from a consumer using an old JS API's durable pull consumer").Action(c.oldjsPullAction)
 	oldJSPull.Arg("subject", "Subject to use for the benchmark").Required().StringVar(&c.subject)
 	oldJSPull.Flag("consumer", "Specify the durable consumer name to use").Default(benchDefaultDurableConsumerName).StringVar(&c.consumerName)
 	oldJSPull.Flag("batch", "Sets the fetch size for the consumer").Default("500").IntVar(&c.batchSize)
 	oldJSPull.Flag("ack", "Uses explicit message acknowledgement or not for the consumer").Default("true").BoolVar(&c.ack)
-	oldJSPull.Flag("doubleack", "Synchronously acknowledge messages, waiting for a reply from the server").Default("false").BoolVar(&c.doubleAck)
+	oldJSPull.Flag("doubleack", "Synchronously acknowledge messages, waiting for a reply from the server").Default("false").UnNegatableBoolVar(&c.doubleAck)
 
 }
 


### PR DESCRIPTION
Follow up to 
https://github.com/nats-io/natscli/pull/506

```
# diff --color --minimal --context=0 <(nats --help-long) <(go run ./nats --help-long)
*** /dev/fd/63  2025-07-17 15:24:03.539293706 +0300
--- /dev/fd/62  2025-07-17 15:24:03.540293715 +0300
***************
*** 176 ****
!     --[no-]bearer                 Allows bearer tokens
--- 176 ----
!     --bearer                      Allows bearer tokens
***************
*** 182 ****
!     --[no-]jetstream              Enables JetStream
--- 182 ----
!     --jetstream                   Enables JetStream
***************
*** 212 ****
!     --[no-]bearer                 Allows bearer tokens
--- 212 ----
!     --bearer                      Allows bearer tokens
***************
*** 218 ****
!     --[no-]jetstream              Enables JetStream
--- 218 ----
!     --jetstream                   Enables JetStream
***************
*** 332 ****
!     --[no-]bearer                Allows bearer tokens
--- 332 ----
!     --bearer                     Allows bearer tokens
***************
*** 550 ****
!     --[no-]doubleack         Synchronously acknowledge messages, waiting for a
--- 550 ----
!     --doubleack              Synchronously acknowledge messages, waiting for a
***************
*** 561 ****
!     --[no-]doubleack         Synchronously acknowledge messages, waiting for a
--- 561 ----
!     --doubleack              Synchronously acknowledge messages, waiting for a
***************
*** 598 ****
!     --[no-]doubleack         Synchronously acknowledge messages, waiting for a
--- 598 ----
!     --doubleack              Synchronously acknowledge messages, waiting for a
***************
*** 609 ****
!     --[no-]doubleack         Synchronously acknowledge messages, waiting for a
--- 609 ----
!     --doubleack              Synchronously acknowledge messages, waiting for a
```

