### PR TITLE
README: How to add authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ NATS Configuration Context "localhost"
   Server URLs: nats://127.0.0.1:4222
 ```
 
+💡 TIP: You can also add authentication configuration here, such as `user` and `password` or `creds`.
+(Either send them as command-line arguments or edit the whole context with `nats context edit localhost`.)
+
 Next we add a context for `demo.nats.io:4222` and we select it as default.
 
 ```


### PR DESCRIPTION
Context:
The readme wasn't providing any information about how to authenticate with the NATS server, and it wasn't trivial to figure this out.

Action:
Mention that authentication config can be added to the context.