### PR TITLE
Add `--replies-all` to `nats request` for unknown number of replies

### DIFF
--- a/cli/pub_command.go
+++ b/cli/pub_command.go
@@ -37,8 +37,9 @@ import (
 )
 
 const (
-	sendOnEOF     = "eof"
-	sendOnNewline = "newline"
+	sendOnEOF       = "eof"
+	sendOnNewline   = "newline"
+	hdrRepliesTotal = "NATS-Replies-Total"
 )
 
 type pubCmd struct {
@@ -133,7 +134,7 @@ Available template functions are:
 	req.Flag("header", "Adds headers to the message using K:V format").Short('H').StringsVar(&c.hdrs)
 	req.Flag("count", "Publish multiple messages").Default("1").IntVar(&c.cnt)
 	req.Flag("replies", "Wait for multiple replies from services. 0 waits until timeout").Default("1").IntVar(&c.replyCount)
-	req.Flag("replies-all", fmt.Sprintf("Wait for all replies from services. Requires the service to include the header '%s' with the number of replies in the first reply.", hdrReplyCount)).Default("false").UnNegatableBoolVar(&c.repliesAll)
+	req.Flag("replies-all", fmt.Sprintf("Wait for all replies from services. Requires the service to include the header '%s' with the number of replies in the first reply.", hdrRepliesTotal)).Default("false").UnNegatableBoolVar(&c.repliesAll)
 	req.Flag("reply-timeout", "Maximum timeout between incoming replies.").Default("300ms").DurationVar(&c.replyTimeout)
 	req.Flag("translate", "Translate the message data by running it through the given command before output").StringVar(&c.translate)
 	req.Flag("send-on", fmt.Sprintf("When to send data from stdin: '%s' (default) or '%s'", sendOnEOF, sendOnNewline)).Default("eof").EnumVar(&c.sendOn, sendOnNewline, sendOnEOF)
@@ -244,7 +245,7 @@ func (c *pubCmd) doReq(nc *nats.Conn, progress *progress.Tracker) error {
 			}
 
 			if c.repliesAll && rc == 0 {
-				repliesAll := m.Header.Get(hdrReplyCount)
+				repliesAll := m.Header.Get(hdrRepliesTotal)
 				if repliesAll != "" {
 					reployCount, err := strconv.ParseInt(repliesAll, 0, 64)
 					if err != nil {

--- a/cli/pub_command.go
+++ b/cli/pub_command.go
@@ -133,7 +133,7 @@ Available template functions are:
 	req.Flag("header", "Adds headers to the message using K:V format").Short('H').StringsVar(&c.hdrs)
 	req.Flag("count", "Publish multiple messages").Default("1").IntVar(&c.cnt)
 	req.Flag("replies", "Wait for multiple replies from services. 0 waits until timeout").Default("1").IntVar(&c.replyCount)
-	req.Flag("replies-all", "Wait for all replies from services. Requires the service to include the header NATS-Reply-Counter with the number of replies in the first reply.").Default("false").UnNegatableBoolVar(&c.repliesAll)
+	req.Flag("replies-all", fmt.Sprintf("Wait for all replies from services. Requires the service to include the header '%s' with the number of replies in the first reply.", hdrReplyCount)).Default("false").UnNegatableBoolVar(&c.repliesAll)
 	req.Flag("reply-timeout", "Maximum timeout between incoming replies.").Default("300ms").DurationVar(&c.replyTimeout)
 	req.Flag("translate", "Translate the message data by running it through the given command before output").StringVar(&c.translate)
 	req.Flag("send-on", fmt.Sprintf("When to send data from stdin: '%s' (default) or '%s'", sendOnEOF, sendOnNewline)).Default("eof").EnumVar(&c.sendOn, sendOnNewline, sendOnEOF)
@@ -244,7 +244,7 @@ func (c *pubCmd) doReq(nc *nats.Conn, progress *progress.Tracker) error {
 			}
 
 			if c.repliesAll && rc == 0 {
-				repliesAll := m.Header.Get("NATS-Reply-Counter")
+				repliesAll := m.Header.Get(hdrReplyCount)
 				if repliesAll != "" {
 					reployCount, err := strconv.ParseInt(repliesAll, 0, 64)
 					if err != nil {

--- a/cli/reply_command.go
+++ b/cli/reply_command.go
@@ -29,10 +29,6 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-const (
-	hdrReplyCount = "NATS-Reply-Count"
-)
-
 type replyCmd struct {
 	subject string
 	body    string
@@ -144,7 +140,7 @@ func (c *replyCmd) reply(_ *fisk.ParseContext) error {
 					}
 				}
 
-				msg.Header.Add(hdrReplyCount, strconv.Itoa(i))
+				msg.Header.Add("NATS-Reply-Counter", strconv.Itoa(i))
 			}
 
 			msg.Data = m.Data

--- a/cli/reply_command.go
+++ b/cli/reply_command.go
@@ -29,6 +29,10 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+const (
+	hdrReplyCount = "NATS-Reply-Count"
+)
+
 type replyCmd struct {
 	subject string
 	body    string
@@ -140,7 +144,7 @@ func (c *replyCmd) reply(_ *fisk.ParseContext) error {
 					}
 				}
 
-				msg.Header.Add("NATS-Reply-Counter", strconv.Itoa(i))
+				msg.Header.Add(hdrReplyCount, strconv.Itoa(i))
 			}
 
 			msg.Data = m.Data

--- a/nats/tests/pub_command_test.go
+++ b/nats/tests/pub_command_test.go
@@ -281,7 +281,7 @@ func TestCLIRequestRepliesAll(t *testing.T) {
 
 	err = svc.AddEndpoint("test-replies-all", micro.HandlerFunc(func(req micro.Request) {
 		// send three replies
-		headers := nats.Header{"NATS-Reply-Count": {"3"}}
+		headers := nats.Header{"NATS-Replies-Total": {"3"}}
 		req.Respond([]byte("Response 0"), micro.WithHeaders(micro.Headers(headers)))
 		req.Respond([]byte("Response 1"))
 		req.Respond([]byte("Response 2"))


### PR DESCRIPTION
Currently with `--replies` you can configure the number of expected replies to a request. If you do not know the number of expected replies, you can set this number to something high, like 100. Two downsides to this approach are that 1) that number may still be less than the number of replies and 2) if the number of replies is lower, like 99, the CLI will need to wait for the reply timeout.

`--replies-all` solves both of the above problems by allowing the responder to indicate the number of replies it will send via a header, `NATS-Replies-Total`.