### PR TITLE
Fix MULTILEADER detection in stream/consumer check

### DIFF
--- a/cli/server_consumer_check.go
+++ b/cli/server_consumer_check.go
@@ -258,7 +258,7 @@ func (c *ConsumerCheckCmd) consumerCheck(_ *fisk.ParseContext) error {
 					statuses["NO_CLUSTER_R"] = true
 					unsynced = true
 				}
-				if peer.Cluster.Leader != replica.Cluster.Leader {
+				if peer.Cluster.Leader != "" && replica.Cluster.Leader != "" && peer.Cluster.Leader != replica.Cluster.Leader {
 					statuses["MULTILEADER"] = true
 					unsynced = true
 				}

--- a/cli/server_stream_check.go
+++ b/cli/server_stream_check.go
@@ -181,7 +181,7 @@ func (c *StreamCheckCmd) streamCheck(_ *fisk.ParseContext) error {
 			}
 			// Cannot trust results unless coming from the stream leader.
 			// Need Stream INFO and collect multiple responses instead.
-			if peer.Cluster.Leader != replica.Cluster.Leader {
+			if peer.Cluster.Leader != "" && replica.Cluster.Leader != "" && peer.Cluster.Leader != replica.Cluster.Leader {
 				status = "MULTILEADER"
 				unsynced = true
 			}


### PR DESCRIPTION
`MULTILEADER` should mean there are multiple leaders at the same time. This should be recognized in the data with one peer saying the leader is X, and other peers saying the leader is Y.

However, it would also report `MULTILEADER` if just a single peer is leaderless and reports `peer.Cluster.Leader: ""`. This is incorrect. Instead it should report that single peer as leaderless, and other peers as "in sync/unsynced".