### PR TITLE
Filter for pending bytes in a connection

### DIFF
--- a/cli/account_command.go
+++ b/cli/account_command.go
@@ -55,7 +55,6 @@ type actCmd struct {
 	user             string
 	filterReason     string
 
-	json               bool
 	pendingBytes       string
 	filterEmpty        bool
 	subscriptionDetail bool
@@ -84,7 +83,6 @@ func configureActCommand(app commandHost) {
 	conns.Flag("filter-empty", "Only shows responses that have connections").UnNegatableBoolVar(&c.filterEmpty)
 	conns.Flag("pending-bytes", "Filter out connections with fewer than pending bytes in the outbound buffer (accepts units: KB, MB, GB; or percentage: 50%)").PlaceHolder("BYTES").StringVar(&c.pendingBytes)
 	conns.Flag("subscription-detail", "Request detailed subscription information rather than a plain subject list").UnNegatableBoolVar(&c.subscriptionDetail)
-	conns.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
 
 	stats := report.Command("statistics", "Report on server statistics").Alias("stats").Alias("statsz").Action(c.reportServerStats)
 	stats.Tag("scope:user", "impact:ro")
@@ -238,11 +236,11 @@ func (c *actCmd) reportConnectionsAction(pc *fisk.ParseContext) error {
 	// resolving a percentage needs each servers max_pending from VARZ which is
 	// only available to the system account, this command runs in a user scope so
 	// reject it before connecting rather than failing after gathering data
-	pending, err := parsePendingBytes(c.pendingBytes)
+	pending, err := iu.ParsePendingBytes(c.pendingBytes)
 	if err != nil {
 		return err
 	}
-	if pending.isPercent {
+	if pending.IsPercent {
 		return fmt.Errorf("percentage based --pending-bytes filters require system account privileges, use an absolute size like 1MB here or use 'nats server report connections' with a system account")
 	}
 
@@ -259,7 +257,6 @@ func (c *actCmd) reportConnectionsAction(pc *fisk.ParseContext) error {
 		stateFilter:             c.stateFilter,
 		filterReason:            c.filterReason,
 		user:                    c.user,
-		json:                    c.json,
 		pendingBytes:            c.pendingBytes,
 		filterEmpty:             c.filterEmpty,
 		subscriptionDetail:      c.subscriptionDetail,

--- a/cli/account_command.go
+++ b/cli/account_command.go
@@ -54,6 +54,11 @@ type actCmd struct {
 	stateFilter      string
 	user             string
 	filterReason     string
+
+	json               bool
+	pendingBytes       string
+	filterEmpty        bool
+	subscriptionDetail bool
 }
 
 func configureActCommand(app commandHost) {
@@ -76,6 +81,10 @@ func configureActCommand(app commandHost) {
 	conns.Flag("reverse", "Reverse sort connections").Short('R').UnNegatableBoolVar(&c.reverse)
 	conns.Flag("state", "Limits responses only to those connections that are in a specific state (open, closed, all)").Default("open").EnumVar(&c.stateFilter, "open", "closed", "all")
 	conns.Flag("closed-reason", "Filter results based on a closed reason").PlaceHolder("REASON").StringVar(&c.filterReason)
+	conns.Flag("filter-empty", "Only shows responses that have connections").UnNegatableBoolVar(&c.filterEmpty)
+	conns.Flag("pending-bytes", "Filter out connections with fewer than pending bytes in the outbound buffer (accepts units: KB, MB, GB; or percentage: 50%)").PlaceHolder("BYTES").StringVar(&c.pendingBytes)
+	conns.Flag("subscription-detail", "Request detailed subscription information rather than a plain subject list").UnNegatableBoolVar(&c.subscriptionDetail)
+	conns.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
 
 	stats := report.Command("statistics", "Report on server statistics").Alias("stats").Alias("statsz").Action(c.reportServerStats)
 	stats.Tag("scope:user", "impact:ro")
@@ -226,6 +235,17 @@ func (c *actCmd) restoreAction(kp *fisk.ParseContext) error {
 }
 
 func (c *actCmd) reportConnectionsAction(pc *fisk.ParseContext) error {
+	// resolving a percentage needs each servers max_pending from VARZ which is
+	// only available to the system account, this command runs in a user scope so
+	// reject it before connecting rather than failing after gathering data
+	pending, err := parsePendingBytes(c.pendingBytes)
+	if err != nil {
+		return err
+	}
+	if pending.isPercent {
+		return fmt.Errorf("percentage based --pending-bytes filters require system account privileges, use an absolute size like 1MB here or use 'nats server report connections' with a system account")
+	}
+
 	nc, _, err := prepareHelper("", natsOpts()...)
 	if err != nil {
 		return err
@@ -239,6 +259,10 @@ func (c *actCmd) reportConnectionsAction(pc *fisk.ParseContext) error {
 		stateFilter:             c.stateFilter,
 		filterReason:            c.filterReason,
 		user:                    c.user,
+		json:                    c.json,
+		pendingBytes:            c.pendingBytes,
+		filterEmpty:             c.filterEmpty,
+		subscriptionDetail:      c.subscriptionDetail,
 		skipDiscoverClusterSize: true,
 		nc:                      nc,
 	}

--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -1178,7 +1176,7 @@ func (c *SrvReportCmd) accountInfo(connz connzList) map[string]*srvReportAccount
 			account.OutBytes += info.OutBytes
 			account.InMsgs += info.InMsgs
 			account.OutMsgs += info.OutMsgs
-			account.Subs += subCount(info)
+			account.Subs += iu.SubCount(info)
 
 			// make sure we only store one server info per unique server
 			found := false
@@ -1200,23 +1198,6 @@ func (c *SrvReportCmd) accountInfo(connz connzList) map[string]*srvReportAccount
 type connInfo struct {
 	*server.ConnInfo
 	Info *server.ServerInfo `json:"server"`
-}
-
-// subCount returns the number of subscriptions on a connection.
-//
-// The server populates either Subs or SubsDetail depending on whether
-// --subscription-detail was requested, never both, and populates neither when
-// the connection has no subscriptions. NumSubs is always set so it serves as
-// the fallback.
-func subCount(ci *server.ConnInfo) int {
-	switch {
-	case len(ci.SubsDetail) > 0:
-		return len(ci.SubsDetail)
-	case len(ci.Subs) > 0:
-		return len(ci.Subs)
-	default:
-		return int(ci.NumSubs)
-	}
 }
 
 func (c *SrvReportCmd) reportConnections(_ *fisk.ParseContext) error {
@@ -1255,80 +1236,6 @@ func (c *SrvReportCmd) boolReverse(v bool) bool {
 	return v
 }
 
-// pendingBytesFilter holds a parsed --pending-bytes value, either an absolute
-// byte count or a percentage of a servers max_pending setting
-type pendingBytesFilter struct {
-	set       bool
-	isPercent bool
-	bytes     int64
-	percent   float64
-}
-
-// threshold resolves the filter to an absolute byte count. maxPending is only
-// consulted for percentage based filters
-func (p pendingBytesFilter) threshold(maxPending int64) int64 {
-	if p.isPercent {
-		return int64(float64(maxPending) * p.percent / 100)
-	}
-
-	return p.bytes
-}
-
-// parsePendingBytes parses a --pending-bytes value, it accepts byte sizes with
-// units like "1MB" or "512KiB" as well as percentages like "50%" that are
-// relative to the servers max_pending setting
-func parsePendingBytes(s string) (pendingBytesFilter, error) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return pendingBytesFilter{}, nil
-	}
-
-	if strings.HasSuffix(s, "%") {
-		pct, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "%")), 64)
-		if err != nil {
-			return pendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes percentage %q: %v", s, err)
-		}
-		if pct < 0 || pct > 100 {
-			return pendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes percentage %q: must be between 0%% and 100%%", s)
-		}
-
-		return pendingBytesFilter{set: true, isPercent: true, percent: pct}, nil
-	}
-
-	bytes, err := humanize.ParseBytes(s)
-	if err != nil {
-		return pendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes value %q: %v", s, err)
-	}
-
-	return pendingBytesFilter{set: true, bytes: int64(bytes)}, nil
-}
-
-// serverMaxPending retrieves the max_pending setting for every server via VARZ,
-// keyed on server ID. This requires system account privileges
-func (c *SrvReportCmd) serverMaxPending(src serverdata.Source) (map[string]int64, error) {
-	privErr := fmt.Errorf("could not determine the max_pending setting of the servers, this is required to resolve a percentage based --pending-bytes filter and needs system account privileges, use an absolute size like 1MB instead")
-
-	responses, err := src.Varz(server.VarzEventOptions{EventFilterOptions: c.reqFilter()})
-	if err != nil {
-		return nil, privErr
-	}
-
-	maxPending := map[string]int64{}
-	for _, vz := range responses {
-		if vz.Error != nil || vz.Server == nil || vz.Data == nil {
-			continue
-		}
-		if vz.Data.MaxPending > 0 {
-			maxPending[vz.Server.ID] = vz.Data.MaxPending
-		}
-	}
-
-	if len(maxPending) == 0 {
-		return nil, privErr
-	}
-
-	return maxPending, nil
-}
 
 func (c *SrvReportCmd) sortConnections(conns []connInfo) {
 	sort.Slice(conns, func(i int, j int) bool {
@@ -1346,9 +1253,51 @@ func (c *SrvReportCmd) sortConnections(conns []connInfo) {
 		case "cid":
 			return c.boolReverse(conns[i].Cid < conns[j].Cid)
 		default:
-			return c.boolReverse(subCount(conns[i].ConnInfo) < subCount(conns[j].ConnInfo))
+			return c.boolReverse(iu.SubCount(conns[i].ConnInfo) < iu.SubCount(conns[j].ConnInfo))
 		}
 	})
+}
+
+// addSubscriptionDetail renders the subscription detail of a connection as an
+// indented block of rows directly below that connections row.
+//
+// The connection table columns are reused for the subscription fields so a
+// labelling row is emitted first to say what they hold, cols is the width of
+// the connection table so the rows line up.
+func (c *SrvReportCmd) addSubscriptionDetail(table *iu.Table, info connInfo, cols int) {
+	if !c.subscriptionDetail || len(info.SubsDetail) == 0 {
+		return
+	}
+
+	// pads every row out to the full table width, without this go-pretty renders
+	// short rows with missing trailing cells
+	row := func(vals ...any) {
+		out := make([]any, cols)
+		for i := range out {
+			out[i] = ""
+		}
+		copy(out, vals)
+		table.AddRow(out...)
+	}
+
+	row("", "  Subscriptions", "Subject", "Queue", "SID", "Msgs", "Max")
+
+	for _, sub := range info.SubsDetail {
+		queue := sub.Queue
+		if queue == "" {
+			queue = "-"
+		}
+
+		// Max is only meaningful for auto unsubscribe subscriptions
+		max := "-"
+		if sub.Max > 0 {
+			max = f(sub.Max)
+		}
+
+		row("", "", sub.Subject, queue, sub.Sid, f(sub.Msgs), max)
+	}
+
+	table.AddSeparator()
 }
 
 func (c *SrvReportCmd) renderConnections(report []connInfo) {
@@ -1395,7 +1344,7 @@ func (c *SrvReportCmd) renderConnections(report []connInfo) {
 		iMsgs += info.InMsgs
 		oBytes += info.OutBytes
 		iBytes += info.InBytes
-		subs += subCount(info.ConnInfo)
+		subs += iu.SubCount(info.ConnInfo)
 
 		srvName := info.Info.Name
 		cluster := info.Info.Cluster
@@ -1419,11 +1368,13 @@ func (c *SrvReportCmd) renderConnections(report []connInfo) {
 		}
 
 		if i < limit {
-			values := []any{cid, name, srvName, cluster, fmt.Sprintf("%s:%d", info.IP, info.Port), acc, info.Uptime, f(info.InMsgs), f(info.OutMsgs), humanize.IBytes(uint64(info.InBytes)), humanize.IBytes(uint64(info.OutBytes)), f(subCount(info.ConnInfo))}
+			values := []any{cid, name, srvName, cluster, fmt.Sprintf("%s:%d", info.IP, info.Port), acc, info.Uptime, f(info.InMsgs), f(info.OutMsgs), humanize.IBytes(uint64(info.InBytes)), humanize.IBytes(uint64(info.OutBytes)), f(iu.SubCount(info.ConnInfo))}
 			if showReason {
 				values = append(values, info.Reason)
 			}
 			table.AddRow(values...)
+
+			c.addSubscriptionDetail(table, info, len(headers))
 		}
 	}
 
@@ -1500,7 +1451,7 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 		fisk.FatalIfError(err, "Invalid expression: %v", err)
 	}
 
-	pending, err := parsePendingBytes(c.pendingBytes)
+	pending, err := iu.ParsePendingBytes(c.pendingBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -1522,8 +1473,8 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 	// percentage based pending filters need each servers max_pending setting,
 	// absolute sizes can be resolved without asking the servers anything
 	var maxPending map[string]int64
-	if pending.set && pending.isPercent {
-		maxPending, err = c.serverMaxPending(src)
+	if pending.Set && pending.IsPercent {
+		maxPending, err = iu.ServerMaxPending(src, c.reqFilter())
 		if err != nil {
 			return nil, err
 		}
@@ -1536,20 +1487,20 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 		srv := iu.StructWithoutOmitEmpty(*co.Server)
 
 		var threshold int64
-		if pending.set {
-			if pending.isPercent {
+		if pending.Set {
+			if pending.IsPercent {
 				mp, ok := maxPending[co.Server.ID]
 				if !ok {
 					return fmt.Errorf("could not determine the max_pending setting of server %s, this is required to resolve a percentage based --pending-bytes filter and needs system account privileges, use an absolute size like 1MB instead", co.Server.Name)
 				}
-				threshold = pending.threshold(mp)
+				threshold = pending.Threshold(mp)
 			} else {
-				threshold = pending.threshold(0)
+				threshold = pending.Threshold(0)
 			}
 		}
 
 		for _, conn := range conns {
-			if pending.set && int64(conn.Pending) < threshold {
+			if pending.Set && int64(conn.Pending) < threshold {
 				continue
 			}
 

--- a/cli/server_report_command.go
+++ b/cli/server_report_command.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -63,6 +65,9 @@ type SrvReportCmd struct {
 	nc                      *nats.Conn
 	apiLevel                uint
 	all                     bool
+	filterEmpty             bool
+	pendingBytes            string
+	subscriptionDetail      bool
 }
 
 type srvReportAccountInfo struct {
@@ -111,6 +116,9 @@ func configureServerReportCommand(srv *fisk.CmdClause) {
 	conns.Flag("state", "Limits responses only to those connections that are in a specific state (open, closed, all)").Default("open").EnumVar(&c.stateFilter, "open", "closed", "all")
 	conns.Flag("closed-reason", "Filter results based on a closed reason").PlaceHolder("REASON").StringVar(&c.filterReason)
 	conns.Flag("filter", "Expression based filter for connections").StringVar(&c.filterExpression)
+	conns.Flag("filter-empty", "Only shows responses that have connections").UnNegatableBoolVar(&c.filterEmpty)
+	conns.Flag("pending-bytes", "Filter out connections with fewer than pending bytes in the outbound buffer (accepts units: KB, MB, GB; or percentage: 50%)").PlaceHolder("BYTES").StringVar(&c.pendingBytes)
+	conns.Flag("subscription-detail", "Request detailed subscription information rather than a plain subject list").UnNegatableBoolVar(&c.subscriptionDetail)
 	addFilterOpts(conns)
 	conns.Flag("archive", "Read data from an archive file").StringVar(&c.archivePath)
 	conns.Flag("json", "Produce JSON output").Short('j').UnNegatableBoolVar(&c.json)
@@ -1078,6 +1086,9 @@ func (c *SrvReportCmd) reportAccount(_ *fisk.ParseContext) error {
 
 	if c.account != "" {
 		accounts := c.accountInfo(connz)
+		if len(accounts) == 0 {
+			return fmt.Errorf("did not receive any results for account %s", c.account)
+		}
 		if len(accounts) != 1 {
 			return fmt.Errorf("received results for multiple accounts, expected %v", c.account)
 		}
@@ -1167,7 +1178,7 @@ func (c *SrvReportCmd) accountInfo(connz connzList) map[string]*srvReportAccount
 			account.OutBytes += info.OutBytes
 			account.InMsgs += info.InMsgs
 			account.OutMsgs += info.OutMsgs
-			account.Subs += len(info.Subs)
+			account.Subs += subCount(info)
 
 			// make sure we only store one server info per unique server
 			found := false
@@ -1191,6 +1202,23 @@ type connInfo struct {
 	Info *server.ServerInfo `json:"server"`
 }
 
+// subCount returns the number of subscriptions on a connection.
+//
+// The server populates either Subs or SubsDetail depending on whether
+// --subscription-detail was requested, never both, and populates neither when
+// the connection has no subscriptions. NumSubs is always set so it serves as
+// the fallback.
+func subCount(ci *server.ConnInfo) int {
+	switch {
+	case len(ci.SubsDetail) > 0:
+		return len(ci.SubsDetail)
+	case len(ci.Subs) > 0:
+		return len(ci.Subs)
+	default:
+		return int(ci.NumSubs)
+	}
+}
+
 func (c *SrvReportCmd) reportConnections(_ *fisk.ParseContext) error {
 	connz, err := c.getConnz(0, c.nc)
 	if err != nil {
@@ -1202,6 +1230,12 @@ func (c *SrvReportCmd) reportConnections(_ *fisk.ParseContext) error {
 	}
 
 	conns := connz.flatConnInfo()
+
+	// --filter-empty suppresses the report entirely when nothing matched, without
+	// it an empty result still renders a normal, empty report
+	if c.filterEmpty && len(conns) == 0 {
+		return nil
+	}
 
 	if c.json {
 		iu.PrintJSON(conns)
@@ -1221,6 +1255,81 @@ func (c *SrvReportCmd) boolReverse(v bool) bool {
 	return v
 }
 
+// pendingBytesFilter holds a parsed --pending-bytes value, either an absolute
+// byte count or a percentage of a servers max_pending setting
+type pendingBytesFilter struct {
+	set       bool
+	isPercent bool
+	bytes     int64
+	percent   float64
+}
+
+// threshold resolves the filter to an absolute byte count. maxPending is only
+// consulted for percentage based filters
+func (p pendingBytesFilter) threshold(maxPending int64) int64 {
+	if p.isPercent {
+		return int64(float64(maxPending) * p.percent / 100)
+	}
+
+	return p.bytes
+}
+
+// parsePendingBytes parses a --pending-bytes value, it accepts byte sizes with
+// units like "1MB" or "512KiB" as well as percentages like "50%" that are
+// relative to the servers max_pending setting
+func parsePendingBytes(s string) (pendingBytesFilter, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return pendingBytesFilter{}, nil
+	}
+
+	if strings.HasSuffix(s, "%") {
+		pct, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "%")), 64)
+		if err != nil {
+			return pendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes percentage %q: %v", s, err)
+		}
+		if pct < 0 || pct > 100 {
+			return pendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes percentage %q: must be between 0%% and 100%%", s)
+		}
+
+		return pendingBytesFilter{set: true, isPercent: true, percent: pct}, nil
+	}
+
+	bytes, err := humanize.ParseBytes(s)
+	if err != nil {
+		return pendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes value %q: %v", s, err)
+	}
+
+	return pendingBytesFilter{set: true, bytes: int64(bytes)}, nil
+}
+
+// serverMaxPending retrieves the max_pending setting for every server via VARZ,
+// keyed on server ID. This requires system account privileges
+func (c *SrvReportCmd) serverMaxPending(src serverdata.Source) (map[string]int64, error) {
+	privErr := fmt.Errorf("could not determine the max_pending setting of the servers, this is required to resolve a percentage based --pending-bytes filter and needs system account privileges, use an absolute size like 1MB instead")
+
+	responses, err := src.Varz(server.VarzEventOptions{EventFilterOptions: c.reqFilter()})
+	if err != nil {
+		return nil, privErr
+	}
+
+	maxPending := map[string]int64{}
+	for _, vz := range responses {
+		if vz.Error != nil || vz.Server == nil || vz.Data == nil {
+			continue
+		}
+		if vz.Data.MaxPending > 0 {
+			maxPending[vz.Server.ID] = vz.Data.MaxPending
+		}
+	}
+
+	if len(maxPending) == 0 {
+		return nil, privErr
+	}
+
+	return maxPending, nil
+}
+
 func (c *SrvReportCmd) sortConnections(conns []connInfo) {
 	sort.Slice(conns, func(i int, j int) bool {
 		switch c.sort {
@@ -1237,7 +1346,7 @@ func (c *SrvReportCmd) sortConnections(conns []connInfo) {
 		case "cid":
 			return c.boolReverse(conns[i].Cid < conns[j].Cid)
 		default:
-			return c.boolReverse(len(conns[i].Subs) < len(conns[j].Subs))
+			return c.boolReverse(subCount(conns[i].ConnInfo) < subCount(conns[j].ConnInfo))
 		}
 	})
 }
@@ -1264,7 +1373,7 @@ func (c *SrvReportCmd) renderConnections(report []connInfo) {
 	var iMsgs int64
 	var oBytes int64
 	var iBytes int64
-	var subs uint32
+	var subs int
 
 	type srvInfo struct {
 		cluster string
@@ -1286,7 +1395,7 @@ func (c *SrvReportCmd) renderConnections(report []connInfo) {
 		iMsgs += info.InMsgs
 		oBytes += info.OutBytes
 		iBytes += info.InBytes
-		subs += info.NumSubs
+		subs += subCount(info.ConnInfo)
 
 		srvName := info.Info.Name
 		cluster := info.Info.Cluster
@@ -1310,7 +1419,7 @@ func (c *SrvReportCmd) renderConnections(report []connInfo) {
 		}
 
 		if i < limit {
-			values := []any{cid, name, srvName, cluster, fmt.Sprintf("%s:%d", info.IP, info.Port), acc, info.Uptime, f(info.InMsgs), f(info.OutMsgs), humanize.IBytes(uint64(info.InBytes)), humanize.IBytes(uint64(info.OutBytes)), f(len(info.Subs))}
+			values := []any{cid, name, srvName, cluster, fmt.Sprintf("%s:%d", info.IP, info.Port), acc, info.Uptime, f(info.InMsgs), f(info.OutMsgs), humanize.IBytes(uint64(info.InBytes)), humanize.IBytes(uint64(info.OutBytes)), f(subCount(info.ConnInfo))}
 			if showReason {
 				values = append(values, info.Reason)
 			}
@@ -1354,7 +1463,7 @@ func (c *SrvReportCmd) renderConnections(report []connInfo) {
 type connzList []*server.ServerAPIConnzResponse
 
 func (c connzList) flatConnInfo() []connInfo {
-	var conns []connInfo
+	conns := []connInfo{}
 
 	for _, conn := range c {
 		for _, c := range conn.Data.Conns {
@@ -1391,38 +1500,9 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 		fisk.FatalIfError(err, "Invalid expression: %v", err)
 	}
 
-	removeFilteredConns := func(co *server.ServerAPIConnzResponse) error {
-		conns := make([]*server.ConnInfo, len(co.Data.Conns))
-		copy(conns, co.Data.Conns)
-		co.Data.Conns = []*server.ConnInfo{}
-		srv := iu.StructWithoutOmitEmpty(*co.Server)
-
-		for _, conn := range conns {
-			env["server"] = srv
-			env["Server"] = co.Server
-			env["conn"] = iu.StructWithoutOmitEmpty(*conn)
-			env["Conn"] = conn
-
-			// backward compat, the `s` here is a mistake
-			env["Conns"] = conn
-			env["conns"] = env["conn"]
-
-			out, err := expr.Run(program, env)
-			if err != nil {
-				fisk.FatalIfError(err, "Invalid expression: %v", err)
-			}
-
-			should, ok := out.(bool)
-			if !ok {
-				fisk.FatalIfError(err, "expression did not return a boolean")
-			}
-
-			if should {
-				co.Data.Conns = append(co.Data.Conns, conn)
-			}
-		}
-
-		return nil
+	pending, err := parsePendingBytes(c.pendingBytes)
+	if err != nil {
+		return nil, err
 	}
 
 	state := server.ConnOpen
@@ -1439,12 +1519,80 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 	}
 	defer src.Close()
 
+	// percentage based pending filters need each servers max_pending setting,
+	// absolute sizes can be resolved without asking the servers anything
+	var maxPending map[string]int64
+	if pending.set && pending.isPercent {
+		maxPending, err = c.serverMaxPending(src)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	removeFilteredConns := func(co *server.ServerAPIConnzResponse) error {
+		conns := make([]*server.ConnInfo, len(co.Data.Conns))
+		copy(conns, co.Data.Conns)
+		co.Data.Conns = []*server.ConnInfo{}
+		srv := iu.StructWithoutOmitEmpty(*co.Server)
+
+		var threshold int64
+		if pending.set {
+			if pending.isPercent {
+				mp, ok := maxPending[co.Server.ID]
+				if !ok {
+					return fmt.Errorf("could not determine the max_pending setting of server %s, this is required to resolve a percentage based --pending-bytes filter and needs system account privileges, use an absolute size like 1MB instead", co.Server.Name)
+				}
+				threshold = pending.threshold(mp)
+			} else {
+				threshold = pending.threshold(0)
+			}
+		}
+
+		for _, conn := range conns {
+			if pending.set && int64(conn.Pending) < threshold {
+				continue
+			}
+
+			// If we have an expression filter, evaluate it
+			if program != nil {
+				env["server"] = srv
+				env["Server"] = co.Server
+				env["conn"] = iu.StructWithoutOmitEmpty(*conn)
+				env["Conn"] = conn
+
+				// backward compat, the `s` here is a mistake
+				env["Conns"] = conn
+				env["conns"] = env["conn"]
+
+				out, err := expr.Run(program, env)
+				if err != nil {
+					fisk.FatalIfError(err, "Invalid expression: %v", err)
+				}
+
+				should, ok := out.(bool)
+				if !ok {
+					fisk.FatalIfError(err, "expression did not return a boolean")
+				}
+
+				if !should {
+					continue
+				}
+			}
+
+			co.Data.Conns = append(co.Data.Conns, conn)
+		}
+
+		return nil
+	}
+
 	offset := 0
 	more := false
 
 	connzOpts := server.ConnzOptions{
+		// the server treats these as mutually exclusive, when SubscriptionsDetail
+		// is set it populates ConnInfo.SubsDetail and leaves ConnInfo.Subs empty
 		Subscriptions:       true,
-		SubscriptionsDetail: false,
+		SubscriptionsDetail: c.subscriptionDetail,
 		Username:            true,
 		User:                c.user,
 		Account:             c.account,
@@ -1471,16 +1619,17 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 		}
 		found += len(co.Data.Conns)
 
-		if c.filterExpression != "" {
+		if c.filterExpression != "" || c.pendingBytes != "" {
 			err = removeFilteredConns(co)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		if len(co.Data.Conns) > 0 {
-			result = append(result, co)
-		}
+		// responses with no connections are kept so that callers can tell the
+		// difference between "no server answered" and "no connection matched",
+		// dropping them is what --filter-empty does
+		result = append(result, co)
 	}
 
 	if limit != 0 && found > limit {
@@ -1539,7 +1688,7 @@ func (c *SrvReportCmd) getConnz(limit int, nc *nats.Conn) (connzList, error) {
 				continue
 			}
 
-			if c.filterExpression != "" {
+			if c.filterExpression != "" || c.pendingBytes != "" {
 				err = removeFilteredConns(co)
 				if err != nil {
 					return nil, err

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -19,7 +19,41 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+
+	"github.com/nats-io/jsm.go/serverdata"
+	"github.com/nats-io/nats-server/v2/server"
 )
+
+// ServerMaxPending retrieves the max_pending configuration setting of every
+// server via VARZ, keyed on server ID. This requires system account privileges.
+//
+// An error is returned when the setting cannot be established for any server,
+// callers should not substitute a default as filtering against a value the
+// servers are not actually configured with produces misleading results.
+func ServerMaxPending(src serverdata.Source, filter server.EventFilterOptions) (map[string]int64, error) {
+	privErr := fmt.Errorf("could not determine the max_pending setting of the servers, this is required to resolve a percentage based --pending-bytes filter and needs system account privileges, use an absolute size like 1MB instead")
+
+	responses, err := src.Varz(server.VarzEventOptions{EventFilterOptions: filter})
+	if err != nil {
+		return nil, privErr
+	}
+
+	maxPending := map[string]int64{}
+	for _, vz := range responses {
+		if vz.Error != nil || vz.Server == nil || vz.Data == nil {
+			continue
+		}
+		if vz.Data.MaxPending > 0 {
+			maxPending[vz.Server.ID] = vz.Data.MaxPending
+		}
+	}
+
+	if len(maxPending) == 0 {
+		return nil, privErr
+	}
+
+	return maxPending, nil
+}
 
 type Config struct {
 	SelectedOperator string `json:"select_operator"`

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -36,12 +36,78 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/google/shlex"
 	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/natscli/internal/asciigraph"
 	"github.com/nats-io/natscli/options"
 	"github.com/nats-io/nkeys"
 	terminal "golang.org/x/term"
 )
+
+// PendingBytesFilter holds a parsed pending bytes filter, either an absolute
+// byte count or a percentage of a servers max_pending setting
+type PendingBytesFilter struct {
+	Set       bool
+	IsPercent bool
+	Bytes     int64
+	Percent   float64
+}
+
+// Threshold resolves the filter to an absolute byte count. maxPending is only
+// consulted for percentage based filters
+func (p PendingBytesFilter) Threshold(maxPending int64) int64 {
+	if p.IsPercent {
+		return int64(float64(maxPending) * p.Percent / 100)
+	}
+
+	return p.Bytes
+}
+
+// ParsePendingBytes parses a pending bytes filter value, it accepts byte sizes
+// with units like "1MB" or "512KiB" as well as percentages like "50%" that are
+// relative to the servers max_pending setting
+func ParsePendingBytes(s string) (PendingBytesFilter, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return PendingBytesFilter{}, nil
+	}
+
+	if strings.HasSuffix(s, "%") {
+		pct, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "%")), 64)
+		if err != nil {
+			return PendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes percentage %q: %v", s, err)
+		}
+		if pct < 0 || pct > 100 {
+			return PendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes percentage %q: must be between 0%% and 100%%", s)
+		}
+
+		return PendingBytesFilter{Set: true, IsPercent: true, Percent: pct}, nil
+	}
+
+	bytes, err := humanize.ParseBytes(s)
+	if err != nil {
+		return PendingBytesFilter{}, fmt.Errorf("invalid --pending-bytes value %q: %v", s, err)
+	}
+
+	return PendingBytesFilter{Set: true, Bytes: int64(bytes)}, nil
+}
+
+// SubCount returns the number of subscriptions on a connection.
+//
+// The server populates either Subs or SubsDetail depending on whether
+// subscription detail was requested, never both, and populates neither when the
+// connection has no subscriptions. NumSubs is always set so it serves as the
+// fallback.
+func SubCount(ci *server.ConnInfo) int {
+	switch {
+	case len(ci.SubsDetail) > 0:
+		return len(ci.SubsDetail)
+	case len(ci.Subs) > 0:
+		return len(ci.Subs)
+	default:
+		return int(ci.NumSubs)
+	}
+}
 
 // RemoveReservedMetadata returns a new version of metadata with reserved keys starting with _nats. removed
 func RemoveReservedMetadata(metadata map[string]string) map[string]string {


### PR DESCRIPTION
We need to be able to detect slow consumers proactively. To enable this `report connections` in `nats server report`  and `nats account report`  has been enhanced:

1. Consistently support --json
2. --filter-empty - Empty result when the result list is empty (all connections filtered out)
3. --subscription-detail - report per sub statistics
4. --pending-bytes -  Report only connection >= nnn  - support `75'%` input relative to the server max_pending value  

Examples:
```
nats server report connections --pending-bytes=75% --top=16000 --filter-empty --subscription-detail --json
nats account report connections --pending-bytes=48MB --top=16000 --filter-empty --subscription-detail --json
```