### PR TITLE
force number of decimal places on Y axis on graphs

### DIFF
--- a/cli/columns.go
+++ b/cli/columns.go
@@ -39,6 +39,10 @@ func f(v any) string {
 	return columns.F(v)
 }
 
+func fFloatFixedDecimal(v any) string {
+	return humanize.FormatFloat("#,###.##", v.(float64))
+}
+
 func fFloat2Int(v any) string {
 	return columns.F(uint64(v.(float64)))
 }

--- a/cli/consumer_command.go
+++ b/cli/consumer_command.go
@@ -548,7 +548,7 @@ func (c *consumerCmd) graphAction(_ *fisk.ParseContext) error {
 				asciigraph.Height(height/4-2),
 				asciigraph.LowerBound(0),
 				asciigraph.Precision(0),
-				asciigraph.ValueFormatter(f),
+				asciigraph.ValueFormatter(fFloatFixedDecimal),
 			)
 
 			ackedPlot := asciigraph.Plot(ackedRates,
@@ -557,7 +557,7 @@ func (c *consumerCmd) graphAction(_ *fisk.ParseContext) error {
 				asciigraph.Height(height/4-2),
 				asciigraph.LowerBound(0),
 				asciigraph.Precision(0),
-				asciigraph.ValueFormatter(f),
+				asciigraph.ValueFormatter(fFloatFixedDecimal),
 			)
 
 			unprocessedPlot := asciigraph.Plot(unprocessedMessages,

--- a/cli/server_graph_command.go
+++ b/cli/server_graph_command.go
@@ -192,7 +192,7 @@ func (c *SrvGraphCmd) graphJetStream() error {
 			asciigraph.Height(height/6-2),
 			asciigraph.Width(width),
 			asciigraph.Precision(0),
-			asciigraph.ValueFormatter(f))
+			asciigraph.ValueFormatter(fFloatFixedDecimal))
 
 		memPlot := asciigraph.Plot(memUsed,
 			asciigraph.Caption("Memory Storage in GB"),
@@ -218,7 +218,7 @@ func (c *SrvGraphCmd) graphJetStream() error {
 			asciigraph.Height(height/6-2),
 			asciigraph.Width(width),
 			asciigraph.Precision(0),
-			asciigraph.ValueFormatter(f))
+			asciigraph.ValueFormatter(fFloatFixedDecimal))
 
 		pendingPlot := asciigraph.Plot(pending,
 			asciigraph.Caption("Pending API Requests"),
@@ -272,7 +272,7 @@ func (c *SrvGraphCmd) graphServer() error {
 			asciigraph.Height(height/6-2),
 			asciigraph.Width(width),
 			asciigraph.Precision(0),
-			asciigraph.ValueFormatter(f))
+			asciigraph.ValueFormatter(fFloatFixedDecimal))
 
 		memPlot := asciigraph.Plot(memUsed,
 			asciigraph.Caption("Memory Used in MB"),
@@ -299,7 +299,7 @@ func (c *SrvGraphCmd) graphServer() error {
 			asciigraph.Height(height/6-2),
 			asciigraph.Width(width),
 			asciigraph.Precision(0),
-			asciigraph.ValueFormatter(f))
+			asciigraph.ValueFormatter(fFloatFixedDecimal))
 
 		bytesPlot := asciigraph.Plot(bytesRate,
 			asciigraph.Caption("Bytes In+Out / second"),

--- a/cli/stream_command.go
+++ b/cli/stream_command.go
@@ -576,7 +576,7 @@ func (c *streamCmd) graphAction(_ *fisk.ParseContext) error {
 				asciigraph.Height(height/3-2),
 				asciigraph.LowerBound(0),
 				asciigraph.Precision(0),
-				asciigraph.ValueFormatter(f),
+				asciigraph.ValueFormatter(fFloatFixedDecimal),
 			)
 
 			msgRatePlot := asciigraph.Plot(messageRates,
@@ -585,7 +585,7 @@ func (c *streamCmd) graphAction(_ *fisk.ParseContext) error {
 				asciigraph.Height(height/3-2),
 				asciigraph.LowerBound(0),
 				asciigraph.Precision(0),
-				asciigraph.ValueFormatter(f),
+				asciigraph.ValueFormatter(fFloatFixedDecimal),
 			)
 
 			iu.ClearScreen()

--- a/cli/sub_command.go
+++ b/cli/sub_command.go
@@ -223,7 +223,7 @@ func (c *subCmd) startGraph(ctx context.Context, mu *sync.Mutex) {
 						asciigraph.Height((c.height/(len(c.subjects)+1))-1),
 						asciigraph.LowerBound(0),
 						asciigraph.Precision(0),
-						asciigraph.ValueFormatter(f),
+						asciigraph.ValueFormatter(fFloatFixedDecimal),
 					)
 					fmt.Println(msgRatePlot)
 					fmt.Println()


### PR DESCRIPTION
The function that we use to format floats on graph axis 
https://github.com/dustin/go-humanize/blob/v1.0.1/comma.go#L84
drops decimal part. That creates Y-axis labels that are hard to read.
It also causes the position of the axis to readjust as you start at the graph.

In once console:
```
nats bench pub yo --msgs=100000000 --sleep 0.01s
```
In second console:
```
nats  sub 'yo' --graph
```

<img width="172" height="597" alt="image" src="https://github.com/user-attachments/assets/07c5c5d2-fc06-453a-b949-5e37c2750a2d" />


With this change, we always display decimal part, and it makes it easier to parse:
<img width="150" height="599" alt="image" src="https://github.com/user-attachments/assets/fd4ae70e-e058-409b-9101-43bc7733b672" />

Also, drop number of decimal places to two, since that high precision is barely useful in cli graphs.

Fixes: https://github.com/nats-io/natscli/issues/1439

