### PR TITLE
(#1473) Allow stream-check and consumer-check to show partial results

### DIFF
--- a/cli/server_consumer_check.go
+++ b/cli/server_consumer_check.go
@@ -104,13 +104,16 @@ func (c *ConsumerCheckCmd) consumerCheck(_ *fisk.ParseContext) error {
 
 	start = time.Now()
 	servers, err := sys.FindServers(c.stdin, c.expected, opts().Timeout, time.Duration(c.readTimeout), true)
-	if err != nil {
+	if err != nil && len(servers) == 0 {
 		return fmt.Errorf("failed to find servers: %s", err)
 	}
 
 	if !c.csv {
 		fmt.Printf("Response took %.3fs\n", time.Since(start).Seconds())
 		fmt.Printf("Servers: %d\n", len(servers))
+		if err != nil && len(servers) > 0 {
+			fmt.Printf("Warning: %s\n", err)
+		}
 	}
 
 	streams := make(map[string]map[string]*streamDetail)

--- a/cli/server_stream_check.go
+++ b/cli/server_stream_check.go
@@ -89,13 +89,16 @@ func (c *StreamCheckCmd) streamCheck(_ *fisk.ParseContext) error {
 
 	start = time.Now()
 	servers, err := sys.FindServers(c.stdin, c.expected, opts().Timeout, time.Duration(c.readTimeout), false)
-	if err != nil {
+	if err != nil && len(servers) == 0 {
 		return fmt.Errorf("failed to find servers: %s", err)
 	}
 
 	if !c.csv {
 		fmt.Printf("Response took %.3fs\n", time.Since(start).Seconds())
 		fmt.Printf("Servers: %d\n", len(servers))
+		if err != nil && len(servers) > 0 {
+			fmt.Printf("Warning: %s\n", err)
+		}
 	}
 
 	// Collect all info from servers.

--- a/internal/sysclient/sysclient.go
+++ b/internal/sysclient/sysclient.go
@@ -77,10 +77,7 @@ func (s *SysClient) JszPing(opts server.JszEventOptions, fopts ...FetchOpt) ([]J
 	if err != nil {
 		return nil, err
 	}
-	resp, err := s.Fetch(subj, payload, fopts...)
-	if err != nil {
-		return nil, err
-	}
+	resp, fetchErr := s.Fetch(subj, payload, fopts...)
 	srvJsz := make([]JSZResp, 0, len(resp))
 	for _, msg := range resp {
 		var jszResp JSZResp
@@ -89,7 +86,7 @@ func (s *SysClient) JszPing(opts server.JszEventOptions, fopts ...FetchOpt) ([]J
 		}
 		srvJsz = append(srvJsz, jszResp)
 	}
-	return srvJsz, nil
+	return srvJsz, fetchErr
 }
 
 // FetchJszPaged pages through JSZ account data from all servers.
@@ -104,7 +101,7 @@ func (s *SysClient) FetchJszPaged(baseOpts server.JszEventOptions, limit int, ti
 
 	// Initial request
 	initialPages, err := s.JszPing(baseOpts, fopts...)
-	if err != nil {
+	if err != nil && len(initialPages) == 0 {
 		return err
 	}
 
@@ -344,7 +341,7 @@ func (s *SysClient) FindServers(stdin bool, expected int, timeout time.Duration,
 			JSzOptions: jszOptions,
 		}, fetchTimeout, fetchReadTimeout, fetchExpected)
 		if err != nil {
-			log.Fatal(err)
+			return servers, err
 		}
 	}
 


### PR DESCRIPTION
* Update both commands to show a warning if --expected > actual results
* Display the actual results if there are more than 0