### PR TITLE
Handle missing objects, keys and buckets better

### DIFF
--- a/cli/kv_command.go
+++ b/cli/kv_command.go
@@ -277,7 +277,7 @@ func (c *kvCommand) lsBucketKeys() error {
 			fmt.Println(v)
 		}
 	}
-	if !found {
+	if !found && !c.listNames {
 		fmt.Println("No keys found in bucket")
 		return nil
 	}
@@ -343,15 +343,16 @@ func (c *kvCommand) lsBuckets() error {
 		return err
 	}
 
-	if len(found) == 0 {
-		fmt.Println("No Key-Value buckets found")
-		return nil
-	}
-
 	if c.listNames {
 		for _, s := range found {
 			fmt.Println(strings.TrimPrefix(s.Name(), "KV_"))
 		}
+		return nil
+	}
+
+	if len(found) == 0 {
+		fmt.Println("No Key-Value buckets found")
+
 		return nil
 	}
 

--- a/cli/object_command.go
+++ b/cli/object_command.go
@@ -386,7 +386,10 @@ func (c *objCommand) listBuckets() error {
 	}
 
 	if len(found) == 0 {
-		fmt.Println("No Object Store buckets found")
+		if !c.listNames {
+			fmt.Println("No Object Store buckets found")
+		}
+
 		return nil
 	}
 
@@ -428,19 +431,20 @@ func (c *objCommand) lsAction(_ *fisk.ParseContext) error {
 	}
 
 	contents, err := obj.List(ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, jetstream.ErrNoObjectsFound) {
 		return err
-	}
-
-	if len(contents) == 0 {
-		fmt.Println("No entries found")
-		return nil
 	}
 
 	if c.listNames {
 		for _, s := range contents {
 			fmt.Println(s.Name)
 		}
+		return nil
+	}
+
+	if len(contents) == 0 {
+		fmt.Println("No entries found")
+
 		return nil
 	}
 


### PR DESCRIPTION
When listing names using --names its likely people will want to use the command in scripts, we should therefor not print error messages but rather return nothing