### PR TITLE
util: fix several correctness and safety bugs

### DIFF
--- a/internal/util/backoff.go
+++ b/internal/util/backoff.go
@@ -64,6 +64,7 @@ func (b BackoffPolicy) Sleep(ctx context.Context, t time.Duration) error {
 	case <-timer.C:
 		return nil
 	case <-ctx.Done():
+		timer.Stop()
 		return ctx.Err()
 	}
 }
@@ -84,7 +85,7 @@ func (b BackoffPolicy) For(ctx context.Context, cb func(try int) error) error {
 			return nil
 		}
 
-		err = b.TrySleep(ctx, tries)
+		err = b.TrySleep(ctx, tries-1)
 		if err != nil {
 			return err
 		}

--- a/internal/util/progress.go
+++ b/internal/util/progress.go
@@ -49,6 +49,9 @@ func NewProgress(opts *options.Options, tracker *progress.Tracker) (progress.Wri
 }
 
 func contextColor(opts *options.Options) text.Colors {
+	if opts.Config == nil {
+		return text.Colors{text.FgWhite}
+	}
 	cs := opts.Config.ColorScheme()
 	s, ok := styles[cs]
 	if !ok {

--- a/internal/util/publisher.go
+++ b/internal/util/publisher.go
@@ -39,6 +39,7 @@ type Publisher struct {
 	Tracker  *progress.Tracker
 
 	reader      *bufio.Reader
+	stdinPipe   *io.PipeReader
 	progressBar progress.Writer
 	templates   bool
 	sendOn      string
@@ -66,6 +67,7 @@ func NewPublisher(cfg PublisherConfig) (*Publisher, error) {
 	p.UseStdin = !cfg.BodyIsSet && (IsTerminal() || cfg.ForceStdin)
 	if p.UseStdin {
 		readPipe, writePipe := io.Pipe()
+		p.stdinPipe = readPipe
 		p.reader = bufio.NewReader(readPipe)
 		go func() {
 			_, err := io.Copy(writePipe, os.Stdin)
@@ -180,12 +182,10 @@ func (p *Publisher) Run(ctx context.Context, callback func() error) error {
 
 	select {
 	case <-ctx.Done():
-		if p.reader != nil {
-			if rp, ok := any(p.reader).(interface{ Close() error }); ok {
-				rp.Close()
-			}
+		if p.stdinPipe != nil {
+			p.stdinPipe.CloseWithError(ctx.Err())
 		}
-		return fmt.Errorf("interrupted")
+		return ctx.Err()
 	case <-complete:
 		return <-errCh
 	}

--- a/internal/util/random.go
+++ b/internal/util/random.go
@@ -36,13 +36,10 @@ func RandomString(shortest uint, longest uint) string {
 
 	var desired int
 
-	switch {
-	case int(longest)-int(shortest) < 0:
-		desired = int(shortest) + rand.IntN(int(longest))
-	case longest == shortest:
+	if longest == shortest {
 		desired = int(shortest)
-	default:
-		desired = int(shortest) + rand.IntN(int(longest-shortest))
+	} else {
+		desired = int(shortest) + rand.IntN(int(longest-shortest)+1)
 	}
 
 	b := make([]rune, desired)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -86,15 +86,19 @@ func versionComponents(version string) (major, minor, patch int, err error) {
 	if err != nil {
 		return -1, -1, -1, err
 	}
-	minor, err = strconv.Atoi(m[2])
-	if err != nil {
-		return -1, -1, -1, err
+	if m[2] != "" {
+		minor, err = strconv.Atoi(m[2])
+		if err != nil {
+			return -1, -1, -1, err
+		}
 	}
-	patch, err = strconv.Atoi(m[3])
-	if err != nil {
-		return -1, -1, -1, err
+	if m[3] != "" {
+		patch, err = strconv.Atoi(m[3])
+		if err != nil {
+			return -1, -1, -1, err
+		}
 	}
-	return major, minor, patch, err
+	return major, minor, patch, nil
 }
 
 // ServerMinVersion checks if the connected server meets certain version constraints
@@ -170,7 +174,7 @@ func SliceGroups(input []string, size int, fn func(group []string)) {
 	if padding != size {
 		p := []string{}
 
-		for i := 0; i <= padding; i++ {
+		for i := 0; i < padding; i++ {
 			p = append(p, "")
 		}
 
@@ -452,7 +456,7 @@ func ProgressWidth() int {
 
 // JSONString returns a quoted string to be used as a JSON object
 func JSONString(s string) string {
-	return "\"" + s + "\""
+	return strconv.Quote(s)
 }
 
 // SplitCommand Split the string into a command and its arguments.


### PR DESCRIPTION
- backoff: stop timer on context cancel in Sleep() to prevent goroutine leak
- backoff: pass tries-1 to TrySleep in For() so first retry uses Millis[0] not Millis[1], matching the documented 500ms starting delay
- random: remove unreachable switch branch in RandomString(); fix off-by-one so longest is an inclusive upper bound (rand.IntN n+1)
- util: fix off-by-one in SliceGroups() padding loop (<= should be <)
- util: fix versionComponents() to treat missing minor/patch semver groups as 0 instead of erroring on partial versions like "2" or "2.1"
- util: fix JSONString() to use strconv.Quote() so special characters are properly escaped rather than producing invalid JSON
- publisher: store *io.PipeReader so Run() can actually close stdin on context cancellation; return ctx.Err() instead of a generic error string
- progress: guard against nil opts.Config in contextColor()