### PR TITLE
add websocket headers and proxy path support

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"os"
 	"os/exec"
 	"sort"
@@ -234,6 +235,22 @@ func natsOpts() []nats.Option {
 	connectionName := strings.TrimSpace(opts().ConnectionName)
 	if len(connectionName) == 0 {
 		connectionName = "NATS CLI Version " + Version
+	}
+
+	if headers := opts().WebSocketHeaders; len(headers) != 0 {
+		hdrs := http.Header{}
+		for _, entry := range headers {
+			key, value, ok := strings.Cut(entry, ":")
+			if !ok {
+				fisk.FatalUsage("Each header should be in the form \"key: value\"")
+			}
+			hdrs.Add(key, strings.TrimSpace(value))
+		}
+		copts = append(copts, nats.WebSocketConnectionHeaders(hdrs))
+	}
+
+	if proxyPath := opts().ProxyPath; proxyPath != "" {
+		copts = append(copts, nats.ProxyPath(proxyPath))
 	}
 
 	return append(copts, []nats.Option{

--- a/nats/main.go
+++ b/nats/main.go
@@ -76,6 +76,8 @@ LLM optimized help output can be obtained using --help-llm for any command. You 
 	ncli.Flag("tlskey", "TLS private key").Envar("NATS_KEY").PlaceHolder("FILE").ExistingFileVar(&opts.TlsKey)
 	ncli.Flag("tlsca", "TLS certificate authority chain").Envar("NATS_CA").PlaceHolder("FILE").ExistingFileVar(&opts.TlsCA)
 	ncli.Flag("tlsfirst", "Perform TLS handshake before expecting the server greeting").BoolVar(&opts.TlsFirst)
+	ncli.Flag("ws-headers", "HTTP headers for use when connecting with websockets").Envar("NATS_WS_HEADERS").PlaceHolder("HEADERS").StringsVar(&opts.WebSocketHeaders)
+	ncli.Flag("proxy-path", "URL path to append to the server URL.  Useful for when a proxying traffic to nats.").Envar("NATS_PROXY_PATH").PlaceHolder("PATH").StringVar(&opts.ProxyPath)
 	// Alias to match nsc's spelling (--tls-first). Hidden so --help keeps
 	// showing only the canonical --tlsfirst; both names bind to the same
 	// variable so either spelling works in scripts.

--- a/options/options.go
+++ b/options/options.go
@@ -54,6 +54,10 @@ type Options struct {
 	UserJwt string
 	// UserSeed is the user seed to connect with
 	UserSeed string
+	// Extra HTTP headers for use with websocket connections
+	WebSocketHeaders []string
+	// Proxy path to use for connecting
+	ProxyPath string
 	// JsApiPrefix is the JetStream API prefix
 	JsApiPrefix string
 	// JsEventPrefix is the JetStream events prefix


### PR DESCRIPTION
This PR adds CLI flags for websocket headers and proxy path.

Some thoughts:
1. While the NATS API separates the proxy path from the server name, is that what we would want in the API?  I think it would be cleaner to support a server URL and then extract the URL path from that and use it as the proxy path.  `-s wss://example.com/path/to/websocket` as opposed to `-s wss://example.com --proxy-path /path/to/websocket`.
2. The NATS context config file should probably support setting the websocket headers and proxy path but that object seems to be defined in a the jsm.js project for some reason.   It is not obvious to me why the config file for the NATS cli is in the jsm.go project.
3. I still need to fix the `rtt` command.  It does some stuff differently that does not seem to work with websockets.