### PR TITLE
add duration flag

### DIFF
--- a/cli/bench_command.go
+++ b/cli/bench_command.go
@@ -48,7 +48,7 @@ import (
 type benchCmd struct {
 	subject              string
 	numClients           int
-	numMsg               int
+	numMsg               int64
 	msgSizeString        string
 	msgSize              int
 	csvFile              string
@@ -85,6 +85,7 @@ type benchCmd struct {
 	filterSubjects       []string // used by JS consumer commands
 	filterSubject        string   // used by JS get command
 	throughput           int
+	duration             time.Duration
 }
 
 // rateThrottler throttles a message loop to approximately target messages/sec.
@@ -105,7 +106,7 @@ func newRateThrottler(target float64) *rateThrottler {
 
 // throttle blocks as needed so that `sent` messages have been produced in at
 // least sent/target seconds since the throttler was created.
-func (r *rateThrottler) throttle(sent int) time.Duration {
+func (r *rateThrottler) throttle(sent int64) time.Duration {
 	expected := float64(sent) / r.target
 	elapsed := time.Since(r.start).Seconds()
 	if expected > elapsed {
@@ -131,7 +132,7 @@ func configureBenchCommand(app commandHost) {
 	addCommonFlags := func(f *fisk.CmdClause) {
 		f.Tag("scope:user", "impact:rw")
 		f.Flag("clients", "Number of concurrent clients").Default("1").IntVar(&c.numClients)
-		f.Flag("msgs", "Number of messages to publish or subscribe to").Default("100000").IntVar(&c.numMsg)
+		f.Flag("msgs", "Number of messages to publish or subscribe to").Default("100000").Int64Var(&c.numMsg)
 		f.Flag("progress", "Enable or disable the progress bar").Default("true").BoolVar(&c.progressBar)
 		f.Flag("csv", "Save benchmark data to CSV file").StringVar(&c.csvFile)
 		f.Flag("size", "Size of the test messages").Default("128B").StringVar(&c.msgSizeString)
@@ -148,6 +149,7 @@ func configureBenchCommand(app commandHost) {
 
 	addThroughputFlag := func(f *fisk.CmdClause) {
 		f.Flag("throughput", "If set > 0, throttle aggregate message send throughput to approximately THROUGHPUT messages/second across all clients (0 disables). If --sleep is set, the achieved rate may be lower").Default("0").PlaceHolder("THROUGHPUT").IntVar(&c.throughput)
+		f.Flag("duration", "Run for approximately this long instead of a fixed message count, deriving the number of messages from --throughput and taking precedence over --msgs (requires --throughput)").Default("0s").PlaceHolder("DURATION").DurationVar(&c.duration)
 	}
 
 	addJSCommonFlags := func(f *fisk.CmdClause) {
@@ -300,7 +302,6 @@ func configureBenchCommand(app commandHost) {
 	oldJSPull.Flag("batch", "Sets the fetch size for the consumer").Default("500").IntVar(&c.batchSize)
 	oldJSPull.Flag("ack", "Uses explicit message acknowledgement or not for the consumer").Default("true").BoolVar(&c.ack)
 	oldJSPull.Flag("doubleack", "Synchronously acknowledge messages, waiting for a reply from the server").Default("false").BoolVar(&c.doubleAck)
-
 }
 
 func init() {
@@ -342,8 +343,8 @@ func (c *benchCmd) getJS(nc *nats.Conn) (jetstream.JetStream, error) {
 	return js, nil
 }
 
-func (c *benchCmd) offset(putter int, counts []int) int {
-	var position = 0
+func (c *benchCmd) offset(putter int, counts []int64) int64 {
+	var position int64 = 0
 
 	for i := 0; i < putter; i++ {
 		position = position + counts[i]
@@ -352,8 +353,33 @@ func (c *benchCmd) offset(putter int, counts []int) int {
 }
 
 func (c *benchCmd) processActionArgs() error {
+	// --duration is a sub-property of --throughput: when set, derive the total
+	// number of messages from the target rate (taking precedence over --msgs).
+	// Only zero means unset; a negative duration is invalid and must fail fast.
+	if c.duration != 0 {
+		if c.duration < 0 {
+			return fmt.Errorf("--duration cannot be negative")
+		}
+
+		if c.throughput <= 0 {
+			return fmt.Errorf("--duration requires --throughput to be set")
+		}
+
+		// Derive the message count as round(throughput * duration)
+		msgs := int64(math.Round(float64(c.throughput) * c.duration.Seconds()))
+		if msgs <= 0 {
+			return fmt.Errorf("the combination of --throughput=%d and --duration=%s results in zero messages", c.throughput, c.duration)
+		}
+
+		c.numMsg = msgs
+	}
+
 	if c.numMsg <= 0 {
 		return fmt.Errorf("number of messages should be greater than 0")
+	}
+
+	if c.numMsg > math.MaxInt {
+		return fmt.Errorf("number of messages %d exceeds the maximum supported on this platform (%d)", c.numMsg, math.MaxInt)
 	}
 
 	// for pubs/request/and put only
@@ -505,6 +531,9 @@ func (c *benchCmd) generateBanner(benchType string) string {
 			bench.TypeJSPubSync, bench.TypeJSPubAsync, bench.TypeJSPubBatchAtomic, bench.TypeJSPubBatchFast,
 			bench.TypeKVPut:
 			argnvps = append(argnvps, nvp{"throughput", f(c.throughput)})
+			if c.duration > 0 {
+				argnvps = append(argnvps, nvp{"duration", f(c.duration)})
+			}
 		}
 	}
 
@@ -565,15 +594,15 @@ func (c *benchCmd) getSubscribeSubject() string {
 	}
 }
 
-func (c *benchCmd) getPublishSubject(number int) string {
+func (c *benchCmd) getPublishSubject(number int64) string {
 	if c.multiSubject {
 		if c.multiSubjectMax == 0 {
-			return c.subject + "." + strconv.Itoa(number)
+			return c.subject + "." + strconv.FormatInt(number, 10)
 		} else {
 			if c.multiSubjectRandom {
 				return c.subject + "." + fmt.Sprintf(c.multisubjectFormat, rand.IntN(c.multiSubjectMax))
 			} else {
-				return c.subject + "." + fmt.Sprintf(c.multisubjectFormat, number%c.multiSubjectMax)
+				return c.subject + "." + fmt.Sprintf(c.multisubjectFormat, number%int64(c.multiSubjectMax))
 			}
 		}
 	} else {
@@ -650,8 +679,8 @@ func (c *benchCmd) pubAction(_ *fisk.ParseContext) error {
 	}
 
 	// catch the number of clients being more than number of messages
-	if c.numClients > c.numMsg {
-		c.numClients = c.numMsg
+	if int64(c.numClients) > c.numMsg {
+		c.numClients = int(c.numMsg)
 	}
 
 	banner := c.generateBanner(bench.TypeCorePub)
@@ -785,8 +814,8 @@ func (c *benchCmd) requestAction(_ *fisk.ParseContext) error {
 	}
 
 	// catch the number of clients being more than number of messages
-	if c.numClients > c.numMsg {
-		c.numClients = c.numMsg
+	if int64(c.numClients) > c.numMsg {
+		c.numClients = int(c.numMsg)
 	}
 
 	banner := c.generateBanner(bench.TypeServiceRequest)
@@ -935,8 +964,8 @@ func (c *benchCmd) jspubActions(_ *fisk.ParseContext, jsPubType string) error {
 	}
 
 	// catch the number of clients being more than number of messages
-	if c.numClients > c.numMsg {
-		c.numClients = c.numMsg
+	if int64(c.numClients) > c.numMsg {
+		c.numClients = int(c.numMsg)
 	}
 
 	if c.persistModeAsync && c.replicas != 1 && jsPubType == bench.TypeJSPubBatchAtomic {
@@ -1412,8 +1441,8 @@ func (c *benchCmd) kvPutAction(_ *fisk.ParseContext) error {
 	}
 
 	// catch the number of clients being more than number of messages
-	if c.numClients > c.numMsg {
-		c.numClients = c.numMsg
+	if int64(c.numClients) > c.numMsg {
+		c.numClients = int(c.numMsg)
 	}
 
 	banner := c.generateBanner(bench.TypeKVPut)
@@ -1874,7 +1903,7 @@ func (c *benchCmd) getPayload(msgSize int) ([]byte, error) {
 	return buffer, nil
 }
 
-func (c *benchCmd) coreNATSPublisher(nc *nats.Conn, progress *uiprogress.Bar, payloadSize int, numMsg int, offset int) ([]uint64, error) {
+func (c *benchCmd) coreNATSPublisher(nc *nats.Conn, progress *uiprogress.Bar, payloadSize int, numMsg int64, offset int64) ([]uint64, error) {
 	state := "Publishing"
 	payload, err := c.getPayload(payloadSize)
 	if err != nil {
@@ -1899,7 +1928,7 @@ func (c *benchCmd) coreNATSPublisher(nc *nats.Conn, progress *uiprogress.Bar, pa
 	latencies := make([]uint64, numMsg)
 	throttler := newRateThrottler(c.perClientThroughput())
 
-	for i := 0; i < numMsg; i++ {
+	for i := int64(0); i < numMsg; i++ {
 		message.Subject = c.getPublishSubject(i + offset)
 		start := time.Now()
 
@@ -1923,7 +1952,7 @@ func (c *benchCmd) coreNATSPublisher(nc *nats.Conn, progress *uiprogress.Bar, pa
 	return latencies, nil
 }
 
-func (c *benchCmd) coreNATSRequester(nc *nats.Conn, progress *uiprogress.Bar, payloadSize int, numMsg int, offset int) ([]uint64, error) {
+func (c *benchCmd) coreNATSRequester(nc *nats.Conn, progress *uiprogress.Bar, payloadSize int, numMsg int64, offset int64) ([]uint64, error) {
 	errBytes := []byte("error")
 	minusByte := byte('-')
 	state := "Requesting"
@@ -1950,7 +1979,7 @@ func (c *benchCmd) coreNATSRequester(nc *nats.Conn, progress *uiprogress.Bar, pa
 	latencies := make([]uint64, numMsg)
 	throttler := newRateThrottler(c.perClientThroughput())
 
-	for i := 0; i < numMsg; i++ {
+	for i := int64(0); i < numMsg; i++ {
 		message.Subject = c.getPublishSubject(i + offset)
 
 		start := time.Now()
@@ -1978,7 +2007,7 @@ func (c *benchCmd) coreNATSRequester(nc *nats.Conn, progress *uiprogress.Bar, pa
 	return latencies, nil
 }
 
-func (c *benchCmd) jsPublisher(nc *nats.Conn, progress *uiprogress.Bar, jsPubType string, payloadSize int, numMsg int, idPrefix string, offset int, clientNumber int) ([]uint64, error) {
+func (c *benchCmd) jsPublisher(nc *nats.Conn, progress *uiprogress.Bar, jsPubType string, payloadSize int, numMsg int64, idPrefix string, offset int64, clientNumber int) ([]uint64, error) {
 	js, err := c.getJS(nc)
 	if err != nil {
 		return nil, err
@@ -2014,16 +2043,16 @@ func (c *benchCmd) jsPublisher(nc *nats.Conn, progress *uiprogress.Bar, jsPubTyp
 		// attempts counts every PublishMsgAsync call including retries after
 		// ack failures, since `i` only advances on successful acks. Driving
 		// the throttler off attempts keeps pacing honest across retries.
-		attempts := 0
+		attempts := int64(0)
 
-		for i := 0; i < numMsg; {
+		for i := int64(0); i < numMsg; {
 			state = "Publishing"
-			futures := make([]jetstream.PubAckFuture, min(c.batchSize, numMsg-i))
+			futures := make([]jetstream.PubAckFuture, min(int64(c.batchSize), numMsg-i))
 			start := time.Now()
 
-			for j := 0; j < c.batchSize && (i+j) < numMsg; j++ {
+			for j := int64(0); j < int64(c.batchSize) && (i+j) < numMsg; j++ {
 				if c.deDuplication {
-					message.Header.Set(nats.MsgIdHdr, idPrefix+"-"+strconv.Itoa(clientNumber)+"-"+strconv.Itoa(i+j+offset))
+					message.Header.Set(nats.MsgIdHdr, idPrefix+"-"+strconv.Itoa(clientNumber)+"-"+strconv.FormatInt(i+j+offset, 10))
 				}
 
 				message.Subject = c.getPublishSubject(i + j + offset)
@@ -2073,22 +2102,22 @@ func (c *benchCmd) jsPublisher(nc *nats.Conn, progress *uiprogress.Bar, jsPubTyp
 		// Atomic batch publish
 		latencies = make([]uint64, uint64(math.Ceil(float64(numMsg)/float64(c.batchSize))))
 		batch := 0
-		var msgs int
+		var msgs int64
 		batchId := idPrefix + "-" + strconv.Itoa(clientNumber)
 
-		for i := 0; i < numMsg; {
+		for i := int64(0); i < numMsg; {
 			state = "Batching  "
-			msgs = min(c.batchSize, numMsg-i)
+			msgs = min(int64(c.batchSize), numMsg-i)
 			message.Header.Del("Nats-Batch-Commit")
 			start := time.Now()
 
-			for j := 0; j < msgs; j++ {
+			for j := int64(0); j < msgs; j++ {
 				if c.deDuplication {
-					message.Header.Set(nats.MsgIdHdr, batchId+"-"+strconv.Itoa(i+j+offset))
+					message.Header.Set(nats.MsgIdHdr, batchId+"-"+strconv.FormatInt(i+j+offset, 10))
 				}
 
 				message.Header.Set("Nats-Batch-Id", batchId)
-				message.Header.Set("Nats-Batch-Sequence", strconv.Itoa(j+1))
+				message.Header.Set("Nats-Batch-Sequence", strconv.FormatInt(j+1, 10))
 				message.Subject = c.getPublishSubject(i + j + offset)
 
 				if j == msgs-1 {
@@ -2144,11 +2173,11 @@ func (c *benchCmd) jsPublisher(nc *nats.Conn, progress *uiprogress.Bar, jsPubTyp
 		start := time.Now()
 		ackSeq := uint64(0)
 
-		for i := 0; i < numMsg; i++ {
+		for i := int64(0); i < numMsg; i++ {
 			state = "Batching  "
 
 			if c.deDuplication {
-				message.Header.Set(nats.MsgIdHdr, batchId+"-"+strconv.Itoa(i+offset))
+				message.Header.Set(nats.MsgIdHdr, batchId+"-"+strconv.FormatInt(i+offset, 10))
 			}
 			message.Subject = c.getPublishSubject(i + offset)
 
@@ -2192,9 +2221,9 @@ func (c *benchCmd) jsPublisher(nc *nats.Conn, progress *uiprogress.Bar, jsPubTyp
 		latencies = make([]uint64, numMsg)
 		state = "Publishing"
 
-		for i := 0; i < numMsg; i++ {
+		for i := int64(0); i < numMsg; i++ {
 			if c.deDuplication {
-				message.Header.Set(nats.MsgIdHdr, idPrefix+"-"+strconv.Itoa(clientNumber)+"-"+strconv.Itoa(i+offset))
+				message.Header.Set(nats.MsgIdHdr, idPrefix+"-"+strconv.Itoa(clientNumber)+"-"+strconv.FormatInt(i+offset, 10))
 			}
 
 			message.Subject = c.getPublishSubject(i + offset)
@@ -2222,7 +2251,7 @@ func (c *benchCmd) jsPublisher(nc *nats.Conn, progress *uiprogress.Bar, jsPubTyp
 	return latencies, nil
 }
 
-func (c *benchCmd) kvPutter(nc *nats.Conn, progress *uiprogress.Bar, msg []byte, numMsg int, offset int) ([]uint64, error) {
+func (c *benchCmd) kvPutter(nc *nats.Conn, progress *uiprogress.Bar, msg []byte, numMsg int64, offset int64) ([]uint64, error) {
 	ctx := context.Background()
 
 	js, err := c.getJS(nc)
@@ -2245,11 +2274,11 @@ func (c *benchCmd) kvPutter(nc *nats.Conn, progress *uiprogress.Bar, msg []byte,
 	latencies := make([]uint64, numMsg)
 	throttler := newRateThrottler(c.perClientThroughput())
 
-	for i := 0; i < numMsg; i++ {
+	for i := int64(0); i < numMsg; i++ {
 		key := offset + i
 
 		if c.randomize > 0 {
-			key = rand.IntN(c.randomize)
+			key = int64(rand.IntN(c.randomize))
 		}
 
 		start := time.Now()
@@ -2271,7 +2300,7 @@ func (c *benchCmd) kvPutter(nc *nats.Conn, progress *uiprogress.Bar, msg []byte,
 	return latencies, nil
 }
 
-func (c *benchCmd) runCorePublisher(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, trigger chan struct{}, numMsg int, offset int, clientNumber int) {
+func (c *benchCmd) runCorePublisher(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, trigger chan struct{}, numMsg int64, offset int64, clientNumber int) {
 	startwg.Done()
 	var progress *uiprogress.Bar
 
@@ -2283,7 +2312,7 @@ func (c *benchCmd) runCorePublisher(bm *bench.BenchmarkResults, errChan chan err
 			barTotal = 1
 		}
 
-		progress = uiprogress.AddBar(barTotal).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(barTotal)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 
 		if numMsg == 0 {
@@ -2323,21 +2352,21 @@ func (c *benchCmd) runCorePublisher(bm *bench.BenchmarkResults, errChan chan err
 		return
 	}
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, time.Now(), latencies, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, time.Now(), latencies, nc))
 
 	donewg.Done()
 	errChan <- nil
 }
 
-func (c *benchCmd) runCoreSubscriber(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, numMsg int, clientNumber int) {
-	received := 0
+func (c *benchCmd) runCoreSubscriber(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, numMsg int64, clientNumber int) {
+	received := int64(0)
 	ch := make(chan time.Time, 2)
 	var progress *uiprogress.Bar
 
 	log.Printf("[%d] Starting %s, expecting %s messages", clientNumber+1, bench.GetBenchTypeLabel(bench.TypeCoreSub), f(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(numMsg)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 	}
 
@@ -2399,20 +2428,20 @@ func (c *benchCmd) runCoreSubscriber(bm *bench.BenchmarkResults, errChan chan er
 
 	state = "Finished  "
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, end, []uint64{}, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, end, []uint64{}, nc))
 
 	donewg.Done()
 	errChan <- nil
 }
 
-func (c *benchCmd) runCoreRequester(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, trigger chan struct{}, numMsg int, offset int, clientNumber int) {
+func (c *benchCmd) runCoreRequester(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, trigger chan struct{}, numMsg int64, offset int64, clientNumber int) {
 	startwg.Done()
 	var progress *uiprogress.Bar
 
 	log.Printf("[%d] Starting %s, requesting %s messages", clientNumber+1, bench.GetBenchTypeLabel(bench.TypeServiceRequest), f(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(numMsg)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 	}
 
@@ -2439,7 +2468,7 @@ func (c *benchCmd) runCoreRequester(bm *bench.BenchmarkResults, errChan chan err
 		return
 	}
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, time.Now(), latencies, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, time.Now(), latencies, nc))
 
 	donewg.Done()
 	errChan <- nil
@@ -2492,14 +2521,14 @@ func (c *benchCmd) runServiceServer(nc *nats.Conn, errChan chan error, startwg *
 	errChan <- nil
 }
 
-func (c *benchCmd) runJSPublisher(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, trigger chan struct{}, benchType string, numMsg int, offset int, idPrefix string, clientNumber int) {
+func (c *benchCmd) runJSPublisher(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, trigger chan struct{}, benchType string, numMsg int64, offset int64, idPrefix string, clientNumber int) {
 	startwg.Done()
 	var progress *uiprogress.Bar
 
 	log.Printf("[%d] Starting %s, publishing %s messages", clientNumber+1, bench.GetBenchTypeLabel(benchType), f(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(numMsg)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 	}
 
@@ -2526,21 +2555,21 @@ func (c *benchCmd) runJSPublisher(bm *bench.BenchmarkResults, errChan chan error
 		return
 	}
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, time.Now(), latencies, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, time.Now(), latencies, nc))
 
 	donewg.Done()
 	errChan <- nil
 }
 
-func (c *benchCmd) runJSSubscriber(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, benchType string, numMsg int, clientNumber int) {
-	received := 0
+func (c *benchCmd) runJSSubscriber(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, benchType string, numMsg int64, clientNumber int) {
+	received := int64(0)
 	ch := make(chan time.Time, 2)
 	var progress *uiprogress.Bar
 
-	log.Printf("[%d] Starting %s, expecting %s messages", clientNumber+1, bench.GetBenchTypeLabel(benchType), humanize.Comma(int64(numMsg)))
+	log.Printf("[%d] Starting %s, expecting %s messages", clientNumber+1, bench.GetBenchTypeLabel(benchType), humanize.Comma(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(numMsg)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 	}
 
@@ -2640,7 +2669,7 @@ func (c *benchCmd) runJSSubscriber(bm *bench.BenchmarkResults, errChan chan erro
 			return
 		}
 
-		cc, err := consumer.Consume(mh, jetstream.PullMaxMessages(c.batchSize), jetstream.StopAfter(numMsg))
+		cc, err := consumer.Consume(mh, jetstream.PullMaxMessages(c.batchSize), jetstream.StopAfter(int(numMsg)))
 		if err != nil {
 			errChan <- fmt.Errorf("calling Consume() on the durable consumer '%s': %w", c.consumerName, err)
 			startwg.Done()
@@ -2675,12 +2704,12 @@ func (c *benchCmd) runJSSubscriber(bm *bench.BenchmarkResults, errChan chan erro
 	if benchType == bench.TypeJSFetch {
 		latencies = make([]uint64, int(math.Ceil(float64(numMsg)/float64(c.batchSize))))
 
-		for i := 0; i < numMsg; {
+		for i := int64(0); i < numMsg; {
 			batchSize := func() int {
-				if c.batchSize <= (numMsg - i) {
+				if int64(c.batchSize) <= (numMsg - i) {
 					return c.batchSize
 				} else {
-					return numMsg - i
+					return int(numMsg - i)
 				}
 			}()
 
@@ -2721,20 +2750,20 @@ func (c *benchCmd) runJSSubscriber(bm *bench.BenchmarkResults, errChan chan erro
 
 	state = "Finished  "
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, end, latencies, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, end, latencies, nc))
 
 	donewg.Done()
 	errChan <- nil
 }
 
-func (c *benchCmd) runJSGetter(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, benchType string, numMsg int, clientNumber int) {
+func (c *benchCmd) runJSGetter(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, benchType string, numMsg int64, clientNumber int) {
 	ch := make(chan time.Time, 2)
 	var progress *uiprogress.Bar
 
 	log.Printf("[%d] Starting %s, expecting %s messages", clientNumber+1, bench.GetBenchTypeLabel(benchType), f(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(numMsg)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 	}
 
@@ -2823,12 +2852,12 @@ func (c *benchCmd) runJSGetter(bm *bench.BenchmarkResults, errChan chan error, n
 		var nextSeq uint64 = 1
 		latencies = make([]uint64, int(math.Ceil(float64(numMsg)/float64(c.batchSize))))
 
-		for i := 0; i < numMsg; {
+		for i := int64(0); i < numMsg; {
 			batchSize := func() int {
-				if c.batchSize <= (numMsg - i) {
+				if int64(c.batchSize) <= (numMsg - i) {
 					return c.batchSize
 				} else {
-					return numMsg - i
+					return int(numMsg - i)
 				}
 			}()
 
@@ -2889,20 +2918,20 @@ func (c *benchCmd) runJSGetter(bm *bench.BenchmarkResults, errChan chan error, n
 
 	state = "Finished  "
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, end, latencies, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, end, latencies, nc))
 
 	donewg.Done()
 	errChan <- nil
 }
 
-func (c *benchCmd) runKVPutter(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, trigger chan struct{}, numMsg int, offset int, clientNumber int) {
+func (c *benchCmd) runKVPutter(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, trigger chan struct{}, numMsg int64, offset int64, clientNumber int) {
 	startwg.Done()
 	var progress *uiprogress.Bar
 
 	log.Printf("[%d] Starting %s, publishing %s messages", clientNumber+1, bench.GetBenchTypeLabel(bench.TypeKVPut), f(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(numMsg)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 	}
 
@@ -2934,20 +2963,20 @@ func (c *benchCmd) runKVPutter(bm *bench.BenchmarkResults, errChan chan error, n
 		return
 	}
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, time.Now(), latencies, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, time.Now(), latencies, nc))
 
 	donewg.Done()
 	errChan <- nil
 }
 
-func (c *benchCmd) runKVGetter(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, numMsg int, offset int, clientNumber int) {
+func (c *benchCmd) runKVGetter(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, numMsg int64, offset int64, clientNumber int) {
 	ch := make(chan time.Time, 2)
 	var progress *uiprogress.Bar
 
 	log.Printf("[%d] Starting %s, trying to get %s messages", clientNumber+1, bench.GetBenchTypeLabel(bench.TypeKVGet), f(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(numMsg)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 	}
 
@@ -2990,7 +3019,7 @@ func (c *benchCmd) runKVGetter(bm *bench.BenchmarkResults, errChan chan error, n
 
 	state = "Getting   "
 
-	for i := 0; i < numMsg; i++ {
+	for i := int64(0); i < numMsg; i++ {
 		var key string
 
 		if c.randomize == 0 {
@@ -3026,21 +3055,21 @@ func (c *benchCmd) runKVGetter(bm *bench.BenchmarkResults, errChan chan error, n
 
 	state = "Finished  "
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, end, latencies, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, end, latencies, nc))
 
 	donewg.Done()
 	errChan <- nil
 }
 
-func (c *benchCmd) runOldJSSubscriber(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, numMsg int, benchType string, clientNumber int) {
-	received := 0
+func (c *benchCmd) runOldJSSubscriber(bm *bench.BenchmarkResults, errChan chan error, nc *nats.Conn, startwg *sync.WaitGroup, donewg *sync.WaitGroup, numMsg int64, benchType string, clientNumber int) {
+	received := int64(0)
 	ch := make(chan time.Time, 2)
 	var progress *uiprogress.Bar
 
 	log.Printf("[%d] Starting %s, expecting %s messages", clientNumber+1, bench.GetBenchTypeLabel(benchType), f(numMsg))
 
 	if c.progressBar {
-		progress = uiprogress.AddBar(numMsg).AppendCompleted().PrependElapsed()
+		progress = uiprogress.AddBar(int(numMsg)).AppendCompleted().PrependElapsed()
 		progress.Width = iu.ProgressWidth()
 	}
 
@@ -3141,7 +3170,7 @@ func (c *benchCmd) runOldJSSubscriber(bm *bench.BenchmarkResults, errChan chan e
 			donewg.Done()
 			return
 		}
-		_ = sub.AutoUnsubscribe(numMsg)
+		_ = sub.AutoUnsubscribe(int(numMsg))
 
 	} else { // benchType == benchTypeOldJSOrdered
 		state = "Consuming "
@@ -3174,12 +3203,12 @@ func (c *benchCmd) runOldJSSubscriber(bm *bench.BenchmarkResults, errChan chan e
 	startwg.Done()
 
 	if benchType == bench.TypeOldJSPull {
-		for i := 0; i < numMsg; {
+		for i := int64(0); i < numMsg; {
 			batchSize := func() int {
-				if c.batchSize <= (numMsg - i) {
+				if int64(c.batchSize) <= (numMsg - i) {
 					return c.batchSize
 				} else {
-					return numMsg - i
+					return int(numMsg - i)
 				}
 			}()
 
@@ -3218,24 +3247,24 @@ func (c *benchCmd) runOldJSSubscriber(bm *bench.BenchmarkResults, errChan chan e
 
 	state = "Finished  "
 
-	bm.AddSample(bench.NewSample(numMsg, c.msgSize, start, end, []uint64{}, nc))
+	bm.AddSample(bench.NewSample(int(numMsg), c.msgSize, start, end, []uint64{}, nc))
 
 	donewg.Done()
 	errChan <- nil
 }
 
 // msgsPerClient divides the number of messages by the number of clients and tries to distribute them as evenly as possible
-func msgsPerClient(numMsgs, numClients int) []int {
-	var counts []int
+func msgsPerClient(numMsgs int64, numClients int) []int64 {
+	var counts []int64
 	if numClients == 0 || numMsgs == 0 {
 		return counts
 	}
-	counts = make([]int, numClients)
-	mc := numMsgs / numClients
+	counts = make([]int64, numClients)
+	mc := numMsgs / int64(numClients)
 	for i := 0; i < numClients; i++ {
 		counts[i] = mc
 	}
-	extra := numMsgs % numClients
+	extra := int(numMsgs % int64(numClients))
 	for i := 0; i < extra; i++ {
 		counts[i]++
 	}

--- a/cli/bench_command_test.go
+++ b/cli/bench_command_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/choria-io/fisk"
+	"github.com/nats-io/jsm.go/natscontext"
+	"github.com/nats-io/natscli/options"
+)
+
+func TestBenchProcessActionArgsDuration(t *testing.T) {
+	// processActionArgs consults the global options for the active context, so
+	// provide an empty one and restore whatever was there afterwards.
+	origOpts := options.DefaultOptions
+	t.Cleanup(func() { options.DefaultOptions = origOpts })
+
+	nctx, err := natscontext.New("test", false)
+	if err != nil {
+		t.Fatalf("creating test context: %v", err)
+	}
+	options.DefaultOptions = &options.Options{Config: nctx}
+
+	tests := []struct {
+		name        string
+		numMsg      int64
+		throughput  int
+		duration    time.Duration
+		expectErr   string
+		expectedMsg int64
+	}{
+		{
+			name:        "duration derives msgs from throughput",
+			numMsg:      100000,
+			throughput:  50000,
+			duration:    30 * time.Second,
+			expectedMsg: 1500000,
+		},
+		{
+			name:        "duration takes precedence over msgs",
+			numMsg:      42,
+			throughput:  1000,
+			duration:    2 * time.Second,
+			expectedMsg: 2000,
+		},
+		{
+			name:      "duration without throughput errors",
+			numMsg:    100000,
+			duration:  10 * time.Second,
+			expectErr: "--duration requires --throughput to be set",
+		},
+		{
+			name:       "negative duration errors",
+			numMsg:     100000,
+			throughput: 50000,
+			duration:   -1 * time.Second,
+			expectErr:  "--duration cannot be negative",
+		},
+		{
+			name:       "duration too short for throughput rounds to zero",
+			numMsg:     100000,
+			throughput: 1,
+			duration:   100 * time.Millisecond,
+			expectErr:  "results in zero messages",
+		},
+		{
+			name:        "no duration leaves msgs unchanged",
+			numMsg:      777,
+			throughput:  50000,
+			expectedMsg: 777,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &benchCmd{
+				numMsg:     tc.numMsg,
+				throughput: tc.throughput,
+				duration:   tc.duration,
+			}
+
+			err := c.processActionArgs()
+
+			if tc.expectErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.expectErr)
+				}
+				if !strings.Contains(err.Error(), tc.expectErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.expectErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if c.numMsg != tc.expectedMsg {
+				t.Fatalf("expected numMsg %d, got %d", tc.expectedMsg, c.numMsg)
+			}
+		})
+	}
+}
+
+// TestBenchDurationWithoutMsgsFlag ensures --msgs is optional: supplying only
+// --duration (with --throughput) must parse cleanly through the real command
+// wiring, so users are not forced to also pass --msgs.
+func TestBenchDurationWithoutMsgsFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "core pub with only duration and throughput",
+			args: []string{"bench", "pub", "foo", "--throughput", "1000", "--duration", "2s"},
+		},
+		{
+			name: "js sync pub with only duration and throughput",
+			args: []string{"bench", "js", "pub", "sync", "foo", "--throughput", "1000", "--duration", "2s"},
+		},
+		{
+			name: "kv put with only duration and throughput",
+			args: []string{"bench", "kv", "put", "--throughput", "1000", "--duration", "2s"},
+		},
+	}
+
+	origOpts := options.DefaultOptions
+	t.Cleanup(func() { options.DefaultOptions = origOpts })
+	options.DefaultOptions = &options.Options{NoCheats: true}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fisk.New("test", "test")
+			configureBenchCommand(app)
+
+			if _, err := app.ParseContext(tc.args); err != nil {
+				t.Fatalf("expected %v to parse without --msgs, got: %v", tc.args, err)
+			}
+		})
+	}
+}

--- a/cli/cheats/bench.md
+++ b/cli/cheats/bench.md
@@ -35,6 +35,9 @@ nats bench pub foo --sleep=100ns
 # throttle aggregate publisher throughput to approximately 50,000 msgs/sec across all clients (useful for head-to-head comparisons with Kafka's --throughput)
 nats bench pub foo --msgs 1000000 --clients 4 --throughput 50000
 
+# run for approximately 30 seconds at 50,000 msgs/sec (--duration derives --msgs from --throughput and is only valid together with it)
+nats bench pub foo --clients 4 --throughput 50000 --duration 30s
+
 # put messages into a KV using synchronous put operations
 nats bench kv put --clients 10
 


### PR DESCRIPTION
This PR adds a --duration flag to the nats bench producer commands, letting a benchmark run for an approximate wall-clock time instead of a fixed message count. It works as a sub-property of --throughput: when set, the number of messages is derived from the target rate (msgs = throughput × duration) and takes precedence over --msgs; it requires --throughput and errors if the derived count rounds to zero. 