### PR TITLE
Fix pub/req commands with piped stdin

### DIFF
--- a/internal/util/publisher.go
+++ b/internal/util/publisher.go
@@ -64,7 +64,7 @@ func NewPublisher(cfg PublisherConfig) (*Publisher, error) {
 		opts:      cfg.Opts,
 	}
 
-	p.UseStdin = !cfg.BodyIsSet && (IsTerminal() || cfg.ForceStdin)
+	p.UseStdin = !cfg.BodyIsSet && (IsStdoutTerminal() || cfg.ForceStdin)
 	if p.UseStdin {
 		readPipe, writePipe := io.Pipe()
 		p.stdinPipe = readPipe

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -135,7 +135,12 @@ func PrintJSON(d any) error {
 
 // IsTerminal checks if stdin and stdout are both normal terminals
 func IsTerminal() bool {
-	return terminal.IsTerminal(int(os.Stdin.Fd())) && terminal.IsTerminal(int(os.Stdout.Fd()))
+	return terminal.IsTerminal(int(os.Stdin.Fd())) && IsStdoutTerminal()
+}
+
+// IsStdoutTerminal checks if stdout is a normal terminal
+func IsStdoutTerminal() bool {
+	return terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // WipeSlice overwrites the contents of slice with 'x'


### PR DESCRIPTION
Tried piping stdin to the `nats pub` command but noticed this wasn't working anymore, and bisected this back to https://github.com/nats-io/natscli/pull/1585.

```sh
# Before this fix
echo "world" | nats pub hello
..
[#1] Received on "hello"
nil body

# After this fix
echo "world" | nats pub hello
..
[#3] Received on "hello"
world
```

The pub command was previously using `terminal.IsTerminal(int(os.Stdout.Fd())` but with the change to `isTerminal()` which also uses the stdin FD in its check this no longer evaluates to true: https://github.com/nats-io/natscli/pull/1585/changes#diff-61f207b144df96e68822452378155f0a5184f8d6994e0f2267e0e54f77faaf1bL433