### PR TITLE
Align with the needs of go 1.24 go vet

### DIFF
--- a/cli/server_check_command.go
+++ b/cli/server_check_command.go
@@ -293,7 +293,7 @@ func (c *SrvCheckCmd) checkRequest(_ *fisk.ParseContext) error {
 	} else {
 		err = monitor.CheckRequestWithConnection(nc, check, opts().Timeout, checkOpts)
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -340,7 +340,7 @@ func (c *SrvCheckCmd) checkConsumer(_ *fisk.ParseContext) error {
 	} else {
 		err = monitor.CheckConsumerHealthWithConnection(mgr, check, checkOpts, logger)
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -364,7 +364,7 @@ func (c *SrvCheckCmd) checkKV(_ *fisk.ParseContext) error {
 	} else {
 		err = monitor.CheckKVBucketAndKeyWithConnection(nc, check, checkOpts)
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -398,7 +398,7 @@ func (c *SrvCheckCmd) checkSrv(_ *fisk.ParseContext) error {
 	} else {
 		err = monitor.CheckServerWithConnection(nc, check, opts().Timeout, checkOpts)
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -429,7 +429,7 @@ func (c *SrvCheckCmd) checkJS(_ *fisk.ParseContext) error {
 	} else {
 		err = monitor.CheckJetStreamAccountWithConnection(mgr, check, checkOpts)
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -452,7 +452,7 @@ func (c *SrvCheckCmd) checkRaft(_ *fisk.ParseContext) error {
 	} else {
 		err = monitor.CheckJetstreamMetaWithConnection(nc, check, checkOpts)
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -512,7 +512,7 @@ func (c *SrvCheckCmd) checkStream(_ *fisk.ParseContext) error {
 	} else {
 		err = monitor.CheckStreamHealthWithConnection(mgr, check, checkOpts, logger)
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -538,7 +538,7 @@ func (c *SrvCheckCmd) checkMsg(_ *fisk.ParseContext) error {
 	} else {
 		err = monitor.CheckStreamMessageWithConnection(mgr, check, checkOpts)
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -549,7 +549,7 @@ func (c *SrvCheckCmd) checkConnection(_ *fisk.ParseContext) error {
 
 	if opts().Config == nil {
 		err := loadContext(false)
-		if check.CriticalIfErr(err, "loading context failed: %v", err) {
+		if check.CriticalIfErrf(err, "loading context failed: %v", err) {
 			return nil
 		}
 	}
@@ -571,7 +571,7 @@ func (c *SrvCheckCmd) checkConnection(_ *fisk.ParseContext) error {
 	} else {
 		err = fmt.Errorf("connection checks are not supported when a connection is supplied")
 	}
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }
@@ -586,7 +586,7 @@ func (c *SrvCheckCmd) checkCredentialAction(_ *fisk.ParseContext) error {
 		ValidityCritical: c.credentialValidityCrit.Seconds(),
 		RequiresExpiry:   c.credentialRequiresExpire,
 	})
-	check.CriticalIfErr(err, "Check failed: %v", err)
+	check.CriticalIfErrf(err, "Check failed: %v", err)
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.6.8
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.18.0
-	github.com/nats-io/jsm.go v0.2.5-0.20250811163717-7a9cbee311a2
+	github.com/nats-io/jsm.go v0.2.5-0.20250813194955-1e93ec03b8b2
 	github.com/nats-io/jwt/v2 v2.8.0
 	github.com/nats-io/nats-server/v2 v2.12.0-preview.1
 	github.com/nats-io/nats.go v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nats-io/jsm.go v0.2.5-0.20250811163717-7a9cbee311a2 h1:WPEKmWX4sbNyxthThAPQaTHdWP3YswOvbYE02LrEgUQ=
-github.com/nats-io/jsm.go v0.2.5-0.20250811163717-7a9cbee311a2/go.mod h1:KG7rEOL6q1CWpWpAS12XKP8iq0gWbb3KHAhx4umtEQQ=
+github.com/nats-io/jsm.go v0.2.5-0.20250813194955-1e93ec03b8b2 h1:tvdct0rQ6frf0O+uKHXCiYekxlzLHOgWLhFhyCub9ro=
+github.com/nats-io/jsm.go v0.2.5-0.20250813194955-1e93ec03b8b2/go.mod h1:KG7rEOL6q1CWpWpAS12XKP8iq0gWbb3KHAhx4umtEQQ=
 github.com/nats-io/jwt/v2 v2.8.0 h1:K7uzyz50+yGZDO5o772eRE7atlcSEENpL7P+b74JV1g=
 github.com/nats-io/jwt/v2 v2.8.0/go.mod h1:me11pOkwObtcBNR8AiMrUbtVOUGkqYjMQZ6jnSdVUIA=
 github.com/nats-io/nats-server/v2 v2.12.0-preview.1 h1:1gPkB7c8bY3umtIZS4bCN5Vz2Covaxpfz3E0Daqnk/8=

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -116,17 +116,17 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		defer result.Collect(ch)
 
 		nctx, err := e.natsContext(check)
-		if result.CriticalIfErr(err, "could not load context: %v", err) {
+		if result.CriticalIfErrf(err, "could not load context: %v", err) {
 			return
 		}
 
 		opts, err := nctx.NATSOptions()
-		if result.CriticalIfErr(err, "could not load context: %v", err) {
+		if result.CriticalIfErrf(err, "could not load context: %v", err) {
 			return
 		}
 
 		jsmopts, err := nctx.JSMOptions()
-		if result.CriticalIfErr(err, "could not load jetstream options: %v", err) {
+		if result.CriticalIfErrf(err, "could not load jetstream options: %v", err) {
 			return
 		}
 
@@ -183,12 +183,12 @@ func (e *Exporter) natsContext(check *Check) (*natscontext.Context, error) {
 func (e *Exporter) checkRequest(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
 	copts := monitor.CheckRequestOptions{}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	nc, _, err := check.connect(servers, natsOpts, jsmOpts)
-	if result.CriticalIfErr(err, "connection failed: %v", err) {
+	if result.CriticalIfErrf(err, "connection failed: %v", err) {
 		return
 	}
 
@@ -197,29 +197,29 @@ func (e *Exporter) checkRequest(servers string, natsOpts []nats.Option, jsmOpts 
 	} else {
 		err = monitor.CheckRequest(servers, natsOpts, result, 5*time.Second, copts)
 	}
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkCredential(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
 	copts := monitor.CheckCredentialOptions{}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	err = monitor.CheckCredential(result, copts)
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkServer(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
 	copts := monitor.CheckServerOptions{}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	nc, _, err := check.connect(servers, natsOpts, jsmOpts)
-	if result.CriticalIfErr(err, "connection failed: %v", err) {
+	if result.CriticalIfErrf(err, "connection failed: %v", err) {
 		return
 	}
 
@@ -228,7 +228,7 @@ func (e *Exporter) checkServer(servers string, natsOpts []nats.Option, jsmOpts [
 	} else {
 		err = monitor.CheckServer(servers, natsOpts, result, time.Second, copts)
 	}
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkJetStream(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
@@ -243,12 +243,12 @@ func (e *Exporter) checkJetStream(servers string, natsOpts []nats.Option, jsmOpt
 		StreamWarning:     -1,
 	}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	_, mgr, err := check.connect(servers, natsOpts, jsmOpts)
-	if result.CriticalIfErr(err, "connection failed: %v", err) {
+	if result.CriticalIfErrf(err, "connection failed: %v", err) {
 		return
 	}
 
@@ -257,18 +257,18 @@ func (e *Exporter) checkJetStream(servers string, natsOpts []nats.Option, jsmOpt
 	} else {
 		err = monitor.CheckJetStreamAccount(servers, natsOpts, jsmOpts, result, copts)
 	}
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkMeta(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
 	copts := monitor.CheckJetstreamMetaOptions{}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	nc, _, err := check.connect(servers, natsOpts, jsmOpts)
-	if result.CriticalIfErr(err, "connection failed: %v", err) {
+	if result.CriticalIfErrf(err, "connection failed: %v", err) {
 		return
 	}
 
@@ -277,18 +277,18 @@ func (e *Exporter) checkMeta(servers string, natsOpts []nats.Option, jsmOpts []j
 	} else {
 		err = monitor.CheckJetstreamMeta(servers, natsOpts, result, copts)
 	}
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkMessage(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
 	copts := monitor.CheckStreamMessageOptions{}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	_, mgr, err := check.connect(servers, natsOpts, jsmOpts)
-	if result.CriticalIfErr(err, "connection failed: %v", err) {
+	if result.CriticalIfErrf(err, "connection failed: %v", err) {
 		return
 	}
 
@@ -297,7 +297,7 @@ func (e *Exporter) checkMessage(servers string, natsOpts []nats.Option, jsmOpts 
 	} else {
 		err = monitor.CheckStreamMessage(servers, natsOpts, jsmOpts, result, copts)
 	}
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkKv(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
@@ -306,12 +306,12 @@ func (e *Exporter) checkKv(servers string, natsOpts []nats.Option, jsmOpts []jsm
 		ValuesCritical: -1,
 	}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	nc, _, err := check.connect(servers, natsOpts, jsmOpts)
-	if result.CriticalIfErr(err, "connection failed: %v", err) {
+	if result.CriticalIfErrf(err, "connection failed: %v", err) {
 		return
 	}
 
@@ -321,18 +321,18 @@ func (e *Exporter) checkKv(servers string, natsOpts []nats.Option, jsmOpts []jsm
 		err = monitor.CheckKVBucketAndKey(servers, natsOpts, result, copts)
 	}
 
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkConsumer(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
 	copts := monitor.CheckConsumerHealthOptions{}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	_, mgr, err := check.connect(servers, natsOpts, jsmOpts)
-	if result.CriticalIfErr(err, "connection failed: %v", err) {
+	if result.CriticalIfErrf(err, "connection failed: %v", err) {
 		return
 	}
 
@@ -341,18 +341,18 @@ func (e *Exporter) checkConsumer(servers string, natsOpts []nats.Option, jsmOpts
 	} else {
 		err = monitor.CheckConsumerHealth(servers, natsOpts, jsmOpts, result, copts, api.NewDiscardLogger())
 	}
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkStream(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
 	copts := monitor.CheckStreamHealthOptions{}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	_, mgr, err := check.connect(servers, natsOpts, jsmOpts)
-	if result.CriticalIfErr(err, "connection failed: %v", err) {
+	if result.CriticalIfErrf(err, "connection failed: %v", err) {
 		return
 	}
 
@@ -361,16 +361,16 @@ func (e *Exporter) checkStream(servers string, natsOpts []nats.Option, jsmOpts [
 	} else {
 		err = monitor.CheckStreamHealth(servers, natsOpts, jsmOpts, result, copts, api.NewDiscardLogger())
 	}
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }
 
 func (e *Exporter) checkConnection(servers string, natsOpts []nats.Option, jsmOpts []jsm.Option, check *Check, result *monitor.Result) {
 	copts := monitor.CheckConnectionOptions{}
 	err := yaml.Unmarshal(check.Properties, &copts)
-	if result.CriticalIfErr(err, "invalid properties: %v", err) {
+	if result.CriticalIfErrf(err, "invalid properties: %v", err) {
 		return
 	}
 
 	err = monitor.CheckConnection(servers, natsOpts, 2*time.Second, result, copts)
-	result.CriticalIfErr(err, "check failed: %v", err)
+	result.CriticalIfErrf(err, "check failed: %v", err)
 }


### PR DESCRIPTION
It naively checks anything with a printf style arguments and complains when passed only one argument, even if no alternative exist.

It also only support turning the check off for the entire codebase not just some lines, so we just have to play along