### PR TITLE
goreleaser: drop windows/arm & fix YAML

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,18 +28,20 @@ builds:
       - amd64
       - arm
       - arm64
-      - 386
+      - "386"
       - s390x
     goarm:
-      - 6
-      - 7
+      - "6"
+      - "7"
     ignore:
       - goos: freebsd
         goarch: arm
       - goos: freebsd
         goarch: arm64
       - goos: freebsd
-        goarch: 386
+        goarch: "386"
+      - goos: windows
+        goarch: arm
 
 archives:
   - name_template: "nats-{{.Version}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"


### PR DESCRIPTION
Go 1.26 dropped support for windows/arm (not arm64).  So drop that here, such that we don't break with one version newer than we normally build with.

Fix some YAML entry types which technically need to be strings (highlighted by the goreleaser schema used by yamlls LSP).
