### PR TITLE
Filter pending bytes

### DIFF
--- a/cli/account_command.go
+++ b/cli/account_command.go
@@ -54,6 +54,7 @@ type actCmd struct {
 	stateFilter      string
 	user             string
 	filterReason     string
+	pendingBytes     string
 }
 
 func configureActCommand(app commandHost) {
@@ -67,7 +68,7 @@ func configureActCommand(app commandHost) {
 	report := act.Command("report", "Report on account metrics").Alias("rep")
 	report.Tag("scope:user", "impact:ro")
 
-	conns := report.Command("connections", "Report on connections").Alias("conn").Alias("connz").Alias("conns").Action(c.reportConnectionsAction)
+	conns := report.Command("connections", "Report on connections. For more options try 'nats server req connections'").Alias("conn").Alias("connz").Alias("conns").Action(c.reportConnectionsAction)
 	conns.Tag("scope:user", "impact:ro")
 	conns.Flag("sort", "Sort by a specific property (in-bytes,out-bytes,in-msgs,out-msgs,uptime,cid,subs)").Default("subs").EnumVar(&c.sort, "in-bytes", "out-bytes", "in-msgs", "out-msgs", "uptime", "cid", "subs")
 	conns.Flag("top", "Limit results to the top results").Default("1000").IntVar(&c.topk)
@@ -76,6 +77,7 @@ func configureActCommand(app commandHost) {
 	conns.Flag("reverse", "Reverse sort connections").Short('R').UnNegatableBoolVar(&c.reverse)
 	conns.Flag("state", "Limits responses only to those connections that are in a specific state (open, closed, all)").Default("open").EnumVar(&c.stateFilter, "open", "closed", "all")
 	conns.Flag("closed-reason", "Filter results based on a closed reason").PlaceHolder("REASON").StringVar(&c.filterReason)
+	conns.Flag("pending-bytes", "Limits responses only to those connections with at least this many pending bytes, supports sizes like 1MB").PlaceHolder("BYTES").StringVar(&c.pendingBytes)
 
 	stats := report.Command("statistics", "Report on server statistics").Alias("stats").Alias("statsz").Action(c.reportServerStats)
 	stats.Tag("scope:user", "impact:ro")
@@ -238,6 +240,7 @@ func (c *actCmd) reportConnectionsAction(pc *fisk.ParseContext) error {
 		reverse:                 c.reverse,
 		stateFilter:             c.stateFilter,
 		filterReason:            c.filterReason,
+		pendingBytesFilter:      c.pendingBytes,
 		user:                    c.user,
 		skipDiscoverClusterSize: true,
 		nc:                      nc,

--- a/cli/cheats/server.md
+++ b/cli/cheats/server.md
@@ -40,5 +40,8 @@ nats server req leafnodes --subscriptions
 nats server req accounts --account WEATHER
 nats server req jsz --leader
 
+# Filter for connections prone to "slow consumer" warnings
+nats server req connections --subscriptions --filter-empty --filter-pending-bytes=48000000"
+
 # To manage JetStream cluster RAFT membership
 nats server raft step-down

--- a/cli/cheats/server.md
+++ b/cli/cheats/server.md
@@ -41,7 +41,8 @@ nats server req accounts --account WEATHER
 nats server req jsz --leader
 
 # Filter for connections prone to "slow consumer" warnings
-nats server req connections --subscriptions --filter-empty --limit=64000 --filter-pending-bytes=48000000"
+nats server req connections --subscriptions --filter-empty --limit=64000 --filter-pending-bytes=48000000
+nats server req connections --subscriptions --filter-empty --limit=64000 --filter-pending-bytes=75%
 
 # To manage JetStream cluster RAFT membership
 nats server raft step-down

--- a/cli/cheats/server.md
+++ b/cli/cheats/server.md
@@ -41,7 +41,7 @@ nats server req accounts --account WEATHER
 nats server req jsz --leader
 
 # Filter for connections prone to "slow consumer" warnings
-nats server req connections --subscriptions --filter-empty --filter-pending-bytes=48000000"
+nats server req connections --subscriptions --filter-empty --limit=64000 --filter-pending-bytes=48000000"
 
 # To manage JetStream cluster RAFT membership
 nats server raft step-down

--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -52,6 +52,7 @@ type SrvReportCmd struct {
 	tags                    []string
 	stateFilter             string
 	filterReason            string
+	pendingBytesFilter      string
 	skipDiscoverClusterSize bool
 	archivePath             string
 	gatewayName             string
@@ -110,6 +111,7 @@ func configureServerReportCommand(srv *fisk.CmdClause) {
 	conns.Flag("username", "Limits responses only to those connections for a specific authentication username").StringVar(&c.user)
 	conns.Flag("state", "Limits responses only to those connections that are in a specific state (open, closed, all)").Default("open").EnumVar(&c.stateFilter, "open", "closed", "all")
 	conns.Flag("closed-reason", "Filter results based on a closed reason").PlaceHolder("REASON").StringVar(&c.filterReason)
+	conns.Flag("pending-bytes", "Limits responses only to those connections with at least this many pending bytes, supports sizes like 1MB").PlaceHolder("BYTES").StringVar(&c.pendingBytesFilter)
 	conns.Flag("filter", "Expression based filter for connections").StringVar(&c.filterExpression)
 	addFilterOpts(conns)
 	conns.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
@@ -1391,6 +1393,25 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 		fisk.FatalIfError(err, "Invalid expression: %v", err)
 	}
 
+	pendingBytes, pendingPercent, err := parsePendingBytesFilter("--pending-bytes", c.pendingBytesFilter)
+	if err != nil {
+		return nil, err
+	}
+	if pendingPercent > 0 {
+		return nil, fmt.Errorf("--pending-bytes does not support percentages, use 'nats server request connections --filter-pending-bytes' instead")
+	}
+
+	// removes any connections with fewer than pendingBytes bytes pending
+	removePendingConns := func(co *server.ServerAPIConnzResponse) {
+		conns := make([]*server.ConnInfo, 0, len(co.Data.Conns))
+		for _, conn := range co.Data.Conns {
+			if conn != nil && int64(conn.Pending) >= pendingBytes {
+				conns = append(conns, conn)
+			}
+		}
+		co.Data.Conns = conns
+	}
+
 	removeFilteredConns := func(co *server.ServerAPIConnzResponse) error {
 		conns := make([]*server.ConnInfo, len(co.Data.Conns))
 		copy(conns, co.Data.Conns)
@@ -1471,6 +1492,10 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 		}
 		found += len(co.Data.Conns)
 
+		if pendingBytes > 0 {
+			removePendingConns(co)
+		}
+
 		if c.filterExpression != "" {
 			err = removeFilteredConns(co)
 			if err != nil {
@@ -1537,6 +1562,10 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 
 			if len(co.Data.Conns) == 0 {
 				continue
+			}
+
+			if pendingBytes > 0 {
+				removePendingConns(co)
 			}
 
 			if c.filterExpression != "" {

--- a/cli/server_request_command.go
+++ b/cli/server_request_command.go
@@ -62,6 +62,7 @@ type SrvRequestCmd struct {
 	accountFilter        string
 	subjectFilter        string
 	nameFilter           string
+	pendingBytesFilter   int
 	accountSubscriptions bool
 
 	nc *nats.Conn
@@ -107,6 +108,7 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	connz.Flag("filter-user", "Filter on a specific username").PlaceHolder("USER").StringVar(&c.userFilter)
 	connz.Flag("filter-account", "Filter on a specific account").PlaceHolder("ACCOUNT").StringVar(&c.accountFilter)
 	connz.Flag("filter-subject", "Limits responses only to those connections with matching subscription interest").PlaceHolder("SUBJECT").StringVar(&c.subjectFilter)
+	connz.Flag("filter-pending-bytes", "Only shows connections with at least this many pending bytes").PlaceHolder("BYTES").IntVar(&c.pendingBytesFilter)
 	connz.Flag("filter-empty", "Only shows responses that have connections").Default("false").UnNegatableBoolVar(&c.filterEmpty)
 	connz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
@@ -587,6 +589,18 @@ func (c *SrvRequestCmd) conns(_ *fisk.ParseContext) error {
 	}
 
 	for _, r := range responses {
+		if c.pendingBytesFilter > 0 && r.Data != nil {
+			matched := make([]*server.ConnInfo, 0, len(r.Data.Conns))
+			for _, conn := range r.Data.Conns {
+				if conn != nil && conn.Pending >= c.pendingBytesFilter {
+					matched = append(matched, conn)
+				}
+			}
+			r.Data.Conns = matched
+			r.Data.NumConns = len(matched)
+			r.Data.Total = len(matched)
+		}
+
 		if c.filterEmpty && (r.Data == nil || r.Data.NumConns == 0) {
 			continue
 		}

--- a/cli/server_request_command.go
+++ b/cli/server_request_command.go
@@ -19,9 +19,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nats-io/jsm.go/serverdata"
+	iu "github.com/nats-io/natscli/internal/util"
 	"github.com/nats-io/natscli/options"
 
 	"github.com/nats-io/nats-server/v2/server"
@@ -62,7 +65,7 @@ type SrvRequestCmd struct {
 	accountFilter        string
 	subjectFilter        string
 	nameFilter           string
-	pendingBytesFilter   int
+	pendingBytesFilter   string
 	accountSubscriptions bool
 
 	nc *nats.Conn
@@ -108,7 +111,7 @@ func configureServerRequestCommand(srv *fisk.CmdClause) {
 	connz.Flag("filter-user", "Filter on a specific username").PlaceHolder("USER").StringVar(&c.userFilter)
 	connz.Flag("filter-account", "Filter on a specific account").PlaceHolder("ACCOUNT").StringVar(&c.accountFilter)
 	connz.Flag("filter-subject", "Limits responses only to those connections with matching subscription interest").PlaceHolder("SUBJECT").StringVar(&c.subjectFilter)
-	connz.Flag("filter-pending-bytes", "Only shows connections with at least this many pending bytes").PlaceHolder("BYTES").IntVar(&c.pendingBytesFilter)
+	connz.Flag("filter-pending-bytes", "Only shows connections with at least this many pending bytes, supports sizes like 1MB and percentages of the server max_pending like 10%").PlaceHolder("BYTES").StringVar(&c.pendingBytesFilter)
 	connz.Flag("filter-empty", "Only shows responses that have connections").Default("false").UnNegatableBoolVar(&c.filterEmpty)
 	connz.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 
@@ -551,6 +554,58 @@ func (c *SrvRequestCmd) routez(_ *fisk.ParseContext) error {
 	return printResults(responses)
 }
 
+// parsePendingBytesFilter parses --filter-pending-bytes which is either an absolute
+// size like 1024 or 1MB, or a percentage of the servers max_pending like 10%.
+// Returns 0 for both values when the filter is not set.
+func (c *SrvRequestCmd) parsePendingBytesFilter() (int64, float64, error) {
+	val := strings.TrimSpace(c.pendingBytesFilter)
+	if val == "" {
+		return 0, 0, nil
+	}
+
+	if strings.HasSuffix(val, "%") {
+		pct, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(val, "%")), 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid percentage %q for --filter-pending-bytes: %v", val, err)
+		}
+		if pct < 0 {
+			return 0, 0, fmt.Errorf("invalid percentage %q for --filter-pending-bytes: must not be negative", val)
+		}
+
+		return 0, pct, nil
+	}
+
+	bytes, err := iu.ParseStringAsBytes(val, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid size %q for --filter-pending-bytes: %v", val, err)
+	}
+	if bytes < 0 {
+		return 0, 0, fmt.Errorf("invalid size %q for --filter-pending-bytes: must not be negative", val)
+	}
+
+	return bytes, 0, nil
+}
+
+// serverMaxPending maps server IDs to their configured max_pending as reported by VARZ
+func (c *SrvRequestCmd) serverMaxPending(src serverdata.Source) (map[string]int64, error) {
+	responses, err := src.Varz(server.VarzEventOptions{
+		EventFilterOptions: c.reqFilter(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]int64, len(responses))
+	for _, r := range responses {
+		if r.Server == nil || r.Data == nil {
+			continue
+		}
+		res[r.Server.ID] = r.Data.MaxPending
+	}
+
+	return res, nil
+}
+
 func (c *SrvRequestCmd) conns(_ *fisk.ParseContext) error {
 	src, err := c.dataSource()
 	if err != nil {
@@ -583,16 +638,43 @@ func (c *SrvRequestCmd) conns(_ *fisk.ParseContext) error {
 		opts.State = server.ConnOpen
 	}
 
+	pendingBytes, pendingPercent, err := c.parsePendingBytesFilter()
+	if err != nil {
+		return err
+	}
+
+	// percentages are relative to each servers max_pending which is only in VARZ
+	var maxPending map[string]int64
+	if pendingPercent > 0 {
+		maxPending, err = c.serverMaxPending(src)
+		if err != nil {
+			return err
+		}
+	}
+
 	responses, err := src.Connz(opts)
 	if err != nil {
 		return err
 	}
 
 	for _, r := range responses {
-		if c.pendingBytesFilter > 0 && r.Data != nil {
+		if (pendingBytes > 0 || pendingPercent > 0) && r.Data != nil {
+			threshold := pendingBytes
+			resolved := true
+
+			if pendingPercent > 0 {
+				var mp int64
+				if r.Server != nil {
+					mp = maxPending[r.Server.ID]
+				}
+				// without a max_pending we cannot resolve the percentage for this server
+				resolved = mp > 0
+				threshold = int64(float64(mp) * pendingPercent / 100)
+			}
+
 			matched := make([]*server.ConnInfo, 0, len(r.Data.Conns))
 			for _, conn := range r.Data.Conns {
-				if conn != nil && conn.Pending >= c.pendingBytesFilter {
+				if resolved && conn != nil && int64(conn.Pending) >= threshold {
 					matched = append(matched, conn)
 				}
 			}

--- a/cli/server_request_command.go
+++ b/cli/server_request_command.go
@@ -554,11 +554,11 @@ func (c *SrvRequestCmd) routez(_ *fisk.ParseContext) error {
 	return printResults(responses)
 }
 
-// parsePendingBytesFilter parses --filter-pending-bytes which is either an absolute
-// size like 1024 or 1MB, or a percentage of the servers max_pending like 10%.
-// Returns 0 for both values when the filter is not set.
-func (c *SrvRequestCmd) parsePendingBytesFilter() (int64, float64, error) {
-	val := strings.TrimSpace(c.pendingBytesFilter)
+// parsePendingBytesFilter parses a pending bytes filter which is either an absolute
+// size like 1024 or 1MB, or a percentage like 10%. Exactly one of the returned values
+// will be non zero, both are 0 when the filter is not set.
+func parsePendingBytesFilter(flag string, val string) (int64, float64, error) {
+	val = strings.TrimSpace(val)
 	if val == "" {
 		return 0, 0, nil
 	}
@@ -566,10 +566,10 @@ func (c *SrvRequestCmd) parsePendingBytesFilter() (int64, float64, error) {
 	if strings.HasSuffix(val, "%") {
 		pct, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(val, "%")), 64)
 		if err != nil {
-			return 0, 0, fmt.Errorf("invalid percentage %q for --filter-pending-bytes: %v", val, err)
+			return 0, 0, fmt.Errorf("invalid percentage %q for %s: %v", val, flag, err)
 		}
 		if pct < 0 {
-			return 0, 0, fmt.Errorf("invalid percentage %q for --filter-pending-bytes: must not be negative", val)
+			return 0, 0, fmt.Errorf("invalid percentage %q for %s: must not be negative", val, flag)
 		}
 
 		return 0, pct, nil
@@ -577,10 +577,10 @@ func (c *SrvRequestCmd) parsePendingBytesFilter() (int64, float64, error) {
 
 	size, err := iu.ParseStringAsBytes(val, 64)
 	if err != nil {
-		return 0, 0, fmt.Errorf("invalid size %q for --filter-pending-bytes: %v", val, err)
+		return 0, 0, fmt.Errorf("invalid size %q for %s: %v", val, flag, err)
 	}
 	if size < 0 {
-		return 0, 0, fmt.Errorf("invalid size %q for --filter-pending-bytes: must not be negative", val)
+		return 0, 0, fmt.Errorf("invalid size %q for %s: must not be negative", val, flag)
 	}
 
 	return size, 0, nil
@@ -638,7 +638,7 @@ func (c *SrvRequestCmd) conns(_ *fisk.ParseContext) error {
 		opts.State = server.ConnOpen
 	}
 
-	pendingBytes, pendingPercent, err := c.parsePendingBytesFilter()
+	pendingBytes, pendingPercent, err := parsePendingBytesFilter("--filter-pending-bytes", c.pendingBytesFilter)
 	if err != nil {
 		return err
 	}

--- a/cli/server_request_command.go
+++ b/cli/server_request_command.go
@@ -575,15 +575,15 @@ func (c *SrvRequestCmd) parsePendingBytesFilter() (int64, float64, error) {
 		return 0, pct, nil
 	}
 
-	bytes, err := iu.ParseStringAsBytes(val, 64)
+	size, err := iu.ParseStringAsBytes(val, 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("invalid size %q for --filter-pending-bytes: %v", val, err)
 	}
-	if bytes < 0 {
+	if size < 0 {
 		return 0, 0, fmt.Errorf("invalid size %q for --filter-pending-bytes: must not be negative", val)
 	}
 
-	return bytes, 0, nil
+	return size, 0, nil
 }
 
 // serverMaxPending maps server IDs to their configured max_pending as reported by VARZ


### PR DESCRIPTION
A (no  longer) fairly simple change that will make looking for slow consumers at lot easier.
Update nats cheat request

Example:
`nats server req connections --subscriptions --filter-empty --limit=64000 --filter-pending-bytes=48000000`
OR
nats server req connections --subscriptions --filter-empty --limit=64000 --filter-pending-bytes=75%


Also supported in:
`nats server report connections --pending-bytes=48000000`
`nats account report connections --pending-bytes=48000000`

