### PR TITLE
fix: use `nats.ProxyPath` when server is a websocket connection with a path

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -400,19 +400,20 @@ func newNatsConnUnlocked(servers string, copts ...nats.Option) (*nats.Conn, erro
 		servers = opts.Config.ServerURL()
 	}
 
-	servers, proxyPath := extractWSProxyPath(servers)
+	servers, proxyPath, err := extractWSProxyPath(servers)
+	if err != nil {
+		return nil, err
+	}
 	if proxyPath != "" {
 		copts = append(copts, nats.ProxyPath(proxyPath))
 	}
-
-	var err error
 
 	opts.Conn, err = nats.Connect(servers, copts...)
 
 	return opts.Conn, err
 }
 
-func extractWSProxyPath(servers string) (string, string) {
+func extractWSProxyPath(servers string) (string, string, error) {
 	var proxyPath string
 	var updated []string
 
@@ -427,8 +428,11 @@ func extractWSProxyPath(servers string) (string, string) {
 			continue
 		}
 		if (u.Scheme == "ws" || u.Scheme == "wss") && u.Path != "" && u.Path != "/" {
+			reqURI := u.RequestURI()
 			if proxyPath == "" {
-				proxyPath = u.RequestURI()
+				proxyPath = reqURI
+			} else if proxyPath != reqURI {
+				return "", "", fmt.Errorf("websocket servers with different paths are not supported: %q, %q", proxyPath, reqURI)
 			}
 			// Strip path and query from the server URL
 			u.Path = ""
@@ -441,7 +445,7 @@ func extractWSProxyPath(servers string) (string, string) {
 		}
 	}
 
-	return strings.Join(updated, ","), proxyPath
+	return strings.Join(updated, ","), proxyPath, nil
 }
 
 func newNatsConn(servers string, copts ...nats.Option) (*nats.Conn, error) {

--- a/cli/util.go
+++ b/cli/util.go
@@ -428,10 +428,13 @@ func extractWSProxyPath(servers string) (string, string) {
 		}
 		if (u.Scheme == "ws" || u.Scheme == "wss") && u.Path != "" && u.Path != "/" {
 			if proxyPath == "" {
-				proxyPath = u.Path
+				proxyPath = u.RequestURI()
 			}
+			// Strip path and query from the server URL
 			u.Path = ""
 			u.RawPath = ""
+			u.RawQuery = ""
+			u.ForceQuery = false
 			updated = append(updated, u.String())
 		} else {
 			updated = append(updated, s)

--- a/cli/util.go
+++ b/cli/util.go
@@ -416,6 +416,7 @@ func newNatsConnUnlocked(servers string, copts ...nats.Option) (*nats.Conn, erro
 func extractWSProxyPath(servers string) (string, string, error) {
 	var proxyPath string
 	var updated []string
+	var hasDefaultPathWS bool
 
 	for s := range strings.SplitSeq(servers, ",") {
 		s = strings.TrimSpace(s)
@@ -427,7 +428,8 @@ func extractWSProxyPath(servers string) (string, string, error) {
 			updated = append(updated, s)
 			continue
 		}
-		if (u.Scheme == "ws" || u.Scheme == "wss") && u.Path != "" && u.Path != "/" {
+		isWS := u.Scheme == "ws" || u.Scheme == "wss"
+		if isWS && u.Path != "" && u.Path != "/" {
 			reqURI := u.RequestURI()
 			if proxyPath == "" {
 				proxyPath = reqURI
@@ -441,8 +443,15 @@ func extractWSProxyPath(servers string) (string, string, error) {
 			u.ForceQuery = false
 			updated = append(updated, u.String())
 		} else {
+			if isWS {
+				hasDefaultPathWS = true
+			}
 			updated = append(updated, s)
 		}
+	}
+
+	if proxyPath != "" && hasDefaultPathWS {
+		return "", "", fmt.Errorf("mixing websocket servers with and without a proxy path is not supported")
 	}
 
 	return strings.Join(updated, ","), proxyPath, nil

--- a/cli/util.go
+++ b/cli/util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/url"
 	"os"
 	"os/exec"
 	"sort"
@@ -399,11 +400,45 @@ func newNatsConnUnlocked(servers string, copts ...nats.Option) (*nats.Conn, erro
 		servers = opts.Config.ServerURL()
 	}
 
+	servers, proxyPath := extractWSProxyPath(servers)
+	if proxyPath != "" {
+		copts = append(copts, nats.ProxyPath(proxyPath))
+	}
+
 	var err error
 
 	opts.Conn, err = nats.Connect(servers, copts...)
 
 	return opts.Conn, err
+}
+
+func extractWSProxyPath(servers string) (string, string) {
+	var proxyPath string
+	var updated []string
+
+	for s := range strings.SplitSeq(servers, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		u, err := url.Parse(s)
+		if err != nil {
+			updated = append(updated, s)
+			continue
+		}
+		if (u.Scheme == "ws" || u.Scheme == "wss") && u.Path != "" && u.Path != "/" {
+			if proxyPath == "" {
+				proxyPath = u.Path
+			}
+			u.Path = ""
+			u.RawPath = ""
+			updated = append(updated, u.String())
+		} else {
+			updated = append(updated, s)
+		}
+	}
+
+	return strings.Join(updated, ","), proxyPath
 }
 
 func newNatsConn(servers string, copts ...nats.Option) (*nats.Conn, error) {

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -41,7 +41,10 @@ func TestExtractWSProxyPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			servers, proxyPath := extractWSProxyPath(tc.input)
+			servers, proxyPath, err := extractWSProxyPath(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if servers != tc.servers {
 				t.Errorf("servers: got %q, want %q", servers, tc.servers)
 			}
@@ -50,6 +53,17 @@ func TestExtractWSProxyPath(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("different paths error", func(t *testing.T) {
+		_, _, err := extractWSProxyPath("ws://h1:80/path-a,ws://h2:80/path-b")
+		if err == nil {
+			t.Fatal("expected error for differing proxy paths")
+		}
+		want := `websocket servers with different paths are not supported: "/path-a", "/path-b"`
+		if err.Error() != want {
+			t.Errorf("error: got %q, want %q", err.Error(), want)
+		}
+	})
 }
 
 func TestRenderCluster(t *testing.T) {

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -64,6 +64,17 @@ func TestExtractWSProxyPath(t *testing.T) {
 			t.Errorf("error: got %q, want %q", err.Error(), want)
 		}
 	})
+
+	t.Run("mixed default and proxy path error", func(t *testing.T) {
+		_, _, err := extractWSProxyPath("ws://a.example/nats,ws://b.example")
+		if err == nil {
+			t.Fatal("expected error for mixed default and proxy paths")
+		}
+		want := "mixing websocket servers with and without a proxy path is not supported"
+		if err.Error() != want {
+			t.Errorf("error: got %q, want %q", err.Error(), want)
+		}
+	})
 }
 
 func TestRenderCluster(t *testing.T) {

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -34,6 +34,8 @@ func TestExtractWSProxyPath(t *testing.T) {
 		{"ws root path only", "ws://localhost:8080/", "ws://localhost:8080/", ""},
 		{"multiple ws same path", "ws://h1:80/path,ws://h2:80/path", "ws://h1:80,ws://h2:80", "/path"},
 		{"mixed ws and nats", "ws://h1:80/path,nats://h2:4222", "ws://h1:80,nats://h2:4222", "/path"},
+		{"ws with path and query", "ws://proxy.example/nats?tenant=a", "ws://proxy.example", "/nats?tenant=a"},
+		{"wss with path and query", "wss://proxy.example/nats?tenant=a&token=b", "wss://proxy.example", "/nats?tenant=a&token=b"},
 		{"empty string", "", "", ""},
 	}
 

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -19,6 +19,37 @@ import (
 	"github.com/nats-io/jsm.go/api"
 )
 
+func TestExtractWSProxyPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		servers   string
+		proxyPath string
+	}{
+		{"nats url unchanged", "nats://localhost:4222", "nats://localhost:4222", ""},
+		{"ws without path", "ws://localhost:8080", "ws://localhost:8080", ""},
+		{"wss without path", "wss://localhost:8080", "wss://localhost:8080", ""},
+		{"ws with path", "ws://localhost:8080/nats", "ws://localhost:8080", "/nats"},
+		{"wss with path", "wss://host:443/proxy/nats", "wss://host:443", "/proxy/nats"},
+		{"ws root path only", "ws://localhost:8080/", "ws://localhost:8080/", ""},
+		{"multiple ws same path", "ws://h1:80/path,ws://h2:80/path", "ws://h1:80,ws://h2:80", "/path"},
+		{"mixed ws and nats", "ws://h1:80/path,nats://h2:4222", "ws://h1:80,nats://h2:4222", "/path"},
+		{"empty string", "", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			servers, proxyPath := extractWSProxyPath(tc.input)
+			if servers != tc.servers {
+				t.Errorf("servers: got %q, want %q", servers, tc.servers)
+			}
+			if proxyPath != tc.proxyPath {
+				t.Errorf("proxyPath: got %q, want %q", proxyPath, tc.proxyPath)
+			}
+		})
+	}
+}
+
 func TestRenderCluster(t *testing.T) {
 	cluster := &api.ClusterInfo{
 		Name:   "test",


### PR DESCRIPTION
Fix WebSocket connections when the URL has a path.

This is an alternative fix to https://github.com/nats-io/nats.go/pull/2092.

```shell
# before
❯ nats -s 'ws://localhost:8080/api/cp-nats/' pub 'xyz' test
nats: error: invalid websocket connection

# after
❯ nats -s 'ws://localhost:8080/api/cp-nats/' pub 'xyz' test
10:22:37 Published 4 bytes to "xyz"
````