### PR TITLE
Populate missing Raft group in stream/consumer check

### DIFF
--- a/cli/server_consumer_check.go
+++ b/cli/server_consumer_check.go
@@ -126,6 +126,9 @@ func (c *ConsumerCheckCmd) consumerCheck(_ *fisk.ParseContext) error {
 			for _, stream := range acc.Streams {
 				var mok bool
 				var ms map[string]*streamDetail
+				if stream.RaftGroup == "" && stream.Cluster != nil {
+					stream.RaftGroup = stream.Cluster.RaftGroup
+				}
 				mkey := fmt.Sprintf("%s|%s", acc.Name, stream.RaftGroup)
 				if ms, mok = streams[mkey]; !mok {
 					ms = make(map[string]*streamDetail)
@@ -148,6 +151,9 @@ func (c *ConsumerCheckCmd) consumerCheck(_ *fisk.ParseContext) error {
 							raftGroup = cr.RaftGroup
 							break
 						}
+					}
+					if raftGroup == "" && consumer.Cluster != nil {
+						raftGroup = consumer.Cluster.RaftGroup
 					}
 
 					var ok bool

--- a/cli/server_stream_check.go
+++ b/cli/server_stream_check.go
@@ -110,6 +110,9 @@ func (c *StreamCheckCmd) streamCheck(_ *fisk.ParseContext) error {
 			for _, stream := range acc.Streams {
 				var ok bool
 				var m map[string]*streamDetail
+				if stream.RaftGroup == "" && stream.Cluster != nil {
+					stream.RaftGroup = stream.Cluster.RaftGroup
+				}
 				key := fmt.Sprintf("%s|%s", acc.Name, stream.RaftGroup)
 				if m, ok = streams[key]; !ok {
 					m = make(map[string]*streamDetail)


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/natscli/pull/1468. If the JSZ output doesn't contain full Raft data, the Raft group can still be populated from the Cluster info.