### PR TITLE
List multiple RAFT meta groups in server report jetstream 

### DIFF
--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -987,7 +987,7 @@ func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 			}
 
 			header := "RAFT Meta Group Information - Lead cluster: " + cluster.Name
-			table := iu.NewTableWriterf(opts(), header)
+			table := iu.NewTableWriterf(opts(), "%s", header)
 
 			table.AddHeaders("Connection Name", "ID", "Leader", "Current", "Online", "Active", "Lag")
 			for i, replica := range cluster.Replicas {


### PR DESCRIPTION
Fix for https://github.com/nats-io/natscli/issues/1527

Observed behavior

When two cluster with diffrent domains are leaf node connected via a system account $SYS.REQ.SERVER.PING.JSZ will correctly return information from all nodes. AS cann be verified easily with --trace

The Jetstream summary will correctly list ALL nodes across two cluster but will only list ONE RAFT Meta Group Information.

This is somewhat annoying and confusing and makes it very hard to debug connected clusters with this command (short of looking at the raw data of $SYS.REQ.SERVER.PING.JSZ )
Expected behavior

List ALL Raft meta groups in the result. 
