### PR TITLE
Add --connect-timeout option

### DIFF
--- a/cli/context_command.go
+++ b/cli/context_command.go
@@ -562,12 +562,15 @@ func (c *ctxCommand) showCommand(_ *fisk.ParseContext) error {
 	cols.AddRowIfNotEmpty("Color Scheme", cfg.ColorScheme())
 
 	checkConn := func() error {
-		opts, err := cfg.NATSOptions()
-		opts = append(opts, nats.MaxReconnects(1))
+		nopts, err := cfg.NATSOptions()
 		if err != nil {
 			return err
 		}
-		nc, err := nats.Connect(cfg.ServerURL(), opts...)
+		nopts = append(nopts, nats.MaxReconnects(1))
+		if opts().ConnectTimeout > 0 {
+			nopts = append(nopts, nats.Timeout(opts().ConnectTimeout))
+		}
+		nc, err := nats.Connect(cfg.ServerURL(), nopts...)
 		if err != nil {
 			return err
 		}

--- a/cli/util.go
+++ b/cli/util.go
@@ -236,6 +236,11 @@ func natsOpts() []nats.Option {
 		connectionName = "NATS CLI Version " + Version
 	}
 
+	// nats.go applies its own default when this is 0, so only set it when asked for
+	if opts().ConnectTimeout > 0 {
+		copts = append(copts, nats.Timeout(opts().ConnectTimeout))
+	}
+
 	return append(copts, []nats.Option{
 		nats.Name(connectionName),
 		nats.MaxReconnects(-1),

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -15,8 +15,11 @@ package cli
 
 import (
 	"testing"
+	"time"
 
 	"github.com/nats-io/jsm.go/api"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/natscli/options"
 )
 
 func TestRenderCluster(t *testing.T) {
@@ -35,5 +38,35 @@ func TestRenderCluster(t *testing.T) {
 
 	if result := renderCluster(&api.ClusterInfo{Name: "test"}); result != "" {
 		t.Fatalf("invalid result: %q", result)
+	}
+}
+
+func TestNatsOptsConnectTimeout(t *testing.T) {
+	// natsOpts reads the global options, so swap in our own for the test
+	origOpts := options.DefaultOptions
+	t.Cleanup(func() { options.DefaultOptions = origOpts })
+
+	resolve := func(t *testing.T) nats.Options {
+		t.Helper()
+
+		res := nats.GetDefaultOptions()
+		for _, o := range natsOpts() {
+			if err := o(&res); err != nil {
+				t.Fatalf("applying connection option: %v", err)
+			}
+		}
+
+		return res
+	}
+
+	options.DefaultOptions = &options.Options{ConnectTimeout: 30 * time.Second}
+	if to := resolve(t).Timeout; to != 30*time.Second {
+		t.Fatalf("expected a 30s connect timeout, got %v", to)
+	}
+
+	// unset should leave the nats.go default in place
+	options.DefaultOptions = &options.Options{}
+	if to := resolve(t).Timeout; to != nats.GetDefaultOptions().Timeout {
+		t.Fatalf("expected the default connect timeout of %v, got %v", nats.GetDefaultOptions().Timeout, to)
 	}
 }

--- a/nats/main.go
+++ b/nats/main.go
@@ -87,6 +87,7 @@ LLM optimized help output can be obtained using --help-llm for any command. You 
 		ncli.Flag("certstore-ca-match", "Which certificate authority should be used from the store").StringsVar(&opts.WinCertCaStoreMatch)
 	}
 	ncli.Flag("timeout", "Time to wait on responses from NATS").Default("5s").Envar("NATS_TIMEOUT").DurationVar(&opts.Timeout)
+	ncli.Flag("connect-timeout", "Time to wait for a connection to a server to be established").Default("2s").Envar("NATS_CONNECT_TIMEOUT").DurationVar(&opts.ConnectTimeout)
 	ncli.Flag("socks-proxy", "SOCKS5 proxy for connecting to NATS server").Envar("NATS_SOCKS_PROXY").PlaceHolder("PROXY").StringVar(&opts.SocksProxy)
 	ncli.Flag("js-api-prefix", "Subject prefix for access to JetStream API").PlaceHolder("PREFIX").StringVar(&opts.JsApiPrefix)
 	ncli.Flag("js-event-prefix", "Subject prefix for access to JetStream Advisories").PlaceHolder("PREFIX").StringVar(&opts.JsEventPrefix)

--- a/nats/tests/connect_timeout_test.go
+++ b/nats/tests/connect_timeout_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConnectTimeoutFlag connects to a listener that accepts the TCP connection
+// but never sends the server INFO, so the connect attempt runs for the full
+// connect timeout. The process startup cost is the same for both invocations
+// and cancels out in the comparison, so only --connect-timeout can account for
+// the difference between the two runs.
+func TestConnectTimeoutFlag(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not listen: %v", err)
+	}
+	defer listener.Close()
+
+	var mu sync.Mutex
+	var accepted []net.Conn
+	defer func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, conn := range accepted {
+			conn.Close()
+		}
+	}()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			mu.Lock()
+			accepted = append(accepted, conn)
+			mu.Unlock()
+		}
+	}()
+
+	url := fmt.Sprintf("nats://%s", listener.Addr().String())
+
+	// first invocation may have to build the CLI, do not measure that one
+	runNatsCliCore(t, "", nil, "--version")
+
+	timed := func(timeout string) time.Duration {
+		t.Helper()
+
+		start := time.Now()
+		err := runNatsCliWithError(t, fmt.Sprintf("--server='%s' --connect-timeout=%s server ping", url, timeout))
+		elapsed := time.Since(start)
+
+		if err == nil {
+			t.Fatalf("expected the connection to %s to fail with a %s connect timeout", url, timeout)
+		}
+
+		return elapsed
+	}
+
+	short := timed("250ms")
+	long := timed("6s")
+
+	if long-short < 4*time.Second {
+		t.Fatalf("--connect-timeout did not extend the connect attempt: 250ms run took %v, 6s run took %v", short, long)
+	}
+}

--- a/options/options.go
+++ b/options/options.go
@@ -40,6 +40,9 @@ type Options struct {
 	TlsCA string
 	// Timeout is how long to wait for operations
 	Timeout time.Duration
+	// ConnectTimeout is how long to wait for a connection to a server to be
+	// established, when 0 the nats.go default is used
+	ConnectTimeout time.Duration
 	// ConnectionName is the name to use for the underlying NATS connection
 	ConnectionName string
 	// Username is the username or token to connect with


### PR DESCRIPTION
The existing --timeout only governs how long to wait on NATS protocol layer responses, after the connection has been established.  The connection setup itself has always used the nats.go default of 2s.

Add a --connect-timeout flag ($NATS_CONNECT_TIMEOUT) to set nats.Timeout, for the connection flow before NATS protocol messages start to be exchanged.

_(Implemented by Claude Fable at my direction, I have reviewed the generated code and am happy with it.)_