### PR TITLE
feat(stream): add search command to retrive message in stream

### DIFF
--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -1137,7 +1137,7 @@ func (c *streamCmd) viewAction(_ *fisk.ParseContext) error {
 	}()
 
 	shouldTerminate := false
-	filterEnabled := true
+	filterEnabled := false
 	re := (*regexp.Regexp)(nil)
 
 	if exp := strings.TrimSpace(c.vwFilterExp); exp != "" {


### PR DESCRIPTION
Another PR achieves the same purpose as #1486 

### Key Changes

- add `filter` flag params in `view` command which is a regular expression
- add fiilterMode in `viewAction`, it means if users set the filter flag, the output and interactive UI would be different
   - Tip message would be "Found one, Continue?"
   - The loop would not stop util we found one match or reach the end of data

### Demo

<img width="1829" height="408" alt="image" src="https://github.com/user-attachments/assets/b959983d-6c58-4c1b-a746-1669beea025e" />
