### PR TITLE
bench command: improve aggregated stats printing

### DIFF
--- a/cli/cheats/bench.md
+++ b/cli/cheats/bench.md
@@ -32,6 +32,12 @@ nats bench service serve testservice --sleep 50us
 # generate load by publishing messages at an interval of 100 nanoseconds rather than back to back
 nats bench pub foo --sleep=100ns
 
+# put messages into a KV using synchronous put operations
+nats bench kv put --clients 10
+
+# get messages from a kv using synchronous get operations and randomizing the key each time
+nats bench kv get --randomize=100000 --clients 10
+
 # remember when benchmarking JetStream
 Once you are finished benchmarking, remember to free up the resources (i.e. memory and files) consumed by the stream using 'nats stream rm'.
 

--- a/internal/bench/stats.go
+++ b/internal/bench/stats.go
@@ -108,11 +108,10 @@ func (bm *BenchmarkResults) Report() string {
 		buffer.WriteString(fmt.Sprintf("%s %s stats: %s\n", bm.Name, GetBenchTypeLabel(bm.BenchType), bm))
 		indent += " "
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s %s aggregated stats: %s\n", bm.Name, GetBenchTypeLabel(bm.BenchType), fmt.Sprintf("%s msgs/sec ~ %s/sec", humanize.Comma(bm.SampleGroup.Rate()), humanize.IBytes(uint64(bm.SampleGroup.Throughput())))))
-		indent += " "
 		for i, stat := range bm.SampleGroup.samples {
-			buffer.WriteString(fmt.Sprintf("%s [%d] %v (%s msgs)\n", indent, i+1, stat, humanize.Comma(int64(stat.jobMsgCnt))))
+			buffer.WriteString(fmt.Sprintf("%s [%d] %v (%s msgs)\n", indent+" ", i+1, stat, humanize.Comma(int64(stat.jobMsgCnt))))
 		}
+		buffer.WriteString(fmt.Sprintf("\n%s %s %s aggregated stats: %s\n", indent, bm.Name, GetBenchTypeLabel(bm.BenchType), fmt.Sprintf("%s msgs/sec ~ %s/sec", humanize.Comma(bm.SampleGroup.Rate()), humanize.IBytes(uint64(bm.SampleGroup.Throughput())))))
 		buffer.WriteString(fmt.Sprintf("%s message rates %s\n", indent, bm.SampleGroup.MsgRateStatistics()))
 		buffer.WriteString(fmt.Sprintf("%s avg latencies %s\n", indent, bm.SampleGroup.LatencyStatistics()))
 	}


### PR DESCRIPTION
Print the aggregated bench run results after printing the list of results for each client as it's more readable that way.