### PR TITLE
Fix the padding on the label for the progress bar for the bench js ordered consumer benchmark

### DIFF
--- a/cli/bench_command.go
+++ b/cli/bench_command.go
@@ -2282,7 +2282,7 @@ func (c *benchCmd) runJSSubscriber(bm *bench.Benchmark, errChan chan error, nc *
 
 	switch benchType {
 	case benchTypeJSOrdered:
-		state = "Receiving"
+		state = "Receiving "
 		consumer, err = s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{FilterSubjects: c.filterSubjects, InactiveThreshold: time.Second * 10})
 		if err != nil {
 			errChan <- fmt.Errorf("creating the ephemeral ordered consumer: %w", err)


### PR DESCRIPTION
Fix the padding on the label for the progress bar for the bench js ordered consumer benchmark