### PR TITLE
fix: misuse of error var in account backup cmd dir scan

### DIFF
--- a/cli/account_command.go
+++ b/cli/account_command.go
@@ -198,7 +198,7 @@ func (c *actCmd) restoreAction(kp *fisk.ParseContext) error {
 	fisk.FatalIfError(err, "setup failed")
 	for _, d := range de {
 		if !d.IsDir() {
-			fisk.FatalIfError(err, "expected a directory")
+			fisk.Fatalf("expected a directory %q", d.Name())
 		}
 		if _, ok := existingStreams[d.Name()]; ok {
 			fisk.Fatalf("stream %q exists already", d.Name())


### PR DESCRIPTION
Reusing err from os.ReadDir inside the loop causes a misleading error check - cmd never exists as intended if searched subpath is not a directory.