### PR TITLE
Default to a hour timeout for obj get

### DIFF
--- a/cli/object_command.go
+++ b/cli/object_command.go
@@ -563,7 +563,14 @@ func (c *objCommand) getAction(_ *fisk.ParseContext) error {
 		return err
 	}
 
-	res, err := obj.Get(ctx, c.file)
+	getCtx := ctx
+	if opts().Timeout < time.Hour {
+		var cancel context.CancelFunc
+		getCtx, cancel = context.WithTimeout(context.Background(), time.Hour)
+		defer cancel()
+	}
+
+	res, err := obj.Get(getCtx, c.file)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously we were able to run forever due to how background contexts work, new go client is defaulting to same as timeout for the overall get operation.

So we pick 1 hour - or more if user pass a bigger timeout