### PR TITLE
make server a required argument in server graph

### DIFF
--- a/cli/server_graph_command.go
+++ b/cli/server_graph_command.go
@@ -39,7 +39,7 @@ func configureServerGraphCommand(srv *fisk.CmdClause) {
 	c := &SrvGraphCmd{}
 
 	graph := srv.Command("graph", "Show graphs for a single server").Action(c.graph)
-	graph.Arg("server", "Server ID or Name to inspect").StringVar(&c.id)
+	graph.Arg("server", "Server ID or Name to inspect").Required().StringVar(&c.id)
 	graph.Flag("jetstream", "Draw JetStream statistics").Short('j').UnNegatableBoolVar(&c.js)
 }
 


### PR DESCRIPTION
Graphs make sense only when displayed info is coming from a single server

Fixes: https://github.com/nats-io/natscli/issues/1440
```
# go run . server graph
error: required argument 'server' not provided

usage: nats server graph [<flags>] <server>
```