### PR TITLE
feat: Add ability to use archives for certain server commands

### DIFF
--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -14,16 +14,16 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 
-	"github.com/nats-io/natscli/internal/sysclient"
+	"github.com/nats-io/natscli/internal/serverdata"
 	iu "github.com/nats-io/natscli/internal/util"
 
 	"github.com/choria-io/fisk"
@@ -54,6 +54,7 @@ type SrvReportCmd struct {
 	stateFilter             string
 	filterReason            string
 	skipDiscoverClusterSize bool
+	archivePath             string
 	gatewayName             string
 	jsEnabled               bool
 	jsServerOnly            bool
@@ -96,6 +97,7 @@ func configureServerReportCommand(srv *fisk.CmdClause) {
 	acct.Flag("sort", "Sort by a specific property (in-bytes,out-bytes,in-msgs,out-msgs,conns,subs)").Default("subs").EnumVar(&c.sort, "in-bytes", "out-bytes", "in-msgs", "out-msgs", "conns", "subs")
 	acct.Flag("top", "Limit results to the top results").Default("1000").IntVar(&c.topk)
 	addFilterOpts(acct)
+	acct.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 	acct.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
 
 	conns := report.Command("connections", "Report on connections").Alias("conn").Alias("connz").Alias("conns").Action(c.withWatcher(c.reportConnections))
@@ -109,11 +111,13 @@ func configureServerReportCommand(srv *fisk.CmdClause) {
 	conns.Flag("closed-reason", "Filter results based on a closed reason").PlaceHolder("REASON").StringVar(&c.filterReason)
 	conns.Flag("filter", "Expression based filter for connections").StringVar(&c.filterExpression)
 	addFilterOpts(conns)
+	conns.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 	conns.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
 
 	cpu := report.Command("cpu", "Report on CPU usage").Action(c.withWatcher(c.reportCPU))
 	cpu.Arg("limit", "Limit the responses to a certain amount of servers").IntVar(&c.waitFor)
 	addFilterOpts(cpu)
+	cpu.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 	cpu.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
 
 	gateways := report.Command("gateways", "Repost on Gateway (Super Cluster) connections").Alias("super").Alias("gateway").Action(c.withWatcher(c.reportGateway))
@@ -121,6 +125,7 @@ func configureServerReportCommand(srv *fisk.CmdClause) {
 	gateways.Flag("filter-name", "Limits responses to a certain name").StringVar(&c.gatewayName)
 	gateways.Flag("sort", "Sorts by a specific property (server,cluster)").Default("cluster").EnumVar(&c.sort, "server", "cluster")
 	addFilterOpts(gateways)
+	gateways.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	health := report.Command("health", "Report on Server health").Action(c.withWatcher(c.reportHealth))
 	health.Arg("limit", "Limit the responses to a certain amount of servers").IntVar(&c.waitFor)
@@ -130,6 +135,7 @@ func configureServerReportCommand(srv *fisk.CmdClause) {
 	health.Flag("stream", "Check only a specific Stream").StringVar(&c.stream)
 	health.Flag("consumer", "Check only a specific Consumer").StringVar(&c.consumer)
 	addFilterOpts(health)
+	health.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	jsz := report.Command("jetstream", "Report on JetStream activity").Alias("jsz").Alias("js").Action(c.withWatcher(c.reportJetStream))
 	jsz.Arg("limit", "Limit the responses to a certain amount of servers").IntVar(&c.waitFor)
@@ -138,37 +144,47 @@ func configureServerReportCommand(srv *fisk.CmdClause) {
 	jsz.Flag("compact", "Compact server names").Default("true").BoolVar(&c.compact)
 	jsz.Flag("leaders", "Show details about cluster leaders").Short('l').UnNegatableBoolVar(&c.reportLeaderDistrib)
 	addFilterOpts(jsz)
+	jsz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	leafs := report.Command("leafnodes", "Report on Leafnode connections").Alias("leaf").Alias("leafz").Action(c.withWatcher(c.reportLeafs))
 	leafs.Arg("limit", "Limit the responses to a certain amount of servers").IntVar(&c.waitFor)
 	leafs.Flag("account", "Produce the report for a specific account").StringVar(&c.account)
 	leafs.Flag("sort", "Sort by a specific property (server,name,account,subs,in-bytes,out-bytes,in-msgs,out-msgs)").EnumVar(&c.sort, "server", "name", "account", "subs", "in-bytes", "out-bytes", "in-msgs", "out-msgs")
 	addFilterOpts(leafs)
+	leafs.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	mem := report.Command("mem", "Report on Memory usage").Action(c.withWatcher(c.reportMem))
 	mem.Arg("limit", "Limit the responses to a certain amount of servers").IntVar(&c.waitFor)
 	addFilterOpts(mem)
+	mem.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 	mem.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
 
 	routes := report.Command("routes", "Report on Route (Cluster) connections").Alias("route").Action(c.withWatcher(c.reportRoute))
 	routes.Arg("limit", "Limit the responses to a certain amount of servers").IntVar(&c.waitFor)
 	routes.Flag("sort", "Sort by a specific property (server,cluster,name,account,subs,in-bytes,out-bytes)").EnumVar(&c.sort, "server", "cluster", "name", "account", "subs", "in-bytes", "out-bytes")
 	addFilterOpts(routes)
+	routes.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	reportCmd := report.Command("downgrade", "List assets incompatible with the specified API level").Action(c.downgradeCheckAction)
 	reportCmd.Arg("api", "Target API level to check compatibility against").Required().UintVar(&c.apiLevel)
 	reportCmd.Flag("json", "Output the downgrade report in JSON format").UnNegatableBoolVar(&c.json)
 	reportCmd.Flag("all", "Include consumers whose associated streams are incompatible with the selected API level").UnNegatableBoolVar(&c.all)
+	reportCmd.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 }
 
 func (c *SrvReportCmd) withWatcher(fn func(*fisk.ParseContext) error) func(*fisk.ParseContext) error {
 	return func(fctx *fisk.ParseContext) error {
-		nc, _, err := prepareHelper("", natsOpts()...)
-		if err != nil {
-			return err
+		if c.archivePath == "" {
+			nc, _, err := prepareHelper("", natsOpts()...)
+			if err != nil {
+				return err
+			}
+			c.nc = nc
 		}
 
-		c.nc = nc
+		if c.archivePath != "" && c.watchInterval > 0 {
+			return fmt.Errorf("--watch is not supported when using --archive")
+		}
 
 		if c.watchInterval <= 0 {
 			return fn(fctx)
@@ -178,16 +194,14 @@ func (c *SrvReportCmd) withWatcher(fn func(*fisk.ParseContext) error) func(*fisk
 		ctx, cancel := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 		defer cancel()
 
-		err = fn(fctx)
-		if err != nil {
+		if err := fn(fctx); err != nil {
 			return err
 		}
 
 		for {
 			select {
 			case <-tick.C:
-				err = fn(fctx)
-				if err != nil {
+				if err := fn(fctx); err != nil {
 					return err
 				}
 			case <-ctx.Done():
@@ -197,15 +211,26 @@ func (c *SrvReportCmd) withWatcher(fn func(*fisk.ParseContext) error) func(*fisk
 	}
 }
 
-func (c *SrvReportCmd) reportLeafs(_ *fisk.ParseContext) error {
-	req := server.LeafzEventOptions{
-		LeafzOptions: server.LeafzOptions{
-			Account: c.account,
-		},
-		EventFilterOptions: c.reqFilter(),
+func (c *SrvReportCmd) dataSource() (serverdata.DataSource, error) {
+	if c.archivePath != "" {
+		return serverdata.NewArchive(c.archivePath)
 	}
+	return serverdata.NewServer(c.nc, doReq, c.waitFor), nil
+}
 
-	results, err := doReq(req, "$SYS.REQ.SERVER.PING.LEAFZ", c.waitFor, c.nc)
+func (c *SrvReportCmd) reportLeafs(_ *fisk.ParseContext) error {
+	c.archiveUnsupported("account")
+
+	src, err := c.dataSource()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	responses, err := src.Leafz(server.LeafzEventOptions{
+		LeafzOptions:       server.LeafzOptions{Account: c.account},
+		EventFilterOptions: c.reqFilter(),
+	})
 	if err != nil {
 		return err
 	}
@@ -216,13 +241,7 @@ func (c *SrvReportCmd) reportLeafs(_ *fisk.ParseContext) error {
 	}
 
 	var leafs []*leaf
-	for _, result := range results {
-		s := &server.ServerAPILeafzResponse{}
-		err := json.Unmarshal(result, s)
-		if err != nil {
-			return err
-		}
-
+	for _, s := range responses {
 		if s.Error != nil {
 			return fmt.Errorf("%v", s.Error.Error())
 		}
@@ -300,7 +319,15 @@ func (c *SrvReportCmd) parseRtt(rtt string, crit time.Duration) string {
 }
 
 func (c *SrvReportCmd) reportHealth(_ *fisk.ParseContext) error {
-	req := server.HealthzEventOptions{
+	c.archiveUnsupported("js-enabled", "server-only", "account", "stream", "consumer")
+
+	src, err := c.dataSource()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	responses, err := src.Healthz(server.HealthzEventOptions{
 		HealthzOptions: server.HealthzOptions{
 			JSEnabledOnly: c.jsEnabled,
 			JSServerOnly:  c.jsServerOnly,
@@ -310,20 +337,13 @@ func (c *SrvReportCmd) reportHealth(_ *fisk.ParseContext) error {
 			Details:       true,
 		},
 		EventFilterOptions: c.reqFilter(),
-	}
-	results, err := doReq(req, "$SYS.REQ.SERVER.PING.HEALTHZ", c.waitFor, c.nc)
+	})
 	if err != nil {
 		return err
 	}
 
 	var servers []server.ServerAPIHealthzResponse
-	for _, result := range results {
-		s := &server.ServerAPIHealthzResponse{}
-		err := json.Unmarshal(result, s)
-		if err != nil {
-			return err
-		}
-
+	for _, s := range responses {
 		if s.Error != nil {
 			return fmt.Errorf("%v", s.Error.Error())
 		}
@@ -393,27 +413,27 @@ func (c *SrvReportCmd) reportHealth(_ *fisk.ParseContext) error {
 }
 
 func (c *SrvReportCmd) reportGateway(_ *fisk.ParseContext) error {
-	req := &server.GatewayzEventOptions{
+	c.archiveUnsupported("filter-name")
+
+	src, err := c.dataSource()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	responses, err := src.Gatewayz(server.GatewayzEventOptions{
 		EventFilterOptions: c.reqFilter(),
 		GatewayzOptions: server.GatewayzOptions{
 			Name:     c.gatewayName,
 			Accounts: true,
 		},
-	}
-
-	results, err := doReq(req, "$SYS.REQ.SERVER.PING.GATEWAYZ", c.waitFor, c.nc)
+	})
 	if err != nil {
 		return err
 	}
 
 	var gateways []server.ServerAPIGatewayzResponse
-	for _, result := range results {
-		g := &server.ServerAPIGatewayzResponse{}
-		err := json.Unmarshal(result, g)
-		if err != nil {
-			return err
-		}
-
+	for _, g := range responses {
 		if g.Error != nil {
 			return fmt.Errorf("%v", g.Error.Error())
 		}
@@ -538,10 +558,15 @@ func (c *SrvReportCmd) reportGateway(_ *fisk.ParseContext) error {
 }
 
 func (c *SrvReportCmd) reportRoute(_ *fisk.ParseContext) error {
-	req := &server.RoutezEventOptions{
-		EventFilterOptions: c.reqFilter(),
+	src, err := c.dataSource()
+	if err != nil {
+		return err
 	}
-	results, err := doReq(req, "$SYS.REQ.SERVER.PING.ROUTEZ", c.waitFor, c.nc)
+	defer src.Close()
+
+	responses, err := src.Routez(server.RoutezEventOptions{
+		EventFilterOptions: c.reqFilter(),
+	})
 	if err != nil {
 		return err
 	}
@@ -552,13 +577,7 @@ func (c *SrvReportCmd) reportRoute(_ *fisk.ParseContext) error {
 	}
 
 	routes := []routeData{}
-	for _, result := range results {
-		r := &server.ServerAPIRoutezResponse{}
-		err := json.Unmarshal(result, r)
-		if err != nil {
-			return err
-		}
-
+	for _, r := range responses {
 		if r.Error != nil {
 			return fmt.Errorf("%v", r.Error.Error())
 		}
@@ -706,21 +725,20 @@ func (c *SrvReportCmd) reportCPU(_ *fisk.ParseContext) error {
 }
 
 func (c *SrvReportCmd) reportCpuOrMem(mem bool) error {
-	req := &server.StatszEventOptions{EventFilterOptions: c.reqFilter()}
-	results, err := doReq(req, "$SYS.REQ.SERVER.PING", c.waitFor, c.nc)
+	src, err := c.dataSource()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	responses, err := src.Statz(server.StatszEventOptions{EventFilterOptions: c.reqFilter()})
 	if err != nil {
 		return err
 	}
 
 	usage := map[string]float64{}
 
-	for _, result := range results {
-		sr := &server.ServerStatsMsg{}
-		err := json.Unmarshal(result, sr)
-		if err != nil {
-			return err
-		}
-
+	for _, sr := range responses {
 		if mem {
 			usage[sr.Server.Name] = float64(sr.Stats.Mem)
 		} else {
@@ -748,6 +766,8 @@ func (c *SrvReportCmd) reportCpuOrMem(mem bool) error {
 }
 
 func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
+	c.archiveUnsupported("account")
+
 	jszOpts := server.JSzOptions{RaftGroups: true}
 	if c.account != "" {
 		jszOpts.Account = c.account
@@ -756,15 +776,19 @@ func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 		jszOpts.Limit = 10000
 	}
 
-	req := &server.JszEventOptions{JSzOptions: jszOpts, EventFilterOptions: c.reqFilter()}
-	res, err := doReq(req, "$SYS.REQ.SERVER.PING.JSZ", c.waitFor, c.nc)
+	src, err := c.dataSource()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	jszResponses, err := src.Jsz(server.JszEventOptions{JSzOptions: jszOpts, EventFilterOptions: c.reqFilter()})
 	if err != nil {
 		return err
 	}
 
 	var (
 		names               []string
-		jszResponses        []*server.ServerAPIJszResponse
 		apiTotal            uint64
 		pendingTotal        int
 		memoryTotal         uint64
@@ -782,19 +806,10 @@ func (c *SrvReportCmd) reportJetStream(_ *fisk.ParseContext) error {
 
 	// TODO: remove after 2.12 is out
 	renderDomain := false
-	for _, r := range res {
-		response := &server.ServerAPIJszResponse{}
-
-		err = json.Unmarshal(r, &response)
-		if err != nil {
-			return err
-		}
-
+	for _, response := range jszResponses {
 		if response.Data.Config.Domain != "" {
 			renderDomain = true
 		}
-
-		jszResponses = append(jszResponses, response)
 	}
 
 	sort.Slice(jszResponses, func(i, j int) bool {
@@ -1171,6 +1186,8 @@ type connInfo struct {
 }
 
 func (c *SrvReportCmd) reportConnections(_ *fisk.ParseContext) error {
+	c.archiveUnsupported("account", "subject", "username", "state", "closed-reason")
+
 	connz, err := c.getConnz(0, c.nc)
 	if err != nil {
 		return err
@@ -1344,25 +1361,6 @@ func (c connzList) flatConnInfo() []connInfo {
 	return conns
 }
 
-func parseConnzResp(resp []byte) (*server.ServerAPIConnzResponse, error) {
-	reqresp := server.ServerAPIConnzResponse{}
-
-	err := json.Unmarshal(resp, &reqresp)
-	if err != nil {
-		return nil, err
-	}
-
-	if reqresp.Error != nil {
-		return nil, fmt.Errorf("invalid response received: %v", reqresp.Error)
-	}
-
-	if reqresp.Data == nil {
-		return nil, fmt.Errorf("no data received in response: %s", string(resp))
-	}
-
-	return &reqresp, nil
-}
-
 func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 	result := connzList{}
 	found := 0
@@ -1371,7 +1369,7 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 	var err error
 	env := map[string]any{}
 
-	if !c.skipDiscoverClusterSize && c.waitFor == 0 {
+	if !c.skipDiscoverClusterSize && c.waitFor == 0 && c.archivePath == "" {
 		c.waitFor, err = currentActiveServers(nc)
 		if err != nil {
 			return nil, err
@@ -1431,32 +1429,41 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 		state = server.ConnClosed
 	}
 
+	src, err := c.dataSource()
+	if err != nil {
+		return nil, err
+	}
+	defer src.Close()
+
 	offset := 0
 	more := false
 
-	req := &server.ConnzEventOptions{
-		ConnzOptions: server.ConnzOptions{
-			Subscriptions:       true,
-			SubscriptionsDetail: false,
-			Username:            true,
-			User:                c.user,
-			Account:             c.account,
-			State:               state,
-			FilterSubject:       c.subject,
-			Limit:               1024,
-			Offset:              offset,
-		},
-		EventFilterOptions: c.reqFilter(),
+	connzOpts := server.ConnzOptions{
+		Subscriptions:       true,
+		SubscriptionsDetail: false,
+		Username:            true,
+		User:                c.user,
+		Account:             c.account,
+		State:               state,
+		FilterSubject:       c.subject,
+		Limit:               1024,
+		Offset:              offset,
 	}
-	results, err := doReq(req, "$SYS.REQ.SERVER.PING.CONNZ", c.waitFor, nc)
+
+	responses, err := src.Connz(server.ConnzEventOptions{
+		ConnzOptions:       connzOpts,
+		EventFilterOptions: c.reqFilter(),
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	for _, res := range results {
-		co, err := parseConnzResp(res)
-		if err != nil {
-			return nil, err
+	for _, co := range responses {
+		if co.Error != nil {
+			return nil, fmt.Errorf("invalid response received: %v", co.Error)
+		}
+		if co.Data == nil {
+			return nil, fmt.Errorf("no data received in response")
 		}
 		found += len(co.Data.Conns)
 
@@ -1501,25 +1508,12 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 		}
 
 		offset += 1025
+		connzOpts.Offset = offset
 
-		// get on offset
-		// iterate and add to results
-		req := &server.ConnzEventOptions{
-			ConnzOptions: server.ConnzOptions{
-				Subscriptions:       true,
-				SubscriptionsDetail: false,
-				Username:            true,
-				User:                c.user,
-				Account:             c.account,
-				State:               state,
-				FilterSubject:       c.subject,
-				Limit:               1024,
-				Offset:              offset,
-			},
+		responses, err := src.Connz(server.ConnzEventOptions{
+			ConnzOptions:       connzOpts,
 			EventFilterOptions: c.reqFilter(),
-		}
-
-		res, err := doReq(req, "$SYS.REQ.SERVER.PING.CONNZ", c.waitFor, nc)
+		})
 		if errors.Is(err, nats.ErrNoResponders) {
 			return nil, fmt.Errorf("server request failed, ensure the account used has system privileges and appropriate permissions")
 		} else if err != nil {
@@ -1528,10 +1522,12 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 
 		more = false
 
-		for _, res := range res {
-			co, err := parseConnzResp(res)
-			if err != nil {
-				return nil, err
+		for _, co := range responses {
+			if co.Error != nil {
+				return nil, fmt.Errorf("invalid response received: %v", co.Error)
+			}
+			if co.Data == nil {
+				return nil, fmt.Errorf("no data received in response")
 			}
 			found += len(co.Data.Conns)
 
@@ -1563,6 +1559,35 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 	}
 
 	return result, nil
+}
+
+func (c *SrvReportCmd) archiveUnsupported(flags ...string) {
+	if c.archivePath == "" {
+		return
+	}
+
+	values := map[string]bool{
+		"account":       c.account != "",
+		"subject":       c.subject != "",
+		"username":      c.user != "",
+		"state":         c.stateFilter != "" && c.stateFilter != "open",
+		"closed-reason": c.filterReason != "",
+		"filter-name":   c.gatewayName != "",
+		"js-enabled":    c.jsEnabled,
+		"server-only":   c.jsServerOnly,
+		"stream":        c.stream != "",
+		"consumer":      c.consumer != "",
+	}
+
+	var unsupported []string
+	for _, name := range flags {
+		if values[name] {
+			unsupported = append(unsupported, "--"+name)
+		}
+	}
+	if len(unsupported) > 0 {
+		fmt.Printf("Warning: %s not supported when using --archive\n", strings.Join(unsupported, ", "))
+	}
 }
 
 func (c *SrvReportCmd) isFiltered() bool {
@@ -1598,26 +1623,25 @@ type jsDowngradeConsumerAsset struct {
 }
 
 func (c *SrvReportCmd) downgradeCheckAction(_ *fisk.ParseContext) error {
-	nc, err := newNatsConn("", natsOpts()...)
-	if err != nil {
-		return fmt.Errorf("connection setup failed: %v", err)
+	if c.archivePath == "" {
+		nc, _, err := prepareHelper("", natsOpts()...)
+		if err != nil {
+			return err
+		}
+		c.nc = nc
 	}
-	defer nc.Close()
 
 	if !c.json {
 		fmt.Println("Obtaining JetStream Asset information")
 	}
 
-	activeServers, err := currentActiveServers(nc)
+	src, err := c.dataSource()
 	if err != nil {
 		return err
 	}
-	if activeServers == 0 {
-		return fmt.Errorf("failed to find any active servers before timeout expired")
-	}
+	defer src.Close()
 
-	sys := sysclient.New(nc, opts().Trace)
-	accounts, err := sys.CollectClusterAccounts(opts().Timeout, activeServers)
+	accounts, err := src.CollectAccounts()
 	if err != nil {
 		return fmt.Errorf("JSZ fetch failed: %v", err)
 	}

--- a/cli/server_request_command.go
+++ b/cli/server_request_command.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/nats-io/natscli/internal/serverdata"
 	"github.com/nats-io/natscli/options"
 
 	"github.com/choria-io/fisk"
@@ -62,8 +63,12 @@ type SrvRequestCmd struct {
 	nameFilter           string
 	accountSubscriptions bool
 
+	nc *nats.Conn
+
 	jsServerOnly bool
 	jsEnabled    bool
+
+	archivePath string
 
 	profileName  string
 	profileDebug int
@@ -87,6 +92,7 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	accountz := req.Command("accounts", "Show account details").Alias("accountz").Alias("acct").Action(c.accountz)
 	accountz.Arg("wait", "Wait for a certain number of responses").Uint32Var(&c.waitFor)
 	accountz.Flag("account", "Retrieve information for a specific account").StringVar(&c.account)
+	accountz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	connz := req.Command("connections", "Show connection details").Alias("conn").Alias("connz").Action(c.conns)
 	connz.Arg("wait", "Wait for a certain number of responses").Uint32Var(&c.waitFor)
@@ -98,6 +104,7 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	connz.Flag("filter-account", "Filter on a specific account").PlaceHolder("ACCOUNT").StringVar(&c.accountFilter)
 	connz.Flag("filter-subject", "Limits responses only to those connections with matching subscription interest").PlaceHolder("SUBJECT").StringVar(&c.subjectFilter)
 	connz.Flag("filter-empty", "Only shows responses that have connections").Default("false").UnNegatableBoolVar(&c.filterEmpty)
+	connz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	gwyz := req.Command("gateways", "Show gateway details").Alias("gateway").Alias("gwy").Alias("gatewayz").Action(c.gwyz)
 	gwyz.Arg("wait", "Wait for a certain number of responses").Uint32Var(&c.waitFor)
@@ -105,6 +112,7 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	gwyz.Flag("filter-account", "Show only a certain account in account detail").PlaceHolder("ACCOUNT").StringVar(&c.accountFilter)
 	gwyz.Flag("accounts", "Show account detail").UnNegatableBoolVar(&c.detail)
 	gwyz.Flag("subscriptions", "Show subscription details").Default("true").BoolVar(&c.accountSubscriptions)
+	gwyz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	ipq := req.Command("ipqueue", "Show IP Queue details").Alias("ipq").Alias("ipqueuesz").Action(c.ipqz)
 	ipq.Flag("all", "Shows all available information").Default("true").BoolVar(&c.includeAll)
@@ -118,6 +126,7 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	healthz.Flag("stream", "Check only a specific Stream").StringVar(&c.stream)
 	healthz.Flag("consumer", "Check only a specific Consumer").StringVar(&c.consumer)
 	healthz.Flag("details", "Include extended details about all failures").Default("true").BoolVar(&c.includeDetails)
+	healthz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	jsz := req.Command("jetstream", "Show JetStream details").Alias("jsz").Alias("js").Action(c.jsz)
 	jsz.Arg("wait", "Wait for a certain number of responses").Uint32Var(&c.waitFor)
@@ -130,6 +139,7 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	jsz.Flag("leader", "Request a response from the Meta-group leader only").UnNegatableBoolVar(&c.leaderOnly)
 	jsz.Flag("stream-leader", "Request a response from Stream leaders only").UnNegatableBoolVar(&c.streamLeaderOnly)
 	jsz.Flag("all", "Include accounts, streams, consumers and configuration").UnNegatableBoolVar(&c.includeAll)
+	jsz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	kick := req.Command("kick", "Disconnects a client immediately").Action(c.kick)
 	kick.Arg("client", "The Client ID to disconnect").Required().PlaceHolder("ID").Uint64Var(&c.cid)
@@ -138,6 +148,7 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	leafz := req.Command("leafnodes", "Show leafnode details").Alias("leaf").Alias("leafz").Action(c.leafz)
 	leafz.Arg("wait", "Wait for a certain number of responses").Uint32Var(&c.waitFor)
 	leafz.Flag("subscriptions", "Show subscription detail").UnNegatableBoolVar(&c.detail)
+	leafz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	profilez := req.Command("profile", "Run a profile").Action(c.profilez)
 	profilez.Arg("profile", "Specify the name of the profile to run (allocs, heap, goroutine, mutex, threadcreate, block, cpu)").Required().EnumVar(&c.profileName, "allocs", "heap", "goroutine", "mutex", "threadcreate", "block", "cpu")
@@ -151,16 +162,69 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	routez := req.Command("routes", "Show route details").Alias("route").Alias("routez").Action(c.routez)
 	routez.Arg("wait", "Wait for a certain number of responses").Uint32Var(&c.waitFor)
 	routez.Flag("subscriptions", "Show subscription detail").UnNegatableBoolVar(&c.detail)
+	routez.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	subz := req.Command("subscriptions", "Show subscription information").Alias("sub").Alias("subsz").Action(c.subs)
 	subz.Arg("wait", "Wait for a certain number of responses").Uint32Var(&c.waitFor)
 	subz.Flag("detail", "Include detail about all subscriptions").UnNegatableBoolVar(&c.detail)
 	subz.Flag("filter-account", "Filter on a specific account").PlaceHolder("ACCOUNT").StringVar(&c.accountFilter)
 	subz.Flag("filter-subject", "Filter based on subscriptions matching this subject").PlaceHolder("SUBJECT").StringVar(&c.subjectFilter)
+	subz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
 	varz := req.Command("variables", "Show runtime variables").Alias("var").Alias("varz").Action(c.varz)
 	varz.Arg("wait", "Wait for a certain number of responses").Uint32Var(&c.waitFor)
+	varz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
+}
+
+func (c *SrvRequestCmd) reqFilter() server.EventFilterOptions {
+	opt := server.EventFilterOptions{
+		Name:       c.name,
+		Host:       c.host,
+		Cluster:    c.cluster,
+		Tags:       c.tags,
+		ExactMatch: true,
+	}
+	if opts().Config != nil {
+		opt.Domain = opts().Config.JSDomain()
+	}
+
+	if c.host != "" || c.name != "" {
+		c.waitFor = 1
+	}
+
+	return opt
+}
+
+func (c *SrvRequestCmd) dataSource() (serverdata.DataSource, error) {
+	if c.archivePath != "" {
+		return serverdata.NewArchive(c.archivePath)
+	}
+
+	nc, _, err := prepareHelper("", natsOpts()...)
+	if err != nil {
+		return nil, err
+	}
+	c.nc = nc
+
+	waitFor := c.waitFor
+	if waitFor == 0 {
+		w, _ := currentActiveServers(nc)
+		waitFor = uint32(w)
+	}
+
+	return serverdata.NewServer(nc, doReq, int(waitFor)), nil
+}
+
+func printResults[T any](results []*T) error {
+	for _, r := range results {
+		j, err := json.Marshal(r)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(j))
+	}
+	return nil
 }
 
 func (c *SrvRequestCmd) ipqz(_ *fisk.ParseContext) error {
@@ -177,7 +241,12 @@ func (c *SrvRequestCmd) ipqz(_ *fisk.ParseContext) error {
 		EventFilterOptions: c.reqFilter(),
 	}
 
-	res, err := c.doReq("IPQUEUESZ", &opts, nc)
+	waitFor := int(c.waitFor)
+	if waitFor == 0 {
+		waitFor, _ = currentActiveServers(nc)
+	}
+
+	res, err := doReq(&opts, "$SYS.REQ.SERVER.PING.IPQUEUESZ", waitFor, nc)
 	if err != nil {
 		return err
 	}
@@ -203,7 +272,12 @@ func (c *SrvRequestCmd) raftz(_ *fisk.ParseContext) error {
 		EventFilterOptions: c.reqFilter(),
 	}
 
-	res, err := c.doReq("RAFTZ", &opts, nc)
+	waitFor := int(c.waitFor)
+	if waitFor == 0 {
+		waitFor, _ = currentActiveServers(nc)
+	}
+
+	res, err := doReq(&opts, "$SYS.REQ.SERVER.PING.RAFTZ", waitFor, nc)
 	if err != nil {
 		return err
 	}
@@ -242,36 +316,6 @@ func (c *SrvRequestCmd) kick(_ *fisk.ParseContext) error {
 	return nil
 }
 
-func (c *SrvRequestCmd) healthz(_ *fisk.ParseContext) error {
-	nc, _, err := prepareHelper("", natsOpts()...)
-	if err != nil {
-		return err
-	}
-
-	opts := server.HealthzEventOptions{
-		HealthzOptions: server.HealthzOptions{
-			JSEnabledOnly: c.jsEnabled,
-			JSServerOnly:  c.jsServerOnly,
-			Details:       c.includeDetails,
-			Account:       c.account,
-			Stream:        c.stream,
-			Consumer:      c.consumer,
-		},
-		EventFilterOptions: c.reqFilter(),
-	}
-
-	res, err := c.doReq("HEALTHZ", &opts, nc)
-	if err != nil {
-		return err
-	}
-
-	for _, m := range res {
-		fmt.Println(string(m))
-	}
-
-	return nil
-}
-
 type profilezResponse struct {
 	Server server.ServerInfo     `json:"server"`
 	Resp   server.ProfilezStatus `json:"data"`
@@ -298,7 +342,12 @@ func (c *SrvRequestCmd) profilez(_ *fisk.ParseContext) error {
 		options.DefaultOptions.Timeout = options.DefaultOptions.Timeout + 2*time.Second
 	}
 
-	res, err := c.doReq("PROFILEZ", &opts, nc)
+	waitFor := int(c.waitFor)
+	if waitFor == 0 {
+		waitFor, _ = currentActiveServers(nc)
+	}
+
+	res, err := doReq(&opts, "$SYS.REQ.SERVER.PING.PROFILEZ", waitFor, nc)
 	if err != nil {
 		return err
 	}
@@ -345,11 +394,37 @@ func (c *SrvRequestCmd) profilezWrite(filename string, resp *profilezResponse) e
 	return nil
 }
 
-func (c *SrvRequestCmd) jsz(_ *fisk.ParseContext) error {
-	nc, _, err := prepareHelper("", natsOpts()...)
+func (c *SrvRequestCmd) healthz(_ *fisk.ParseContext) error {
+	src, err := c.dataSource()
 	if err != nil {
 		return err
 	}
+	defer src.Close()
+
+	responses, err := src.Healthz(server.HealthzEventOptions{
+		HealthzOptions: server.HealthzOptions{
+			JSEnabledOnly: c.jsEnabled,
+			JSServerOnly:  c.jsServerOnly,
+			Details:       c.includeDetails,
+			Account:       c.account,
+			Stream:        c.stream,
+			Consumer:      c.consumer,
+		},
+		EventFilterOptions: c.reqFilter(),
+	})
+	if err != nil {
+		return err
+	}
+
+	return printResults(responses)
+}
+
+func (c *SrvRequestCmd) jsz(_ *fisk.ParseContext) error {
+	src, err := c.dataSource()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
 
 	opts := server.JszEventOptions{
 		JSzOptions: server.JSzOptions{
@@ -378,81 +453,48 @@ func (c *SrvRequestCmd) jsz(_ *fisk.ParseContext) error {
 		opts.JSzOptions.RaftGroups = true
 	}
 
-	res, err := c.doReq("JSZ", &opts, nc)
+	responses, err := src.Jsz(opts)
 	if err != nil {
 		return err
 	}
 
-	for _, m := range res {
-		fmt.Println(string(m))
-	}
-
-	return nil
-}
-
-func (c *SrvRequestCmd) reqFilter() server.EventFilterOptions {
-	opt := server.EventFilterOptions{
-		Name:       c.name,
-		Host:       c.host,
-		Cluster:    c.cluster,
-		Tags:       c.tags,
-		ExactMatch: true,
-	}
-	if opts().Config != nil {
-		opt.Domain = opts().Config.JSDomain()
-	}
-
-	if c.host != "" || c.name != "" {
-		c.waitFor = 1
-	}
-
-	return opt
+	return printResults(responses)
 }
 
 func (c *SrvRequestCmd) accountz(_ *fisk.ParseContext) error {
-	nc, _, err := prepareHelper("", natsOpts()...)
+	src, err := c.dataSource()
 	if err != nil {
 		return err
 	}
+	defer src.Close()
 
-	opts := server.AccountzEventOptions{
+	responses, err := src.Accountz(server.AccountzEventOptions{
 		AccountzOptions:    server.AccountzOptions{Account: c.account},
 		EventFilterOptions: c.reqFilter(),
-	}
-
-	res, err := c.doReq("ACCOUNTZ", &opts, nc)
+	})
 	if err != nil {
 		return err
 	}
 
-	for _, m := range res {
-		fmt.Println(string(m))
-	}
-
-	return nil
+	return printResults(responses)
 }
 
 func (c *SrvRequestCmd) leafz(_ *fisk.ParseContext) error {
-	nc, _, err := prepareHelper("", natsOpts()...)
+	src, err := c.dataSource()
 	if err != nil {
 		return err
 	}
+	defer src.Close()
 
-	opts := server.LeafzEventOptions{
+	responses, err := src.Leafz(server.LeafzEventOptions{
 		LeafzOptions:       server.LeafzOptions{Subscriptions: c.detail},
 		EventFilterOptions: c.reqFilter(),
-	}
-
-	res, err := c.doReq("LEAFZ", &opts, nc)
+	})
 	if err != nil {
 		return err
 	}
 
-	for _, m := range res {
-		fmt.Println(string(m))
-	}
-
-	return nil
+	return printResults(responses)
 }
 
 func (c *SrvRequestCmd) gwyz(_ *fisk.ParseContext) error {
@@ -460,10 +502,11 @@ func (c *SrvRequestCmd) gwyz(_ *fisk.ParseContext) error {
 		c.detail = true
 	}
 
-	nc, _, err := prepareHelper("", natsOpts()...)
+	src, err := c.dataSource()
 	if err != nil {
 		return err
 	}
+	defer src.Close()
 
 	opts := server.GatewayzEventOptions{
 		GatewayzOptions: server.GatewayzOptions{
@@ -479,46 +522,43 @@ func (c *SrvRequestCmd) gwyz(_ *fisk.ParseContext) error {
 		opts.GatewayzOptions.AccountSubscriptionsDetail = c.accountSubscriptions
 	}
 
-	res, err := c.doReq("GATEWAYZ", &opts, nc)
+	responses, err := src.Gatewayz(opts)
 	if err != nil {
 		return err
 	}
 
-	for _, m := range res {
-		fmt.Println(string(m))
-	}
-
-	return nil
+	return printResults(responses)
 }
 
 func (c *SrvRequestCmd) routez(_ *fisk.ParseContext) error {
-	nc, _, err := prepareHelper("", natsOpts()...)
+	src, err := c.dataSource()
 	if err != nil {
 		return err
 	}
+	defer src.Close()
 
-	opts := server.RoutezEventOptions{
+	responses, err := src.Routez(server.RoutezEventOptions{
 		RoutezOptions: server.RoutezOptions{
 			Subscriptions:       c.detail,
 			SubscriptionsDetail: c.detail,
 		},
 		EventFilterOptions: c.reqFilter(),
-	}
-
-	res, err := c.doReq("ROUTEZ", &opts, nc)
+	})
 	if err != nil {
 		return err
 	}
 
-	for _, m := range res {
-		fmt.Println(string(m))
-	}
-
-	return nil
+	return printResults(responses)
 }
 
 func (c *SrvRequestCmd) conns(_ *fisk.ParseContext) error {
-	opts := &server.ConnzEventOptions{
+	src, err := c.dataSource()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	opts := server.ConnzEventOptions{
 		ConnzOptions: server.ConnzOptions{
 			Sort:                server.SortOpt(c.sortOpt),
 			Username:            true,
@@ -543,63 +583,51 @@ func (c *SrvRequestCmd) conns(_ *fisk.ParseContext) error {
 		opts.State = server.ConnOpen
 	}
 
-	nc, _, err := prepareHelper("", natsOpts()...)
+	responses, err := src.Connz(opts)
 	if err != nil {
 		return err
 	}
 
-	res, err := c.doReq("CONNZ", opts, nc)
-	if err != nil {
-		return err
-	}
-
-	for _, m := range res {
-		if c.filterEmpty {
-			var r server.ServerAPIConnzResponse
-			err = json.Unmarshal(m, &r)
-			if err == nil {
-				if r.Data == nil || r.Data.NumConns == 0 {
-					continue
-				}
-			}
+	for _, r := range responses {
+		if c.filterEmpty && (r.Data == nil || r.Data.NumConns == 0) {
+			continue
 		}
 
-		fmt.Println(string(m))
+		j, err := json.Marshal(r)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(j))
 	}
 
 	return nil
 }
 
 func (c *SrvRequestCmd) varz(_ *fisk.ParseContext) error {
-	nc, _, err := prepareHelper("", natsOpts()...)
+	src, err := c.dataSource()
 	if err != nil {
 		return err
 	}
+	defer src.Close()
 
-	opts := server.VarzEventOptions{
-		VarzOptions:        server.VarzOptions{},
+	responses, err := src.Varz(server.VarzEventOptions{
 		EventFilterOptions: c.reqFilter(),
-	}
-
-	res, err := c.doReq("VARZ", &opts, nc)
+	})
 	if err != nil {
 		return err
 	}
 
-	for _, m := range res {
-		fmt.Println(string(m))
-	}
-
-	return nil
+	return printResults(responses)
 }
 
 func (c *SrvRequestCmd) subs(_ *fisk.ParseContext) error {
-	nc, _, err := prepareHelper("", natsOpts()...)
+	src, err := c.dataSource()
 	if err != nil {
 		return err
 	}
+	defer src.Close()
 
-	opts := server.SubszEventOptions{
+	responses, err := src.Subsz(server.SubszEventOptions{
 		SubszOptions: server.SubszOptions{
 			Offset:        c.offset,
 			Limit:         c.limit,
@@ -608,25 +636,10 @@ func (c *SrvRequestCmd) subs(_ *fisk.ParseContext) error {
 			Test:          c.subjectFilter,
 		},
 		EventFilterOptions: c.reqFilter(),
-	}
-
-	res, err := c.doReq("SUBSZ", &opts, nc)
+	})
 	if err != nil {
 		return err
 	}
 
-	for _, m := range res {
-		fmt.Println(string(m))
-	}
-
-	return nil
-}
-
-func (c *SrvRequestCmd) doReq(kind string, req any, nc *nats.Conn) ([][]byte, error) {
-	if c.waitFor == 0 {
-		wait, _ := currentActiveServers(nc)
-		c.waitFor = uint32(wait)
-	}
-
-	return doReq(req, fmt.Sprintf("$SYS.REQ.SERVER.PING.%s", kind), int(c.waitFor), nc)
+	return printResults(responses)
 }

--- a/internal/serverdata/archive.go
+++ b/internal/serverdata/archive.go
@@ -1,0 +1,439 @@
+package serverdata
+
+import (
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/nats-io/jsm.go/audit/archive"
+	"github.com/nats-io/nats-server/v2/server"
+)
+
+// Archive implements DataSource by reading from a captured archive.
+type Archive struct {
+	reader *archive.Reader
+}
+
+// NewArchive creates an Archive data source from an archive file.
+func NewArchive(archivePath string) (*Archive, error) {
+	r, err := archive.NewReader(archivePath)
+	if err != nil {
+		return nil, err
+	}
+	return &Archive{reader: r}, nil
+}
+
+// Varz builds and filters a Varz response from the archive
+func (a *Archive) Varz(opts server.VarzEventOptions) ([]*server.ServerAPIVarzResponse, error) {
+	var results []*server.ServerAPIVarzResponse
+	_, err := a.reader.EachClusterServerVarz(func(_ *archive.Tag, _ *archive.Tag, cbError error, vz *server.ServerAPIVarzResponse) error {
+		if cbError != nil || !matchesFilter(vz.Server, &opts.EventFilterOptions) {
+			return nil
+		}
+		results = append(results, vz)
+		return nil
+	})
+	return results, err
+}
+
+// Connz builds and filters a Connz response from the archive
+func (a *Archive) Connz(opts server.ConnzEventOptions) ([]*server.ServerAPIConnzResponse, error) {
+	seen := map[string]*server.ServerAPIConnzResponse{}
+	var results []*server.ServerAPIConnzResponse
+
+	for _, accountName := range a.reader.AccountNames() {
+		tags := []*archive.Tag{
+			archive.TagAccount(accountName),
+			archive.TagAccountConnections(),
+		}
+		err := archive.ForEachTaggedArtifact(a.reader, tags, func(cz *server.ServerAPIConnzResponse) error {
+			if !matchesFilter(cz.Server, &opts.EventFilterOptions) {
+				return nil
+			}
+			for _, conn := range cz.Data.Conns {
+				if conn.Account == "" {
+					conn.Account = accountName
+				}
+			}
+			if cz.Server == nil {
+				return nil
+			}
+			key := cz.Server.ID
+			if base, ok := seen[key]; ok {
+				base.Data.Conns = append(base.Data.Conns, cz.Data.Conns...)
+			} else {
+				seen[key] = cz
+				results = append(results, cz)
+			}
+			return nil
+		})
+		if err != nil && err != archive.ErrNoMatches {
+			return nil, err
+		}
+	}
+
+	return results, nil
+}
+
+// Routez builds and filters a Routez response from the archive
+func (a *Archive) Routez(opts server.RoutezEventOptions) ([]*server.ServerAPIRoutezResponse, error) {
+	var results []*server.ServerAPIRoutezResponse
+	_, err := archive.EachClusterServerArtifact(a.reader, archive.TagServerRoutes(),
+		func(_ *archive.Tag, _ *archive.Tag, cbError error, rz *server.ServerAPIRoutezResponse) error {
+			if cbError != nil || !matchesFilter(rz.Server, &opts.EventFilterOptions) {
+				return nil
+			}
+			results = append(results, rz)
+			return nil
+		})
+	return results, err
+}
+
+// Gatewayz builds and filters a Gatewayz response from the archive
+func (a *Archive) Gatewayz(opts server.GatewayzEventOptions) ([]*server.ServerAPIGatewayzResponse, error) {
+	var results []*server.ServerAPIGatewayzResponse
+	_, err := archive.EachClusterServerArtifact(a.reader, archive.TagServerGateways(),
+		func(_ *archive.Tag, _ *archive.Tag, cbError error, gz *server.ServerAPIGatewayzResponse) error {
+			if cbError != nil || !matchesFilter(gz.Server, &opts.EventFilterOptions) {
+				return nil
+			}
+			results = append(results, gz)
+			return nil
+		})
+	return results, err
+}
+
+// Leafz builds and filters a Leafz response from the archive
+func (a *Archive) Leafz(opts server.LeafzEventOptions) ([]*server.ServerAPILeafzResponse, error) {
+	var results []*server.ServerAPILeafzResponse
+	_, err := a.reader.EachClusterServerLeafz(func(_ *archive.Tag, _ *archive.Tag, cbError error, lz *server.ServerAPILeafzResponse) error {
+		if cbError != nil || !matchesFilter(lz.Server, &opts.EventFilterOptions) {
+			return nil
+		}
+		results = append(results, lz)
+		return nil
+	})
+	return results, err
+}
+
+// Subsz builds and filters a Subsz response from the archive
+func (a *Archive) Subsz(opts server.SubszEventOptions) ([]*server.ServerAPISubszResponse, error) {
+	seen := map[string]*server.ServerAPISubszResponse{}
+	var results []*server.ServerAPISubszResponse
+
+	_, err := archive.EachClusterServerArtifact(a.reader, archive.TagServerSubs(),
+		func(clusterTag *archive.Tag, serverTag *archive.Tag, cbError error, sz *server.ServerAPISubszResponse) error {
+			if cbError != nil || !matchesFilter(sz.Server, &opts.EventFilterOptions) {
+				return nil
+			}
+			key := serverKey(clusterTag, serverTag)
+			if base, ok := seen[key]; ok {
+				base.Data.Subs = append(base.Data.Subs, sz.Data.Subs...)
+			} else {
+				seen[key] = sz
+				results = append(results, sz)
+			}
+			return nil
+		})
+	return results, err
+}
+
+// Jsz builds and filters a Jsz response from the archive
+func (a *Archive) Jsz(opts server.JszEventOptions) ([]*server.ServerAPIJszResponse, error) {
+	seen := map[string]*server.ServerAPIJszResponse{}
+	var results []*server.ServerAPIJszResponse
+
+	_, err := a.reader.EachClusterServerJsz(func(clusterTag *archive.Tag, serverTag *archive.Tag, cbError error, jsz *server.ServerAPIJszResponse) error {
+		if cbError != nil || !matchesFilter(jsz.Server, &opts.EventFilterOptions) {
+			return nil
+		}
+		key := serverKey(clusterTag, serverTag)
+		if base, ok := seen[key]; ok {
+			base.Data.AccountDetails = append(base.Data.AccountDetails, jsz.Data.AccountDetails...)
+		} else {
+			seen[key] = jsz
+			results = append(results, jsz)
+		}
+		return nil
+	})
+	return results, err
+}
+
+// Healthz builds and filters a Healthz response from the archive
+func (a *Archive) Healthz(opts server.HealthzEventOptions) ([]*server.ServerAPIHealthzResponse, error) {
+	var results []*server.ServerAPIHealthzResponse
+	_, err := a.reader.EachClusterServerHealthz(func(_ *archive.Tag, _ *archive.Tag, cbError error, hz *server.ServerAPIHealthzResponse) error {
+		if cbError != nil || !matchesFilter(hz.Server, &opts.EventFilterOptions) {
+			return nil
+		}
+		results = append(results, hz)
+		return nil
+	})
+	return results, err
+}
+
+type accountInfoResponse struct {
+	Server *server.ServerInfo  `json:"server"`
+	Data   *server.AccountInfo `json:"data,omitempty"`
+}
+
+// Accountz builds and filters an Accountz response from the archive.
+func (a *Archive) Accountz(opts server.AccountzEventOptions) ([]*server.ServerAPIAccountzResponse, error) {
+	if opts.AccountzOptions.Account != "" {
+		return a.accountzDetail(opts)
+	}
+
+	var results []*server.ServerAPIAccountzResponse
+	_, err := a.reader.EachClusterServerAccountz(func(_ *archive.Tag, _ *archive.Tag, cbError error, az *server.ServerAPIAccountzResponse) error {
+		if cbError != nil || !matchesFilter(az.Server, &opts.EventFilterOptions) {
+			return nil
+		}
+		results = append(results, az)
+		return nil
+	})
+	return results, err
+}
+
+// accountzDetail reads per-account account_info artifacts and wraps them
+func (a *Archive) accountzDetail(opts server.AccountzEventOptions) ([]*server.ServerAPIAccountzResponse, error) {
+	var results []*server.ServerAPIAccountzResponse
+	tags := []*archive.Tag{
+		archive.TagAccount(opts.AccountzOptions.Account),
+		archive.TagAccountInfo(),
+	}
+
+	err := archive.ForEachTaggedArtifact(a.reader, tags, func(air *accountInfoResponse) error {
+		if !matchesFilter(air.Server, &opts.EventFilterOptions) {
+			return nil
+		}
+		resp := &server.ServerAPIAccountzResponse{
+			Server: air.Server,
+			Data: &server.Accountz{
+				Account: air.Data,
+			},
+		}
+		results = append(results, resp)
+		return nil
+	})
+	if err == archive.ErrNoMatches {
+		return results, nil
+	}
+	return results, err
+}
+
+// Statz builds and filters a Statz response from the archive
+// TODO(ploubser:) ActiveAccounts, StaleConnections, StaleConnectionStats, StalledClients
+// and ActiveServers are not available in archive data and cannot be added to the response.
+func (a *Archive) Statz(opts server.StatszEventOptions) ([]*server.ServerStatsMsg, error) {
+	varzResponses, err := a.Varz(server.VarzEventOptions{EventFilterOptions: opts.EventFilterOptions})
+	if err != nil {
+		return nil, err
+	}
+
+	routesByID := map[string]*server.Routez{}
+	routezResponses, _ := a.Routez(server.RoutezEventOptions{EventFilterOptions: opts.EventFilterOptions})
+	for _, r := range routezResponses {
+		if r.Server != nil {
+			routesByID[r.Server.ID] = r.Data
+		}
+	}
+
+	gatewaysByID := map[string]*server.Gatewayz{}
+	gatewayzResponses, _ := a.Gatewayz(server.GatewayzEventOptions{EventFilterOptions: opts.EventFilterOptions})
+	for _, g := range gatewayzResponses {
+		if g.Server != nil {
+			gatewaysByID[g.Server.ID] = g.Data
+		}
+	}
+
+	var results []*server.ServerStatsMsg
+	for _, vr := range varzResponses {
+		if vr.Server == nil || vr.Data == nil {
+			continue
+		}
+
+		msg := &server.ServerStatsMsg{
+			Server: *vr.Server,
+			Stats: server.ServerStats{
+				Start:            vr.Data.Start,
+				Mem:              vr.Data.Mem,
+				Cores:            vr.Data.Cores,
+				CPU:              vr.Data.CPU,
+				Connections:      vr.Data.Connections,
+				TotalConnections: vr.Data.TotalConnections,
+				NumSubs:          vr.Data.Subscriptions,
+				Sent: server.DataStats{
+					MsgBytes: server.MsgBytes{Msgs: vr.Data.OutMsgs, Bytes: vr.Data.OutBytes},
+				},
+				Received: server.DataStats{
+					MsgBytes: server.MsgBytes{Msgs: vr.Data.InMsgs, Bytes: vr.Data.InBytes},
+				},
+				SlowConsumers:      vr.Data.SlowConsumers,
+				SlowConsumersStats: vr.Data.SlowConsumersStats,
+				MemLimit:           vr.Data.MemLimit,
+				MaxProcs:           vr.Data.MaxProcs,
+			},
+		}
+
+		if vr.Data.JetStream.Config != nil {
+			msg.Stats.JetStream = &vr.Data.JetStream
+		}
+
+		if rz, ok := routesByID[vr.Server.ID]; ok {
+			for _, ri := range rz.Routes {
+				msg.Stats.Routes = append(msg.Stats.Routes, &server.RouteStat{
+					ID:   ri.Rid,
+					Name: ri.RemoteName,
+					Sent: server.DataStats{
+						MsgBytes: server.MsgBytes{Msgs: ri.OutMsgs, Bytes: ri.OutBytes},
+					},
+					Received: server.DataStats{
+						MsgBytes: server.MsgBytes{Msgs: ri.InMsgs, Bytes: ri.InBytes},
+					},
+					Pending: ri.Pending,
+				})
+			}
+		}
+
+		if gz, ok := gatewaysByID[vr.Server.ID]; ok {
+			gwStats := map[string]*server.GatewayStat{}
+
+			for gname, conns := range gz.InboundGateways {
+				stat := gwStats[gname]
+				if stat == nil {
+					stat = &server.GatewayStat{Name: gname}
+					gwStats[gname] = stat
+				}
+				stat.NumInbound += len(conns)
+				for _, c := range conns {
+					if c.Connection != nil {
+						stat.Received.Msgs += c.Connection.InMsgs
+						stat.Received.Bytes += c.Connection.InBytes
+					}
+				}
+			}
+
+			for gname, gw := range gz.OutboundGateways {
+				stat := gwStats[gname]
+				if stat == nil {
+					stat = &server.GatewayStat{Name: gname}
+					gwStats[gname] = stat
+				}
+				if gw.Connection != nil {
+					stat.Sent.Msgs += gw.Connection.OutMsgs
+					stat.Sent.Bytes += gw.Connection.OutBytes
+				}
+			}
+
+			for _, stat := range gwStats {
+				msg.Stats.Gateways = append(msg.Stats.Gateways, stat)
+			}
+		}
+
+		results = append(results, msg)
+	}
+
+	return results, nil
+}
+
+// CollectAccounts gathers account-level JetStream metadata from the archive
+func (a *Archive) CollectAccounts() ([]*server.AccountDetail, error) {
+	jszResponses, err := a.Jsz(server.JszEventOptions{
+		JSzOptions: server.JSzOptions{
+			Accounts: true,
+			Streams:  true,
+			Consumer: true,
+			Config:   true,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	accountMap := map[string]*server.AccountDetail{}
+	for _, jsz := range jszResponses {
+		if jsz.Data == nil {
+			continue
+		}
+		for _, acct := range jsz.Data.AccountDetails {
+			if existing, found := accountMap[acct.Name]; found {
+				existing.Streams = mergeArchiveStreams(existing.Streams, acct.Streams)
+			} else {
+				cp := *acct
+				accountMap[acct.Name] = &cp
+			}
+		}
+	}
+
+	accounts := make([]*server.AccountDetail, 0, len(accountMap))
+	for _, acct := range accountMap {
+		accounts = append(accounts, acct)
+	}
+	sort.Slice(accounts, func(i, j int) bool { return accounts[i].Name < accounts[j].Name })
+	for _, acct := range accounts {
+		sort.Slice(acct.Streams, func(i, j int) bool { return acct.Streams[i].Name < acct.Streams[j].Name })
+	}
+
+	return accounts, nil
+}
+
+func mergeArchiveStreams(a, b []server.StreamDetail) []server.StreamDetail {
+	seen := map[string]any{}
+	var result []server.StreamDetail
+
+	for _, s := range append(a, b...) {
+		if _, found := seen[s.Name]; found {
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		result = append(result, s)
+	}
+	return result
+}
+
+func (a *Archive) Close() error {
+	return a.reader.Close()
+}
+
+func serverKey(clusterTag, serverTag *archive.Tag) string {
+	return clusterTag.Value + "/" + serverTag.Value
+}
+
+// matchesFilter checks whether a server matches the given EventFilterOptions.
+func matchesFilter(info *server.ServerInfo, f *server.EventFilterOptions) bool {
+	if info == nil || f == nil {
+		return true
+	}
+
+	if f.Name != "" && !matchField(info.Name, f.Name, f.ExactMatch) {
+		return false
+	}
+	if f.Host != "" && !matchField(info.Host, f.Host, f.ExactMatch) {
+		return false
+	}
+	if f.Cluster != "" && !matchField(info.Cluster, f.Cluster, f.ExactMatch) {
+		return false
+	}
+	if f.Domain != "" && info.Domain != f.Domain {
+		return false
+	}
+	for _, ft := range f.Tags {
+		if !hasTag(info.Tags, ft) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchField(value, filter string, exact bool) bool {
+	if exact {
+		return value == filter
+	}
+	return strings.Contains(value, filter)
+}
+
+func hasTag(tags []string, filter string) bool {
+	filter = strings.ToLower(strings.TrimSpace(filter))
+	return slices.Contains(tags, filter)
+}

--- a/internal/serverdata/archive_test.go
+++ b/internal/serverdata/archive_test.go
@@ -1,0 +1,774 @@
+package serverdata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nats-io/jsm.go/audit/archive"
+	"github.com/nats-io/nats-server/v2/server"
+)
+
+// newTestArchive creates a temporary archive file, calls the populate function
+// to add artifacts, closes the writer, and returns an *Archive ready for testing.
+// The caller does not need to clean up; t.TempDir() handles that.
+func newTestArchive(t *testing.T, populate func(w *archive.Writer)) *Archive {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.zip")
+
+	w, err := archive.NewWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	populate(w)
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := NewArchive(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { a.Close() })
+
+	return a
+}
+
+func TestArchiveVarz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data:   &server.Varz{MaxConn: 100},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerVars())
+	})
+
+	results, err := a.Varz(server.VarzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Server.Name != "srv-1" {
+		t.Errorf("expected server name srv-1, got %s", results[0].Server.Name)
+	}
+	if results[0].Data.MaxConn != 100 {
+		t.Errorf("expected MaxConn 100, got %d", results[0].Data.MaxConn)
+	}
+}
+
+func TestArchiveConnz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPIConnzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.Connz{
+				NumConns: 2,
+				Conns: []*server.ConnInfo{
+					{Name: "conn-1", Account: "acct-A"},
+					{Name: "conn-2", Account: "acct-A"},
+				},
+			},
+		}
+		w.Add(resp,
+			archive.TagAccount("acct-A"),
+			archive.TagCluster("c1"),
+			archive.TagServer("srv-1"),
+			archive.TagAccountConnections())
+	})
+
+	results, err := a.Connz(server.ConnzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Data.Conns) != 2 {
+		t.Errorf("expected 2 conns, got %d", len(results[0].Data.Conns))
+	}
+}
+
+func TestArchiveConnzMergesAccounts(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		// Two accounts on the same server should be merged into one result
+		resp1 := &server.ServerAPIConnzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.Connz{
+				Conns: []*server.ConnInfo{{Name: "conn-1"}},
+			},
+		}
+		resp2 := &server.ServerAPIConnzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.Connz{
+				Conns: []*server.ConnInfo{{Name: "conn-2"}},
+			},
+		}
+		w.Add(resp1,
+			archive.TagAccount("acct-A"),
+			archive.TagCluster("c1"),
+			archive.TagServer("srv-1"),
+			archive.TagAccountConnections())
+		w.Add(resp2,
+			archive.TagAccount("acct-B"),
+			archive.TagCluster("c1"),
+			archive.TagServer("srv-1"),
+			archive.TagAccountConnections())
+	})
+
+	results, err := a.Connz(server.ConnzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 merged result, got %d", len(results))
+	}
+	if len(results[0].Data.Conns) != 2 {
+		t.Errorf("expected 2 merged conns, got %d", len(results[0].Data.Conns))
+	}
+}
+
+func TestArchiveRoutez(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPIRoutezResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.Routez{
+				Routes: []*server.RouteInfo{{RemoteName: "srv-2"}},
+			},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerRoutes())
+	})
+
+	results, err := a.Routez(server.RoutezEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Data.Routes) != 1 {
+		t.Errorf("expected 1 route, got %d", len(results[0].Data.Routes))
+	}
+}
+
+func TestArchiveGatewayz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPIGatewayzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data:   &server.Gatewayz{Name: "gw-east"},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerGateways())
+	})
+
+	results, err := a.Gatewayz(server.GatewayzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Data.Name != "gw-east" {
+		t.Errorf("expected gateway name gw-east, got %s", results[0].Data.Name)
+	}
+}
+
+func TestArchiveLeafz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPILeafzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.Leafz{
+				Leafs: []*server.LeafInfo{{Name: "leaf-1"}},
+			},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerLeafs())
+	})
+
+	results, err := a.Leafz(server.LeafzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Data.Leafs) != 1 {
+		t.Errorf("expected 1 leaf, got %d", len(results[0].Data.Leafs))
+	}
+}
+
+func TestArchiveSubsz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPISubszResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data:   &server.Subsz{Total: 10},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerSubs())
+	})
+
+	results, err := a.Subsz(server.SubszEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Data.Total != 10 {
+		t.Errorf("expected 10 subs, got %d", results[0].Data.Total)
+	}
+}
+
+func TestArchiveJsz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPIJszResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.JSInfo{
+				JetStreamStats: server.JetStreamStats{Memory: 1024},
+			},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerJetStream())
+	})
+
+	results, err := a.Jsz(server.JszEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Data.Memory != 1024 {
+		t.Errorf("expected Memory 1024, got %d", results[0].Data.Memory)
+	}
+}
+
+func TestArchiveHealthz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPIHealthzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data:   &server.HealthStatus{Status: "ok"},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerHealth())
+	})
+
+	results, err := a.Healthz(server.HealthzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Data.Status != "ok" {
+		t.Errorf("expected status ok, got %s", results[0].Data.Status)
+	}
+}
+
+func TestArchiveAccountz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPIAccountzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.Accountz{
+				Accounts: []string{"acct-A", "acct-B"},
+			},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerAccounts())
+	})
+
+	results, err := a.Accountz(server.AccountzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Data.Accounts) != 2 {
+		t.Errorf("expected 2 accounts, got %d", len(results[0].Data.Accounts))
+	}
+}
+
+func TestArchiveAccountzDetail(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		air := &accountInfoResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data:   &server.AccountInfo{AccountName: "acct-A"},
+		}
+		w.Add(air,
+			archive.TagCluster("c1"),
+			archive.TagServer("srv-1"),
+			archive.TagAccount("acct-A"),
+			archive.TagAccountInfo())
+	})
+
+	opts := server.AccountzEventOptions{}
+	opts.AccountzOptions.Account = "acct-A"
+	results, err := a.Accountz(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Data.Account.AccountName != "acct-A" {
+		t.Errorf("expected account acct-A, got %s", results[0].Data.Account.AccountName)
+	}
+}
+
+func TestArchiveAccountzDetailMissing(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		// Add nothing for the requested account
+		resp := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data:   &server.Varz{},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerVars())
+	})
+
+	opts := server.AccountzEventOptions{}
+	opts.AccountzOptions.Account = "no-such-account"
+	results, err := a.Accountz(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for missing account, got %d", len(results))
+	}
+}
+
+func TestArchiveStatz(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		varz := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1", Cluster: "c1"},
+			Data: &server.Varz{
+				Connections:      5,
+				TotalConnections: 10,
+				InMsgs:           100,
+				OutMsgs:          200,
+				InBytes:          1000,
+				OutBytes:         2000,
+				Mem:              4096,
+				CPU:              1.5,
+				Cores:            4,
+				Subscriptions:    50,
+				SlowConsumers:    2,
+			},
+		}
+		w.Add(varz, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerVars())
+
+		routez := &server.ServerAPIRoutezResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.Routez{
+				Routes: []*server.RouteInfo{
+					{Rid: 1, RemoteName: "srv-2", InMsgs: 10, OutMsgs: 20, InBytes: 100, OutBytes: 200, Pending: 5},
+				},
+			},
+		}
+		w.Add(routez, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerRoutes())
+
+		gatewayz := &server.ServerAPIGatewayzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.Gatewayz{
+				OutboundGateways: map[string]*server.RemoteGatewayz{
+					"gw-west": {Connection: &server.ConnInfo{OutMsgs: 30, OutBytes: 300}},
+				},
+			},
+		}
+		w.Add(gatewayz, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerGateways())
+	})
+
+	results, err := a.Statz(server.StatszEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	msg := results[0]
+	if msg.Server.Name != "srv-1" {
+		t.Errorf("expected server name srv-1, got %s", msg.Server.Name)
+	}
+	if msg.Stats.Connections != 5 {
+		t.Errorf("expected 5 connections, got %d", msg.Stats.Connections)
+	}
+	if msg.Stats.Sent.Msgs != 200 {
+		t.Errorf("expected 200 sent msgs, got %d", msg.Stats.Sent.Msgs)
+	}
+	if msg.Stats.Received.Msgs != 100 {
+		t.Errorf("expected 100 received msgs, got %d", msg.Stats.Received.Msgs)
+	}
+	if msg.Stats.Mem != 4096 {
+		t.Errorf("expected Mem 4096, got %d", msg.Stats.Mem)
+	}
+	if msg.Stats.CPU != 1.5 {
+		t.Errorf("expected CPU 1.5, got %f", msg.Stats.CPU)
+	}
+	if msg.Stats.NumSubs != 50 {
+		t.Errorf("expected 50 subs, got %d", msg.Stats.NumSubs)
+	}
+	if msg.Stats.SlowConsumers != 2 {
+		t.Errorf("expected 2 slow consumers, got %d", msg.Stats.SlowConsumers)
+	}
+
+	// Route stats
+	if len(msg.Stats.Routes) != 1 {
+		t.Fatalf("expected 1 route stat, got %d", len(msg.Stats.Routes))
+	}
+	if msg.Stats.Routes[0].Name != "srv-2" {
+		t.Errorf("expected route name srv-2, got %s", msg.Stats.Routes[0].Name)
+	}
+	if msg.Stats.Routes[0].Sent.Msgs != 20 {
+		t.Errorf("expected route sent 20, got %d", msg.Stats.Routes[0].Sent.Msgs)
+	}
+	if msg.Stats.Routes[0].Pending != 5 {
+		t.Errorf("expected route pending 5, got %d", msg.Stats.Routes[0].Pending)
+	}
+
+	// Gateway stats
+	if len(msg.Stats.Gateways) != 1 {
+		t.Fatalf("expected 1 gateway stat, got %d", len(msg.Stats.Gateways))
+	}
+	if msg.Stats.Gateways[0].Name != "gw-west" {
+		t.Errorf("expected gateway name gw-west, got %s", msg.Stats.Gateways[0].Name)
+	}
+	if msg.Stats.Gateways[0].Sent.Msgs != 30 {
+		t.Errorf("expected gateway sent 30, got %d", msg.Stats.Gateways[0].Sent.Msgs)
+	}
+}
+
+func TestArchiveMultipleServers(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		r1 := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "srv-a", ID: "id-a"},
+			Data:   &server.Varz{},
+		}
+		r2 := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "srv-b", ID: "id-b"},
+			Data:   &server.Varz{},
+		}
+		w.Add(r1, archive.TagCluster("c1"), archive.TagServer("srv-a"), archive.TagServerVars())
+		w.Add(r2, archive.TagCluster("c1"), archive.TagServer("srv-b"), archive.TagServerVars())
+	})
+
+	results, err := a.Varz(server.VarzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	names := map[string]bool{}
+	for _, r := range results {
+		names[r.Server.Name] = true
+	}
+	if !names["srv-a"] || !names["srv-b"] {
+		t.Errorf("expected srv-a and srv-b, got %v", names)
+	}
+}
+
+func TestArchiveFilterByName(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		r1 := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "prod-srv-1", ID: "id-1"},
+			Data:   &server.Varz{},
+		}
+		r2 := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "dev-srv-2", ID: "id-2"},
+			Data:   &server.Varz{},
+		}
+		w.Add(r1, archive.TagCluster("c1"), archive.TagServer("prod-srv-1"), archive.TagServerVars())
+		w.Add(r2, archive.TagCluster("c1"), archive.TagServer("dev-srv-2"), archive.TagServerVars())
+	})
+
+	opts := server.VarzEventOptions{}
+	opts.EventFilterOptions.Name = "prod"
+	results, err := a.Varz(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 filtered result, got %d", len(results))
+	}
+	if results[0].Server.Name != "prod-srv-1" {
+		t.Errorf("expected prod-srv-1, got %s", results[0].Server.Name)
+	}
+}
+
+func TestArchiveFilterByCluster(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		r1 := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1", Cluster: "east"},
+			Data:   &server.Varz{},
+		}
+		r2 := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "srv-2", ID: "id-2", Cluster: "west"},
+			Data:   &server.Varz{},
+		}
+		w.Add(r1, archive.TagCluster("east"), archive.TagServer("srv-1"), archive.TagServerVars())
+		w.Add(r2, archive.TagCluster("west"), archive.TagServer("srv-2"), archive.TagServerVars())
+	})
+
+	opts := server.VarzEventOptions{}
+	opts.EventFilterOptions.Cluster = "east"
+	results, err := a.Varz(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 filtered result, got %d", len(results))
+	}
+	if results[0].Server.Cluster != "east" {
+		t.Errorf("expected cluster east, got %s", results[0].Server.Cluster)
+	}
+}
+
+func TestArchiveEmptyResults(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		// Only add varz, nothing else
+		resp := &server.ServerAPIVarzResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data:   &server.Varz{},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerVars())
+	})
+
+	// Endpoints with no data should return empty slices (no error)
+	routez, err := a.Routez(server.RoutezEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routez) != 0 {
+		t.Errorf("expected 0 routez results, got %d", len(routez))
+	}
+
+	gatewayz, err := a.Gatewayz(server.GatewayzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gatewayz) != 0 {
+		t.Errorf("expected 0 gatewayz results, got %d", len(gatewayz))
+	}
+
+	healthz, err := a.Healthz(server.HealthzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(healthz) != 0 {
+		t.Errorf("expected 0 healthz results, got %d", len(healthz))
+	}
+}
+
+func TestArchiveClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.zip")
+	w, err := archive.NewWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+
+	a, err := NewArchive(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewArchiveInvalidPath(t *testing.T) {
+	_, err := NewArchive("/nonexistent/path/to/archive.zip")
+	if err == nil {
+		t.Fatal("expected error for invalid path")
+	}
+}
+
+func TestNewArchiveInvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.zip")
+	os.WriteFile(path, []byte("not a zip"), 0644)
+
+	_, err := NewArchive(path)
+	if err == nil {
+		t.Fatal("expected error for invalid zip")
+	}
+}
+
+func TestArchiveCollectAccountsSingleServer(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		resp := &server.ServerAPIJszResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.JSInfo{
+				AccountDetails: []*server.AccountDetail{
+					{Name: "beta", Streams: []server.StreamDetail{{Name: "s2"}, {Name: "s1"}}},
+					{Name: "alpha", Streams: []server.StreamDetail{{Name: "s3"}}},
+				},
+			},
+		}
+		w.Add(resp, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerJetStream())
+	})
+
+	accounts, err := a.CollectAccounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("expected 2 accounts, got %d", len(accounts))
+	}
+	// Sorted by name
+	if accounts[0].Name != "alpha" {
+		t.Errorf("expected first account alpha, got %s", accounts[0].Name)
+	}
+	if accounts[1].Name != "beta" {
+		t.Errorf("expected second account beta, got %s", accounts[1].Name)
+	}
+	// Streams sorted within account
+	if accounts[1].Streams[0].Name != "s1" || accounts[1].Streams[1].Name != "s2" {
+		t.Errorf("expected streams sorted [s1 s2], got [%s %s]", accounts[1].Streams[0].Name, accounts[1].Streams[1].Name)
+	}
+}
+
+func TestArchiveCollectAccountsMergesAcrossServers(t *testing.T) {
+	a := newTestArchive(t, func(w *archive.Writer) {
+		r1 := &server.ServerAPIJszResponse{
+			Server: &server.ServerInfo{Name: "srv-1", ID: "id-1"},
+			Data: &server.JSInfo{
+				AccountDetails: []*server.AccountDetail{
+					{Name: "acct-A", Streams: []server.StreamDetail{{Name: "s1"}, {Name: "s2"}}},
+				},
+			},
+		}
+		r2 := &server.ServerAPIJszResponse{
+			Server: &server.ServerInfo{Name: "srv-2", ID: "id-2"},
+			Data: &server.JSInfo{
+				AccountDetails: []*server.AccountDetail{
+					{Name: "acct-A", Streams: []server.StreamDetail{{Name: "s2"}, {Name: "s3"}}},
+				},
+			},
+		}
+		w.Add(r1, archive.TagCluster("c1"), archive.TagServer("srv-1"), archive.TagServerJetStream())
+		w.Add(r2, archive.TagCluster("c1"), archive.TagServer("srv-2"), archive.TagServerJetStream())
+	})
+
+	accounts, err := a.CollectAccounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 merged account, got %d", len(accounts))
+	}
+	// s1, s2, s3 -- s2 deduplicated, sorted
+	if len(accounts[0].Streams) != 3 {
+		t.Errorf("expected 3 deduplicated streams, got %d", len(accounts[0].Streams))
+	}
+	if accounts[0].Streams[0].Name != "s1" || accounts[0].Streams[1].Name != "s2" || accounts[0].Streams[2].Name != "s3" {
+		names := make([]string, len(accounts[0].Streams))
+		for i, s := range accounts[0].Streams {
+			names[i] = s.Name
+		}
+		t.Errorf("expected sorted [s1 s2 s3], got %v", names)
+	}
+}
+
+// matchesFilter tests -- kept from original test file
+
+func TestMatchesFilter_NilInputs(t *testing.T) {
+	info := &server.ServerInfo{Name: "srv"}
+	if !matchesFilter(nil, &server.EventFilterOptions{}) {
+		t.Error("nil info should match")
+	}
+	if !matchesFilter(info, nil) {
+		t.Error("nil filter should match")
+	}
+	if !matchesFilter(nil, nil) {
+		t.Error("both nil should match")
+	}
+}
+
+func TestMatchesFilter_NameHostCluster(t *testing.T) {
+	info := &server.ServerInfo{
+		Name:    "ProdServer",
+		Host:    "Host-A",
+		Cluster: "East-1",
+	}
+
+	tests := []struct {
+		name   string
+		filter server.EventFilterOptions
+		match  bool
+	}{
+		{"name substring", server.EventFilterOptions{Name: "Prod"}, true},
+		{"name wrong case", server.EventFilterOptions{Name: "prod"}, false},
+		{"name exact", server.EventFilterOptions{Name: "ProdServer", ExactMatch: true}, true},
+		{"name exact mismatch", server.EventFilterOptions{Name: "Prod", ExactMatch: true}, false},
+		{"name exact wrong case", server.EventFilterOptions{Name: "prodserver", ExactMatch: true}, false},
+		{"host substring", server.EventFilterOptions{Host: "Host"}, true},
+		{"host wrong case", server.EventFilterOptions{Host: "host"}, false},
+		{"cluster substring", server.EventFilterOptions{Cluster: "East"}, true},
+		{"cluster wrong case", server.EventFilterOptions{Cluster: "east"}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchesFilter(info, &tc.filter)
+			if got != tc.match {
+				t.Errorf("expected %v, got %v", tc.match, got)
+			}
+		})
+	}
+}
+
+func TestMatchesFilter_DomainAlwaysExact(t *testing.T) {
+	info := &server.ServerInfo{Domain: "hub"}
+
+	tests := []struct {
+		name   string
+		filter server.EventFilterOptions
+		match  bool
+	}{
+		{"equal", server.EventFilterOptions{Domain: "hub"}, true},
+		{"substring", server.EventFilterOptions{Domain: "hu"}, false},
+		{"different", server.EventFilterOptions{Domain: "spoke"}, false},
+		{"empty filter", server.EventFilterOptions{Domain: ""}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchesFilter(info, &tc.filter)
+			if got != tc.match {
+				t.Errorf("expected %v, got %v", tc.match, got)
+			}
+		})
+	}
+}
+
+func TestMatchesFilter_TagsLowercaseExact(t *testing.T) {
+	info := &server.ServerInfo{Tags: []string{"region:us-east", "env:prod"}}
+
+	tests := []struct {
+		name  string
+		tags  []string
+		exact bool
+		match bool
+	}{
+		{"exact tag", []string{"region:us-east"}, false, true},
+		{"uppercase filter lowercased", []string{"Region:us-east"}, false, true},
+		{"tag substring should not match", []string{"region"}, false, false},
+		{"all tags present", []string{"region:us-east", "env:prod"}, false, true},
+		{"one tag missing", []string{"region:us-east", "env:staging"}, false, false},
+		{"ExactMatch flag ignored for tags", []string{"region:us-east"}, true, true},
+		{"ExactMatch flag ignored substring still fails", []string{"region"}, true, false},
+		{"whitespace trimmed", []string{"  region:us-east  "}, false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &server.EventFilterOptions{Tags: tc.tags, ExactMatch: tc.exact}
+			got := matchesFilter(info, f)
+			if got != tc.match {
+				t.Errorf("expected %v, got %v", tc.match, got)
+			}
+		})
+	}
+}

--- a/internal/serverdata/server.go
+++ b/internal/serverdata/server.go
@@ -1,0 +1,180 @@
+package serverdata
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+// Server implements DataSource by querying live servers
+type Server struct {
+	nc      *nats.Conn
+	reqFn   RequestFunc
+	waitFor int
+}
+
+// NewServer creates a Server data source that delegates requests to the reqFn callback
+func NewServer(nc *nats.Conn, reqFn RequestFunc, waitFor int) *Server {
+	return &Server{nc: nc, reqFn: reqFn, waitFor: waitFor}
+}
+
+func (s *Server) Varz(opts server.VarzEventOptions) ([]*server.ServerAPIVarzResponse, error) {
+	return doRequest[server.ServerAPIVarzResponse](s, opts, "$SYS.REQ.SERVER.PING.VARZ")
+}
+
+func (s *Server) Connz(opts server.ConnzEventOptions) ([]*server.ServerAPIConnzResponse, error) {
+	return doRequest[server.ServerAPIConnzResponse](s, opts, "$SYS.REQ.SERVER.PING.CONNZ")
+}
+
+func (s *Server) Routez(opts server.RoutezEventOptions) ([]*server.ServerAPIRoutezResponse, error) {
+	return doRequest[server.ServerAPIRoutezResponse](s, opts, "$SYS.REQ.SERVER.PING.ROUTEZ")
+}
+
+func (s *Server) Gatewayz(opts server.GatewayzEventOptions) ([]*server.ServerAPIGatewayzResponse, error) {
+	return doRequest[server.ServerAPIGatewayzResponse](s, opts, "$SYS.REQ.SERVER.PING.GATEWAYZ")
+}
+
+func (s *Server) Leafz(opts server.LeafzEventOptions) ([]*server.ServerAPILeafzResponse, error) {
+	return doRequest[server.ServerAPILeafzResponse](s, opts, "$SYS.REQ.SERVER.PING.LEAFZ")
+}
+
+func (s *Server) Subsz(opts server.SubszEventOptions) ([]*server.ServerAPISubszResponse, error) {
+	return doRequest[server.ServerAPISubszResponse](s, opts, "$SYS.REQ.SERVER.PING.SUBSZ")
+}
+
+func (s *Server) Jsz(opts server.JszEventOptions) ([]*server.ServerAPIJszResponse, error) {
+	return doRequest[server.ServerAPIJszResponse](s, opts, "$SYS.REQ.SERVER.PING.JSZ")
+}
+
+func (s *Server) Healthz(opts server.HealthzEventOptions) ([]*server.ServerAPIHealthzResponse, error) {
+	return doRequest[server.ServerAPIHealthzResponse](s, opts, "$SYS.REQ.SERVER.PING.HEALTHZ")
+}
+
+func (s *Server) Accountz(opts server.AccountzEventOptions) ([]*server.ServerAPIAccountzResponse, error) {
+	return doRequest[server.ServerAPIAccountzResponse](s, opts, "$SYS.REQ.SERVER.PING.ACCOUNTZ")
+}
+
+func (s *Server) Statz(opts server.StatszEventOptions) ([]*server.ServerStatsMsg, error) {
+	return doRequest[server.ServerStatsMsg](s, opts, "$SYS.REQ.SERVER.PING")
+}
+
+// CollectAccounts gathers account-level JetStream metadata from all servers
+func (s *Server) CollectAccounts() ([]*server.AccountDetail, error) {
+	const pageLimit = 1024
+
+	baseOpts := server.JszEventOptions{
+		JSzOptions: server.JSzOptions{
+			Accounts: true,
+			Streams:  true,
+			Consumer: true,
+			Config:   true,
+			Limit:    pageLimit,
+		},
+	}
+
+	initialResponses, err := s.Jsz(baseOpts)
+	if err != nil && len(initialResponses) == 0 {
+		return nil, err
+	}
+
+	accountMap := map[string]*server.AccountDetail{}
+	mergeAccounts := func(details []*server.AccountDetail) {
+		for _, acct := range details {
+			if existing, found := accountMap[acct.Name]; found {
+				existing.Streams = mergeStreams(existing.Streams, acct.Streams)
+			} else {
+				cp := *acct
+				accountMap[acct.Name] = &cp
+			}
+		}
+	}
+
+	offsets := map[string]int{}
+	for _, resp := range initialResponses {
+		if resp.Data == nil || resp.Server == nil {
+			continue
+		}
+		mergeAccounts(resp.Data.AccountDetails)
+		if len(resp.Data.AccountDetails) == pageLimit {
+			offsets[resp.Server.Name] = pageLimit
+		}
+	}
+
+	for len(offsets) > 0 {
+		for name, offset := range offsets {
+			opts := baseOpts
+			opts.EventFilterOptions.Name = name
+			opts.ExactMatch = true
+			opts.Offset = offset
+
+			pages, err := doRequest[server.ServerAPIJszResponse](s, opts, "$SYS.REQ.SERVER.PING.JSZ")
+			if err != nil {
+				return nil, err
+			}
+			if len(pages) == 0 || pages[0].Data == nil {
+				delete(offsets, name)
+				continue
+			}
+
+			jsz := pages[0]
+			mergeAccounts(jsz.Data.AccountDetails)
+
+			if len(jsz.Data.AccountDetails) == pageLimit {
+				offsets[name] += pageLimit
+			} else {
+				delete(offsets, name)
+			}
+		}
+	}
+
+	accounts := make([]*server.AccountDetail, 0, len(accountMap))
+	for _, acct := range accountMap {
+		accounts = append(accounts, acct)
+	}
+	sort.Slice(accounts, func(i, j int) bool { return accounts[i].Name < accounts[j].Name })
+	for _, acct := range accounts {
+		sort.Slice(acct.Streams, func(i, j int) bool { return acct.Streams[i].Name < acct.Streams[j].Name })
+	}
+
+	return accounts, nil
+}
+
+// Close is a noop for connecting to live servers. The caller owns the connections
+func (s *Server) Close() error {
+	return nil
+}
+
+func doRequest[T any](s *Server, opts any, subj string) ([]*T, error) {
+	results, err := s.reqFn(opts, subj, s.waitFor, s.nc)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", subj, err)
+	}
+
+	responses := make([]*T, 0, len(results))
+	for _, raw := range results {
+		resp := new(T)
+		if err := json.Unmarshal(raw, resp); err != nil {
+			return nil, fmt.Errorf("unmarshal %s response: %w", subj, err)
+		}
+		responses = append(responses, resp)
+	}
+
+	return responses, nil
+}
+
+func mergeStreams(a, b []server.StreamDetail) []server.StreamDetail {
+	seen := map[string]any{}
+	var result []server.StreamDetail
+
+	for _, s := range append(a, b...) {
+		if _, found := seen[s.Name]; found {
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		result = append(result, s)
+	}
+	return result
+}

--- a/internal/serverdata/server_test.go
+++ b/internal/serverdata/server_test.go
@@ -1,0 +1,324 @@
+package serverdata
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+// mockReqFn returns a RequestFunc that records calls and returns preset responses.
+func mockReqFn(responses [][]byte, err error) (RequestFunc, *[]mockCall) {
+	var calls []mockCall
+	fn := func(req any, subj string, waitFor int, nc *nats.Conn) ([][]byte, error) {
+		calls = append(calls, mockCall{req: req, subj: subj, waitFor: waitFor})
+		return responses, err
+	}
+	return fn, &calls
+}
+
+type mockCall struct {
+	req     any
+	subj    string
+	waitFor int
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestServerVarz(t *testing.T) {
+	resp := &server.ServerAPIVarzResponse{
+		Server: &server.ServerInfo{Name: "srv-1"},
+		Data:   &server.Varz{MaxConn: 100},
+	}
+	reqFn, calls := mockReqFn([][]byte{mustMarshal(t, resp)}, nil)
+	src := NewServer(nil, reqFn, 3)
+
+	opts := server.VarzEventOptions{}
+	results, err := src.Varz(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Server.Name != "srv-1" {
+		t.Errorf("expected server name srv-1, got %s", results[0].Server.Name)
+	}
+	if results[0].Data.MaxConn != 100 {
+		t.Errorf("expected MaxConn 100, got %d", results[0].Data.MaxConn)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(*calls))
+	}
+	if (*calls)[0].subj != "$SYS.REQ.SERVER.PING.VARZ" {
+		t.Errorf("expected VARZ subject, got %s", (*calls)[0].subj)
+	}
+	if (*calls)[0].waitFor != 3 {
+		t.Errorf("expected waitFor 3, got %d", (*calls)[0].waitFor)
+	}
+}
+
+func TestServerConnz(t *testing.T) {
+	resp := &server.ServerAPIConnzResponse{
+		Server: &server.ServerInfo{Name: "srv-2"},
+		Data:   &server.Connz{NumConns: 42},
+	}
+	reqFn, _ := mockReqFn([][]byte{mustMarshal(t, resp)}, nil)
+	src := NewServer(nil, reqFn, 0)
+
+	results, err := src.Connz(server.ConnzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Data.NumConns != 42 {
+		t.Errorf("expected 42 connections, got %d", results[0].Data.NumConns)
+	}
+}
+
+func TestServerStatz(t *testing.T) {
+	resp := &server.ServerStatsMsg{
+		Server: server.ServerInfo{Name: "srv-3", Cluster: "c1"},
+	}
+	reqFn, calls := mockReqFn([][]byte{mustMarshal(t, resp)}, nil)
+	src := NewServer(nil, reqFn, 5)
+
+	results, err := src.Statz(server.StatszEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Server.Name != "srv-3" {
+		t.Errorf("expected server name srv-3, got %s", results[0].Server.Name)
+	}
+	if (*calls)[0].subj != "$SYS.REQ.SERVER.PING" {
+		t.Errorf("expected PING subject, got %s", (*calls)[0].subj)
+	}
+}
+
+func TestServerMultipleResponses(t *testing.T) {
+	r1 := mustMarshal(t, &server.ServerAPIVarzResponse{
+		Server: &server.ServerInfo{Name: "srv-a"},
+		Data:   &server.Varz{},
+	})
+	r2 := mustMarshal(t, &server.ServerAPIVarzResponse{
+		Server: &server.ServerInfo{Name: "srv-b"},
+		Data:   &server.Varz{},
+	})
+	reqFn, _ := mockReqFn([][]byte{r1, r2}, nil)
+	src := NewServer(nil, reqFn, 2)
+
+	results, err := src.Varz(server.VarzEventOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Server.Name != "srv-a" {
+		t.Errorf("expected srv-a, got %s", results[0].Server.Name)
+	}
+	if results[1].Server.Name != "srv-b" {
+		t.Errorf("expected srv-b, got %s", results[1].Server.Name)
+	}
+}
+
+func TestServerRequestError(t *testing.T) {
+	reqFn, _ := mockReqFn(nil, fmt.Errorf("connection lost"))
+	src := NewServer(nil, reqFn, 1)
+
+	_, err := src.Varz(server.VarzEventOptions{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestServerUnmarshalError(t *testing.T) {
+	reqFn, _ := mockReqFn([][]byte{[]byte("not json")}, nil)
+	src := NewServer(nil, reqFn, 1)
+
+	_, err := src.Varz(server.VarzEventOptions{})
+	if err == nil {
+		t.Fatal("expected unmarshal error")
+	}
+}
+
+func TestServerClose(t *testing.T) {
+	src := NewServer(nil, nil, 0)
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// mockReqFnSequence returns a RequestFunc that returns different responses on each call.
+func mockReqFnSequence(sequence []mockResponse) RequestFunc {
+	idx := 0
+	return func(req any, subj string, waitFor int, nc *nats.Conn) ([][]byte, error) {
+		if idx >= len(sequence) {
+			return nil, fmt.Errorf("unexpected call %d", idx)
+		}
+		resp := sequence[idx]
+		idx++
+		return resp.data, resp.err
+	}
+}
+
+type mockResponse struct {
+	data [][]byte
+	err  error
+}
+
+func TestServerCollectAccountsSingleServer(t *testing.T) {
+	resp := &server.ServerAPIJszResponse{
+		Server: &server.ServerInfo{Name: "srv-1"},
+		Data: &server.JSInfo{
+			AccountDetails: []*server.AccountDetail{
+				{Name: "beta", Streams: []server.StreamDetail{{Name: "s1"}}},
+				{Name: "alpha", Streams: []server.StreamDetail{{Name: "s2"}}},
+			},
+		},
+	}
+	reqFn, _ := mockReqFn([][]byte{mustMarshal(t, resp)}, nil)
+	src := NewServer(nil, reqFn, 1)
+
+	accounts, err := src.CollectAccounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("expected 2 accounts, got %d", len(accounts))
+	}
+	// Should be sorted by name
+	if accounts[0].Name != "alpha" {
+		t.Errorf("expected first account alpha, got %s", accounts[0].Name)
+	}
+	if accounts[1].Name != "beta" {
+		t.Errorf("expected second account beta, got %s", accounts[1].Name)
+	}
+}
+
+func TestServerCollectAccountsMergesAcrossServers(t *testing.T) {
+	r1 := &server.ServerAPIJszResponse{
+		Server: &server.ServerInfo{Name: "srv-1"},
+		Data: &server.JSInfo{
+			AccountDetails: []*server.AccountDetail{
+				{Name: "acct-A", Streams: []server.StreamDetail{{Name: "s1"}, {Name: "s2"}}},
+			},
+		},
+	}
+	r2 := &server.ServerAPIJszResponse{
+		Server: &server.ServerInfo{Name: "srv-2"},
+		Data: &server.JSInfo{
+			AccountDetails: []*server.AccountDetail{
+				{Name: "acct-A", Streams: []server.StreamDetail{{Name: "s2"}, {Name: "s3"}}},
+			},
+		},
+	}
+	reqFn, _ := mockReqFn([][]byte{mustMarshal(t, r1), mustMarshal(t, r2)}, nil)
+	src := NewServer(nil, reqFn, 2)
+
+	accounts, err := src.CollectAccounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 merged account, got %d", len(accounts))
+	}
+	// s1, s2, s3 -- s2 deduplicated
+	if len(accounts[0].Streams) != 3 {
+		t.Errorf("expected 3 deduplicated streams, got %d", len(accounts[0].Streams))
+	}
+	// Streams should be sorted
+	if accounts[0].Streams[0].Name != "s1" || accounts[0].Streams[1].Name != "s2" || accounts[0].Streams[2].Name != "s3" {
+		names := make([]string, len(accounts[0].Streams))
+		for i, s := range accounts[0].Streams {
+			names[i] = s.Name
+		}
+		t.Errorf("expected sorted [s1 s2 s3], got %v", names)
+	}
+}
+
+func TestServerCollectAccountsPaging(t *testing.T) {
+	// Build a response with exactly 1024 accounts to trigger paging
+	details := make([]*server.AccountDetail, 1024)
+	for i := range details {
+		details[i] = &server.AccountDetail{Name: fmt.Sprintf("acct-%04d", i)}
+	}
+	initialResp := &server.ServerAPIJszResponse{
+		Server: &server.ServerInfo{Name: "srv-1"},
+		Data:   &server.JSInfo{AccountDetails: details},
+	}
+
+	// Second page has fewer than 1024, ending paging
+	page2 := &server.ServerAPIJszResponse{
+		Server: &server.ServerInfo{Name: "srv-1"},
+		Data: &server.JSInfo{
+			AccountDetails: []*server.AccountDetail{
+				{Name: "acct-extra"},
+			},
+		},
+	}
+
+	seq := mockReqFnSequence([]mockResponse{
+		{data: [][]byte{mustMarshal(t, initialResp)}},
+		{data: [][]byte{mustMarshal(t, page2)}},
+	})
+	src := NewServer(nil, seq, 1)
+
+	accounts, err := src.CollectAccounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 1025 {
+		t.Fatalf("expected 1025 accounts, got %d", len(accounts))
+	}
+}
+
+func TestServerSubjects(t *testing.T) {
+	tests := []struct {
+		name   string
+		call   func(ds DataSource) error
+		expect string
+	}{
+		{"Varz", func(ds DataSource) error { _, err := ds.Varz(server.VarzEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.VARZ"},
+		{"Connz", func(ds DataSource) error { _, err := ds.Connz(server.ConnzEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.CONNZ"},
+		{"Routez", func(ds DataSource) error { _, err := ds.Routez(server.RoutezEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.ROUTEZ"},
+		{"Gatewayz", func(ds DataSource) error { _, err := ds.Gatewayz(server.GatewayzEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.GATEWAYZ"},
+		{"Leafz", func(ds DataSource) error { _, err := ds.Leafz(server.LeafzEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.LEAFZ"},
+		{"Subsz", func(ds DataSource) error { _, err := ds.Subsz(server.SubszEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.SUBSZ"},
+		{"Jsz", func(ds DataSource) error { _, err := ds.Jsz(server.JszEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.JSZ"},
+		{"Healthz", func(ds DataSource) error { _, err := ds.Healthz(server.HealthzEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.HEALTHZ"},
+		{"Accountz", func(ds DataSource) error { _, err := ds.Accountz(server.AccountzEventOptions{}); return err }, "$SYS.REQ.SERVER.PING.ACCOUNTZ"},
+		{"Statz", func(ds DataSource) error { _, err := ds.Statz(server.StatszEventOptions{}); return err }, "$SYS.REQ.SERVER.PING"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := []byte(`{}`)
+			reqFn, calls := mockReqFn([][]byte{resp}, nil)
+			src := NewServer(nil, reqFn, 1)
+
+			_ = tc.call(src)
+
+			if len(*calls) != 1 {
+				t.Fatalf("expected 1 call, got %d", len(*calls))
+			}
+			if (*calls)[0].subj != tc.expect {
+				t.Errorf("expected subject %s, got %s", tc.expect, (*calls)[0].subj)
+			}
+		})
+	}
+}

--- a/internal/serverdata/serverdata.go
+++ b/internal/serverdata/serverdata.go
@@ -1,0 +1,25 @@
+package serverdata
+
+import (
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+// RequestFunc defines the callback used when connecting to live servers for data
+type RequestFunc func(req any, subj string, waitFor int, nc *nats.Conn) ([][]byte, error)
+
+// DataSource abstracts server data retrieval
+type DataSource interface {
+	Varz(opts server.VarzEventOptions) ([]*server.ServerAPIVarzResponse, error)
+	Connz(opts server.ConnzEventOptions) ([]*server.ServerAPIConnzResponse, error)
+	Routez(opts server.RoutezEventOptions) ([]*server.ServerAPIRoutezResponse, error)
+	Gatewayz(opts server.GatewayzEventOptions) ([]*server.ServerAPIGatewayzResponse, error)
+	Leafz(opts server.LeafzEventOptions) ([]*server.ServerAPILeafzResponse, error)
+	Subsz(opts server.SubszEventOptions) ([]*server.ServerAPISubszResponse, error)
+	Jsz(opts server.JszEventOptions) ([]*server.ServerAPIJszResponse, error)
+	Healthz(opts server.HealthzEventOptions) ([]*server.ServerAPIHealthzResponse, error)
+	Accountz(opts server.AccountzEventOptions) ([]*server.ServerAPIAccountzResponse, error)
+	Statz(opts server.StatszEventOptions) ([]*server.ServerStatsMsg, error)
+	CollectAccounts() ([]*server.AccountDetail, error)
+	Close() error
+}


### PR DESCRIPTION
Add the DataSource interface with server and archive implementations. This allows us to let certain server commands inspect the archived data instead of querying servers.

There is no behavioral changes when querying servers from the DataSource implementation. The same doReq callback is used to get responses, but the interface allows us to simulate these reponses by looking at the archive contents and responding with the data contained in it.

`server report` and `server request` commands are the first commands to have been ported to use this interface where it makes sense. The --archive flag activates this feature and will warn and or fail when used with invalid filter flags.