### PR TITLE
Add timezone UTC offset 

### DIFF
--- a/columns/columns.go
+++ b/columns/columns.go
@@ -534,7 +534,7 @@ func F(v any) string {
 	case time.Duration:
 		return HumanizeDuration(x)
 	case time.Time:
-		return x.Local().Format("2006-01-02 15:04:05")
+		return x.Local().Format("2006-01-02 15:04:05 -0700 MST")
 	case bool:
 		return fmt.Sprintf("%t", x)
 	case uint:

--- a/columns/columns.go
+++ b/columns/columns.go
@@ -534,7 +534,7 @@ func F(v any) string {
 	case time.Duration:
 		return HumanizeDuration(x)
 	case time.Time:
-		return x.Local().Format("2006-01-02 15:04:05 -0700 MST")
+		return x.Local().Format("2006-01-02 15:04:05 -07:00")
 	case bool:
 		return fmt.Sprintf("%t", x)
 	case uint:


### PR DESCRIPTION
Nats server stores message timestamps in nanoseconds since epoch, and the server local timezone does not matter.

Imagine we have a nats server in MST, a client in CET and a client in PST. When humans located in different timezone look at the NATS CLI output(e.g. shared via a zoom call), the timezone differences may be confusing.

Avoid ambiguity by providing a timezone specifier, using the same `-07:30` timezone format that, e.g. `git log` uses.
Do not use an abbreviation (e.g. [CST](https://www.timeanddate.com/time/zones/cst)) since those are not standardized. 

## Before:
The local timezone of natscli affects the output, but it is not obvious:
```
# TZ=UTC nats stream  info JS_AUDIT | grep Sequence
               First Sequence: 35,376,486,641 @ 2026-04-24 16:27:32
                Last Sequence: 35,467,058,135 @ 2026-04-24 23:16:43

# TZ="America/Los_Angeles" nats stream  info JS_AUDIT | grep Sequence
               First Sequence: 35,376,486,641 @ 2026-04-24 09:27:32
                Last Sequence: 35,467,058,135 @ 2026-04-24 16:16:43
```

## After
Make it obvious which time zone is used:
```
# nats stream  info JS_AUDIT | grep Sequence
               First Sequence: 35,376,486,641 @ 2026-04-24 09:27:32 -07:00
                Last Sequence: 35,467,058,135 @ 2026-04-24 16:16:43 -07:00

```
This change does affect the following commands where we format time for users: https://gist.github.com/alexbozhenko/f0af003ac1d5ba17449fab7218312b3e

